### PR TITLE
[FIX] fix taker pays funded calculation

### DIFF
--- a/src/js/ripple/orderbook.js
+++ b/src/js/ripple/orderbook.js
@@ -640,7 +640,7 @@ OrderBook.prototype.setOfferFundedAmount = function(offer) {
     );
 
     offer.taker_pays_funded = this._currencyPays.is_native()
-      ? String(parseInt(takerPaysFunded.to_json().value, 10))
+      ? String(Math.floor(takerPaysFunded.to_number()))
       : takerPaysFunded.to_json().value;
   } else {
     offer.taker_gets_funded = '0';

--- a/test/fixtures/orderbook.js
+++ b/test/fixtures/orderbook.js
@@ -372,6 +372,37 @@ module.exports.QUALITY_OFFERS = [
   }
 ];
 
+// This fixture is to exercise a bug where taker_pays_funded = taker_gets_funded * quality
+// has decimal amounts.
+module.exports.DECIMAL_TAKER_PAYS_FUNDED_OFFERS = [
+  {
+    Account: addresses.ACCOUNT,
+    BookDirectory: '4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5D0689673FA9094A',
+    BookNode: '0000000000000000',
+    Flags: 0,
+    LedgerEntryType: 'Offer',
+    OwnerNode: '0000000000000006',
+    PreviousTxnID: 'C1BB04CE39E30BF5982B7660793723E9B3A832F5B458DB1C5938F4737E0E9ABF',
+    PreviousTxnLgrSeq: 11631257,
+    Sequence: 2936,
+    TakerGets: {
+      currency: 'USD',
+      issuer: addresses.ISSUER,
+      value: '9280.04'
+    },
+    TakerPays: '1707459061637',
+    index: '89D85BBE91E0F419953EB89CE62E194922ED930EE57BE0C62FCC3B22DDB20852',
+    owner_funds: '9280.037154029904',
+    quality: '183992640.2943306',
+    taker_gets_funded: {
+      currency: 'USD',
+      issuer: addresses.ISSUER,
+      value: '9261.514125778347'
+    },
+    taker_pays_funded: '1704050437125'
+  }
+];
+
 module.exports.bookOffersResponse = function (options) {
   options = options || {};
   _.defaults(options, {

--- a/test/orderbook-test.js
+++ b/test/orderbook-test.js
@@ -1533,6 +1533,27 @@ describe('OrderBook', function() {
     assert.strictEqual(book.getOwnerFunds(addresses.FOURTH_ACCOUNT).to_text(), '7229.594289344439');
   });
 
+  it('Set offers - incorrect taker pays funded', function() {
+    var remote = new Remote();
+
+    var book = remote.createOrderBook({
+      currency_gets: 'USD',
+      issuer_gets: addresses.ISSUER,
+      currency_pays: 'XRP'
+    });
+
+    book._issuerTransferRate = 1002000000;
+
+    var offers = fixtures.DECIMAL_TAKER_PAYS_FUNDED_OFFERS;
+
+    book.setOffers(offers);
+
+    assert.strictEqual(book._offers.length, 1);
+
+    assert.strictEqual(book._offers[0].taker_gets_funded, '9261.514125778347');
+    assert.strictEqual(book._offers[0].taker_pays_funded, '1704050437125');
+  });
+
   it('Notify - created node', function() {
     var remote = new Remote();
 


### PR DESCRIPTION
We were calling `parseInt` on a string that looks like `12345342e-3`, which gave us `12345342` instead of `12345`.