### PR TITLE
Set User-Agent Header with ripple-lib/{version}

### DIFF
--- a/src/js/ripple/server.js
+++ b/src/js/ripple/server.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter;
 var Amount       = require('./amount').Amount;
 var RangeSet     = require('./rangeset').RangeSet;
 var log          = require('./log').internal.sub('server');
+var utils        = require('./utils');
 
 /**
  *  @constructor Server
@@ -423,7 +424,9 @@ Server.prototype.connect = function() {
     log.info(this.getServerID(), 'connect');
   }
 
-  var ws = this._ws = new WebSocket(this._opts.url);
+  var ws = this._ws = new WebSocket(this._opts.url, {
+    headers: { 'User-Agent': 'ripple-lib/' + utils.getPackageVersion() }
+  });
 
   this._shouldConnect = true;
 

--- a/src/js/ripple/utils.js
+++ b/src/js/ripple/utils.js
@@ -1,3 +1,8 @@
+var packageJson = require('../../../package.json');
+
+function getPackageVersion() {
+  return packageJson.version;
+}
 
 function getMantissaDecimalString(bignum) {
   var mantissa = bignum.toPrecision(16)
@@ -170,6 +175,7 @@ exports.arrayUnique   = arrayUnique;
 exports.toTimestamp   = toTimestamp;
 exports.fromTimestamp = fromTimestamp;
 exports.getMantissaDecimalString = getMantissaDecimalString;
+exports.getPackageVersion = getPackageVersion;
 
 // Going up three levels is needed to escape the src-cov folder used for the
 // test coverage stuff.


### PR DESCRIPTION
- This would be helpful for us to analyze usage of ripple-lib for anyone
  using the public rippled

See: https://github.com/websockets/ws/blob/master/lib/WebSocket.js#L530