### PR TITLE
[BUG] `Request.prototype.ledgerSelect` can accept ledger_index as String

### DIFF
--- a/src/js/ripple/request.js
+++ b/src/js/ripple/request.js
@@ -355,8 +355,8 @@ Request.prototype.ledgerSelect = function(ledger) {
       this.message.ledger_index = ledger;
       break;
     default:
-      if (typeof ledger === 'number' && isFinite(ledger)) {
-        this.message.ledger_index = ledger;
+      if (Number(ledger) && isFinite(Number(ledger))) {
+        this.message.ledger_index = Number(ledger);
       } else if (/^[A-F0-9]{64}$/.test(ledger)) {
         this.message.ledger_hash = ledger;
       }

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -726,6 +726,16 @@ describe('Request', function() {
     assert.strictEqual(request.message.ledger_hash, void(0));
   });
 
+  it('Select ledger - index (String)', function() {
+    var remote = new Remote();
+    remote._connected = true;
+
+    var request = new Request(remote, 'server_info');
+    request.ledgerSelect('7016915');
+    assert.strictEqual(request.message.ledger_index, 7016915);
+    assert.strictEqual(request.message.ledger_hash, void(0));
+  });
+
   it('Select ledger - hash', function() {
     var remote = new Remote();
     remote._connected = true;


### PR DESCRIPTION
This behavior is consistent with `ripple-lib` before https://github.com/ripple/ripple-lib/commit/8af5f9c2#diff-a8d289f91765fc0f634609ad7c15c239L227