### PR TITLE
[TASK] Update jshintrc

### DIFF
--- a/jshintrc
+++ b/jshintrc
@@ -2,7 +2,7 @@
   "browser": true,
   "jquery": true,
   "node": true,
-  "camelcase": false,
+
   "eqeqeq": true,
   "eqnull": true,
   "latedef": true,
@@ -13,10 +13,8 @@
   "curly": true,
   "freeze": true,
   "nonbsp": true,
-  "boss": true,
-  "laxbreak": true,
   "maxparams": 4,
   "maxdepth": 3,
-  "esnext": true,
-  "-W004": true
+
+  "laxbreak": true
 }


### PR DESCRIPTION
@wltsmrz Thanks for polishing up the jshintrc file. There are just two edits that I'd like to add: removing the `boss` and `W004` relaxing options. I also moved `laxbreak` to the end, that is one relaxing option that may have some readability benefits. And I removed `camelcase` since it has no effect.

I can't think of any cases where `boss` (assignments where comparisons are expected) or `W004` (redefining parameters) should be allowed, but if there is a rare case where someone really wants to use it, they can disable the jshint warning with the `// jshint ignore:line` comment directive. But I'd imagine that 99% of the time when these warnings fire it will be catching bugs for us.