### PR TITLE
Remove return value of mergeDirectAndAutobridgedBooks

### DIFF
--- a/src/js/ripple/orderbook.js
+++ b/src/js/ripple/orderbook.js
@@ -1224,7 +1224,7 @@ OrderBook.prototype.mergeDirectAndAutobridgedBooks = function() {
   var self = this;
 
   if (_.isEmpty(this._offers) && _.isEmpty(this._offersAutobridged)) {
-    return null;
+    return;
   }
 
   this._mergedOffers = this._offers
@@ -1237,8 +1237,6 @@ OrderBook.prototype.mergeDirectAndAutobridgedBooks = function() {
     });
 
   this.emit('model', this._mergedOffers);
-
-  return this._mergedOffers;
 };
 
 exports.OrderBook = OrderBook;


### PR DESCRIPTION
Since the function has a side effect, it's better to not return a value.

http://en.wikipedia.org/wiki/Command%E2%80%93query_separation