### PR TITLE
Cache Keypairs, allow using RegularKey.

### DIFF
--- a/src/js/ripple/remote.js
+++ b/src/js/ripple/remote.js
@@ -37,6 +37,7 @@ var sjcl = require('./utils').sjcl;
 var hashprefixes = require('./hashprefixes');
 var config = require('./config');
 var log = require('./log').internal.sub('remote');
+var Seed = require('./seed').Seed;
 
 /**
  * Interface to manage connections to rippled servers
@@ -102,6 +103,9 @@ function Remote(opts) {
   // Secrets can be set by calling set_secret(account, secret).
   // account : secret
   this.secrets = { };
+
+  // cache keypairs.
+  this.keyPairs = { };
 
   // Cache for various ledgers.
   // XXX Clear when ledger advances.
@@ -373,16 +377,49 @@ Remote.prototype._trace = function() {
   }
 };
 
+
+
+// Generate KeyPair from given seed. 
+Remote.prototype.generateKeyPair = function(secret, id) {
+  try {
+        var seed = Seed.from_json(secret);
+        var key  = seed.get_key(id);
+        return key;
+      } catch(e) {
+        return false;
+      }
+};
+
+// cache keypairs.
+Remote.prototype.setKeyPair = function(account, key) {
+  this.keyPairs[account] = key;
+}
+
 /**
  * Store a secret - allows the Remote to automatically fill
  * out auth information.
  *
  * @param {String} account
  * @param {String} secret
+ * @param {String|Number} account or index number.
  */
 
-Remote.prototype.setSecret = function(account, secret) {
+Remote.prototype.setSecret = function(account, secret, id) {
   this.secrets[account] = secret;
+
+  // try to cache keypairs, so we don't need to re-generate it for each tx.
+
+  // id could be RegularKey or index number of Account Family, 
+  // if ommited assume using Masterkey.
+  if (typeof id == 'undefined') id = account; 
+
+  var key = this.generateKeyPair(secret, id);
+
+  if (!key) {
+    this.emit('error', new RippleError('secretInvalid'));
+  } else { 
+    this.setKeyPair(account, key);
+  }
 };
 
 Remote.prototype.addServer = function(opts) {

--- a/src/js/ripple/transaction.js
+++ b/src/js/ripple/transaction.js
@@ -273,6 +273,17 @@ Transaction.prototype.getManager = function(account) {
   return this.remote.account(account)._transactionManager;
 };
 
+
+Transaction.prototype.generateKeyPair = function(secret) {
+    try {
+      var seed = Seed.from_json(this._secret);
+      var key  = seed.get_key();
+      return key;
+    } catch(e) {
+      return false;
+    }
+}
+
 /**
  * Get keypair for signing.
  *
@@ -401,7 +412,7 @@ Transaction.prototype.complete = function() {
 
   if (typeof this.tx_json.SigningPubKey === 'undefined') {
     var key = this._keyPair;
-    if (!key && this.remote && !(key = this.remote.generateKeyPair(this._secret))) {
+    if (!key && !(key = this.generateKeyPair(this._secret))) {
       this.emit('error', new RippleError('tejSecretInvalid', 'Invalid secret'));
       return false;
     }
@@ -474,7 +485,7 @@ Transaction.prototype.sign = function() {
   }
 
   var key = this._keyPair || this.getKeyPair(); 
-  if (!key && this.remote && !(key = this.remote.generateKeyPair(this._secret))) {
+  if (!key && !(key = this.generateKeyPair(this._secret))) {
     this.emit('error', new RippleError('tejSecretInvalid', 'Invalid secret'));
     return false;      
   } 

--- a/src/js/ripple/transaction.js
+++ b/src/js/ripple/transaction.js
@@ -275,6 +275,9 @@ Transaction.prototype.getManager = function(account) {
 
 
 Transaction.prototype.generateKeyPair = function(secret) {
+  if (this.remote) {
+    return this.remote.generateKeyPair();
+  } else {
     try {
       var seed = Seed.from_json(this._secret);
       var key  = seed.get_key();
@@ -282,6 +285,7 @@ Transaction.prototype.generateKeyPair = function(secret) {
     } catch(e) {
       return false;
     }
+  }
 }
 
 /**

--- a/src/js/ripple/transaction.js
+++ b/src/js/ripple/transaction.js
@@ -276,7 +276,7 @@ Transaction.prototype.getManager = function(account) {
 
 Transaction.prototype.generateKeyPair = function(secret) {
   if (this.remote) {
-    return this.remote.generateKeyPair();
+    return this.remote.generateKeyPair(this._secret);
   } else {
     try {
       var seed = Seed.from_json(this._secret);


### PR DESCRIPTION
- add new param to setSecret(), allow specifying regularKey.
- cache KeyPairs instead of re-generating from seed every time.

https://github.com/ripple/ripple-lib/issues/81, https://github.com/ripple/ripple-lib/issues/183, https://github.com/ripple/ripple-lib/issues/218, https://github.com/ripple/ripple-lib/issues/226