### PR TITLE
fix handling of false parameters in requestLedger

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -862,7 +862,7 @@ Remote.prototype.requestLedger = function(options, callback) {
           case 'expand':
           case 'transactions':
           case 'accounts':
-            request.message[o] = true;
+            request.message[o] = options[o] ? true : false;
             break;
           case 'ledger':
             request.selectLedger(options.ledger);


### PR DESCRIPTION
I passed in {expand:false, transactions:false} and still got transactions with the ledger.