### PR TITLE
Cleanup amount.js

### DIFF
--- a/src/js/ripple/serializedtypes.js
+++ b/src/js/ripple/serializedtypes.js
@@ -298,7 +298,11 @@ var STAmount = exports.Amount = new SerializedType({
     var valueBytes = utils.arraySet(8, 0);
 
     if (amount.is_native()) {
-      var valueHex = value.absoluteValue().toString(16);
+      var valueHex = value.abs().toString(16);
+
+      if (value.abs().greaterThan(Amount.bi_xns_max)) {
+        throw new Error('Value out of bounds');
+      }
 
       // Enforce correct length (64 bits)
       if (valueHex.length > 16) {

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -336,9 +336,9 @@ describe('Amount', function() {
   });
   describe('Amount parsing', function() {
     it('Parse invalid string', function() {
-      assert.strictEqual(Amount.from_json('x').to_text(), '0');
-      assert.strictEqual(typeof Amount.from_json('x').to_text(true), 'number');
-      assert(isNaN(Amount.from_json('x').to_text(true)));
+      assert.strictEqual(Amount.from_json('x').to_text(), 'NaN');
+      assert.strictEqual(typeof Amount.from_json('x').to_text(), 'string');
+      assert(isNaN(Amount.from_json('x').to_text()));
     });
     it('parse dem', function() {
       assert.strictEqual(Amount.from_json('10/015841551A748AD2C1F76FF6ECB0CCCD00000000/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh').to_text_full(), '10/XAU (-0.5%pa)/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
@@ -1085,6 +1085,11 @@ describe('Amount', function() {
   });
 
   describe('from_quality', function() {
+    it('XRP/XRP', function () {
+      assert.throws(function() {
+        Amount.from_quality('7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F0FF9FF678E1000', 'XRP', NaN, {base_currency: 'XRP'}).to_text_full()
+      });
+    });
     it('BTC/XRP', function () {
       assert.strictEqual(Amount.from_quality('7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F0FF9FF678E1000', 'XRP', NaN, {base_currency: 'BTC'}).to_text_full(), '44,970/XRP');
     });
@@ -1188,11 +1193,11 @@ describe('Amount', function() {
 
   describe('amount limits', function() {
     it ('max JSON wire limite', function() {
-      assert.strictEqual(Amount.bi_xns_max.toString(), '9000000000000000000');
+      assert.strictEqual(Amount.bi_xns_max.toString(), '100000000000000000');
     });
 
     it ('max JSON wire limite', function() {
-      assert.strictEqual(Amount.bi_xns_min.toString(), '-9000000000000000000');
+      assert.strictEqual(Amount.bi_xns_min.toString(), '-100000000000000000');
     });
 
     it('max mantissa value', function() {
@@ -1204,23 +1209,25 @@ describe('Amount', function() {
     });
 
     it ('from_json minimum XRP', function() {
-      var amt = Amount.from_json('-9000000000000000000');
-      assert.strictEqual(amt.to_json(), '-9000000000000000000');
+      var amt = Amount.from_json('-100000000000000000');
+      assert.strictEqual(amt.to_json(), '-100000000000000000');
     });
 
     it ('from_json maximum XRP', function() {
-      var amt = Amount.from_json('-9000000000000000000');
-      assert.strictEqual(amt.to_json(), '-9000000000000000000');
+      var amt = Amount.from_json('100000000000000000');
+      assert.strictEqual(amt.to_json(), '100000000000000000');
     });
 
     it ('from_json less than minimum XRP', function() {
-      var amt = Amount.from_json('-9000000000000000001');
-      assert.strictEqual(amt.to_json(), '0');
+      assert.throws(function() {
+        Amount.from_json('-100000000000000001');
+      });
     });
 
     it ('from_json more than maximum XRP', function() {
-      var amt = Amount.from_json('9000000000000000001');
-      assert.strictEqual(amt.to_json(), '0');
+      assert.throws(function() {
+        Amount.from_json('100000000000000001');
+      });
     });
 
     it ('from_json minimum IOU', function() {

--- a/test/remote-test.js
+++ b/test/remote-test.js
@@ -858,7 +858,7 @@ describe('Remote', function() {
   it('Get reserve', function() {
     remote._connected = true;
     remote._servers[0]._connected = true;
-    assert.strictEqual(remote.reserve(1).to_json(), '0');
+    assert.strictEqual(remote.reserve(1).to_json(), 'NaN');
     remote._servers = [ ];
     assert.throws(function() {
       remote.reserve(10).to_json();

--- a/test/serializedtypes-test.js
+++ b/test/serializedtypes-test.js
@@ -509,8 +509,10 @@ describe('Serialized types', function() {
     });
     it('Serialize 1161981756646125568 XRP', function () {
       var so = new SerializedObject();
-      types.Amount.serialize(so, '1161981756646125696');
-      assert.strictEqual(so.to_hex(), '5020304050607080');
+      assert.throws(function() {
+        var amt = Amount.from_json('1161981756646125696');
+        types.Amount.serialize(so, amt);
+      });
     });
     it('Serialize 1/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
       var so = new SerializedObject();
@@ -570,8 +572,11 @@ describe('Serialized types', function() {
       assert.strictEqual(types.Amount.parse(so).to_json(), '270544960');
     });
     it('Parse 1161981756646125568 XRP', function () {
-      var so = new SerializedObject('5020304050607080');
-      assert.strictEqual(types.Amount.parse(so).to_json(), '1161981756646125696');
+      assert.throws(function() {
+        // hex(1161981756646125568) = 1020304050607000
+        var so = new SerializedObject('1020304050607000');
+        types.Amount.parse(so).to_json();
+      })
     });
     it('Parse 1/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', function () {
       var so = new SerializedObject('D4838D7EA4C680000000000000000000000000005553440000000000B5F762798A53D543A014CAF8B297CFF8F2F937E8');
@@ -687,25 +692,25 @@ describe('Serialized types', function() {
         }]
       ];
 
-      var result_json = [ 
-        [{ 
+      var result_json = [
+        [{
           account: 'rrrrrrrrrrrrrrrrrrrrNxV3Xza',
           currency: 'USD',
           issuer: 'rrrrrrrrrrrrrrrrrrrpYnYCNYf',
           type: 49,
-          type_hex: '0000000000000031' 
+          type_hex: '0000000000000031'
         }],
-        [{ 
-          currency: 'XRP', 
-          type: 16, 
-          type_hex: '0000000000000010' 
-        }, { 
+        [{
+          currency: 'XRP',
+          type: 16,
+          type_hex: '0000000000000010'
+        }, {
           account: 'rrrrrrrrrrrrrrrrrrrpvQsW3V3',
           currency: 'EUR',
           issuer: 'rrrrrrrrrrrrrrrrrrrdHRtqg2',
           type: 49,
-          type_hex: '0000000000000031' 
-        }] 
+          type_hex: '0000000000000031'
+        }]
       ];
 
       var so = new SerializedObject();
@@ -734,26 +739,26 @@ describe('Serialized types', function() {
         }]
       ];
 
-      var result_json = [ 
-        [{ 
+      var result_json = [
+        [{
           account: 'rrrrrrrrrrrrrrrrrrrrNxV3Xza',
           currency: 'USD',
           issuer: 'rrrrrrrrrrrrrrrrrrrpYnYCNYf',
           type: 49,
-          type_hex: '0000000000000031' 
+          type_hex: '0000000000000031'
         }],
-        [{ 
+        [{
           currency: 'XRP',
           non_native: true,
           type: 16,
-          type_hex: '0000000000000010' 
-        }, { 
+          type_hex: '0000000000000010'
+        }, {
           account: 'rrrrrrrrrrrrrrrrrrrpvQsW3V3',
           currency: 'EUR',
           issuer: 'rrrrrrrrrrrrrrrrrrrdHRtqg2',
           type: 49,
-          type_hex: '0000000000000031' 
-        }] 
+          type_hex: '0000000000000031'
+        }]
       ];
 
       var so = new SerializedObject();
@@ -821,78 +826,78 @@ describe('Serialized types', function() {
         }]
       ];
 
-      var result_json = [ 
-        [{ 
+      var result_json = [
+        [{
           account: 'r9hEDb4xBGRfBCcX3E4FirDWQBAYtpxC8K',
           currency: 'BTC',
           issuer: 'r9hEDb4xBGRfBCcX3E4FirDWQBAYtpxC8K',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           account: 'rM1oqKtfh1zgjdAgbFmaRm3btfGBX25xVo',
           currency: 'BTC',
           issuer: 'rM1oqKtfh1zgjdAgbFmaRm3btfGBX25xVo',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           account: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
           currency: 'BTC',
           issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           currency: 'USD',
           issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
           type: 48,
-          type_hex: '0000000000000030' 
+          type_hex: '0000000000000030'
         }],
-        [{ 
+        [{
           account: 'r9hEDb4xBGRfBCcX3E4FirDWQBAYtpxC8K',
           currency: 'BTC',
           issuer: 'r9hEDb4xBGRfBCcX3E4FirDWQBAYtpxC8K',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           account: 'rM1oqKtfh1zgjdAgbFmaRm3btfGBX25xVo',
           currency: 'BTC',
           issuer: 'rM1oqKtfh1zgjdAgbFmaRm3btfGBX25xVo',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           account: 'rpvfJ4mR6QQAeogpXEKnuyGBx8mYCSnYZi',
           currency: 'BTC',
           issuer: 'rpvfJ4mR6QQAeogpXEKnuyGBx8mYCSnYZi',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           currency: 'USD',
           issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
           type: 48,
-          type_hex: '0000000000000030' 
+          type_hex: '0000000000000030'
         }],
-        [{ 
+        [{
           account: 'r9hEDb4xBGRfBCcX3E4FirDWQBAYtpxC8K',
           currency: 'BTC',
           issuer: 'r9hEDb4xBGRfBCcX3E4FirDWQBAYtpxC8K',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           account: 'r3AWbdp2jQLXLywJypdoNwVSvr81xs3uhn',
           currency: 'BTC',
           issuer: 'r3AWbdp2jQLXLywJypdoNwVSvr81xs3uhn',
           type: 49,
-          type_hex: '0000000000000031' 
-        }, { 
+          type_hex: '0000000000000031'
+        }, {
           currency: 'XRP',
           non_native: true,
           type: 16,
-          type_hex: '0000000000000010' 
-        }, { 
+          type_hex: '0000000000000010'
+        }, {
           currency: 'USD',
           issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
           type: 48,
-          type_hex: '0000000000000030' 
-        }] 
+          type_hex: '0000000000000030'
+        }]
       ];
 
       var so = new SerializedObject();


### PR DESCRIPTION
Behavioral changes:

remove allow_nan option (option to convert NaN to 0)
all overflow checking is done in canonicalize
to_text always returns a string ('NaN' instead of NaN)
from_quality disallows XRP/XRP quality
