### PR TITLE
[FIX] Amount: clone in ratio_human, product_human

### DIFF
--- a/src/js/ripple/amount.js
+++ b/src/js/ripple/amount.js
@@ -197,9 +197,7 @@ Amount.prototype.divide = function(divisor) {
 Amount.prototype.ratio_human = function(denominator, opts) {
   opts = extend({ }, opts);
 
-  /*eslint-disable consistent-this */
-  var numerator = this;
-  /*eslint-enable consistent-this */
+  var numerator = this.clone();
 
   denominator = Amount.from_json(denominator);
 


### PR DESCRIPTION
Amount.ratio_human and Amount.product_human should only change and return the cloned Amount object.