### PR TITLE
[FIX] properly close path find request

### DIFF
--- a/src/js/ripple/pathfind.js
+++ b/src/js/ripple/pathfind.js
@@ -55,7 +55,7 @@ PathFind.prototype.create = function () {
 };
 
 PathFind.prototype.close = function () {
-  this.remote.request_path_find_close().request();
+  this.remote.request_path_find_close().broadcast().request();
   this.emit('end');
   this.emit('close');
 };


### PR DESCRIPTION
path create uses broadcast, so close must
use this too