### PR TITLE
Merge flipped orderbook in getOrderbook

### DIFF
--- a/src/api/ledger/parse/orderbook-order.js
+++ b/src/api/ledger/parse/orderbook-order.js
@@ -32,9 +32,8 @@ function parseOrderbookOrder(order: Object): Object {
   const takerPaysFunded = order.taker_pays_funded ?
       parseAmount(order.taker_pays_funded) : undefined;
   const available = utils.removeUndefined({
-    availableQuantity: direction === 'buy' ? takerPaysFunded : takerGetsFunded,
-    priceOfAvailableQuantity: direction === 'buy' ?
-      takerGetsFunded : takerPaysFunded
+    fundedAmount: takerGetsFunded,
+    priceOfFundedAmount: takerPaysFunded
   });
   const state = _.isEmpty(available) ? undefined : available;
   return utils.removeUndefined({specification, properties, state});

--- a/test/fixtures/book-offers-response.js
+++ b/test/fixtures/book-offers-response.js
@@ -5,11 +5,11 @@ const _ = require('lodash');
 module.exports.requestBookOffersBidsResponse = function(request, options={}) {
   _.defaults(options, {
     gets: {
-      currency: 'BTC',
+      currency: 'USD',
       issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
     },
     pays: {
-      currency: 'USD',
+      currency: 'BTC',
       issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
     }
   });
@@ -36,7 +36,7 @@ module.exports.requestBookOffersBidsResponse = function(request, options={}) {
          },
           TakerPays: {
             currency: options.pays.currency,
-            issuer: options.gets.issuer,
+            issuer: options.pays.issuer,
             value: '10'
          },
           index: 'CE457115A4ADCC8CB351B3E35A0851E48DE16605C23E305017A9B697B156DE5A',
@@ -417,11 +417,11 @@ module.exports.requestBookOffersAsksPartialFundedResponse = function(request, op
 module.exports.requestBookOffersAsksResponse = function(request, options={}) {
   _.defaults(options, {
     pays: {
-      currency: 'BTC',
+      currency: 'USD',
       issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
     },
     gets: {
-      currency: 'USD',
+      currency: 'BTC',
       issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B'
     }
   });

--- a/test/fixtures/get-orderbook-response.json
+++ b/test/fixtures/get-orderbook-response.json
@@ -5,123 +5,19 @@
         "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "10",
+          "value": "93.030522464522",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "3205.1",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-        "sequence": 434,
-        "makerExchangeRate": "0.003120027456241615"
-      }
-    },
-    {
-      "specification": {
-        "direction": "buy",
-        "quantity": {
-          "currency": "USD",
-          "value": "4.99707396683212",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "1599.063669386278",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "rDYCRhpahKEhCFV25xScg67Bwf4W9sTYAm",
-        "sequence": 233,
-        "makerExchangeRate": "0.003125"
-      }
-    },
-    {
-      "specification": {
-        "direction": "buy",
-        "quantity": {
-          "currency": "USD",
-          "value": "0.4499999999999999",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "143.1050962074379",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
-        "sequence": 110104,
-        "makerExchangeRate": "0.003144542101755081"
-      },
-      "state": {
-        "availableQuantity": {
-          "currency": "USD",
-          "value": "0",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "priceOfAvailableQuantity": {
-          "currency": "BTC",
-          "value": "0",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      }
-    },
-    {
-      "specification": {
-        "direction": "buy",
-        "quantity": {
-          "currency": "USD",
-          "value": "0.8",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "254.329207354604",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
-        "sequence": 35625,
-        "makerExchangeRate": "0.003145529403882357"
-      },
-      "state": {
-        "availableQuantity": {
-          "currency": "USD",
-          "value": "0",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "priceOfAvailableQuantity": {
-          "currency": "BTC",
-          "value": "0",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      }
-    },
-    {
-      "specification": {
-        "direction": "buy",
-        "quantity": {
-          "currency": "USD",
-          "value": "1.23231134568807",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "390.4979",
+          "value": "0.2849323720855092",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
       "properties": {
         "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
-        "sequence": 387756,
-        "makerExchangeRate": "0.003155743848271834"
+        "sequence": 386940,
+        "makerExchangeRate": "326.5003614141928"
       }
     },
     {
@@ -129,19 +25,19 @@
         "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "0.003160328237957649",
+          "value": "1",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "1",
+          "value": "0.00302447007930511",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
       "properties": {
         "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
-        "sequence": 208927,
-        "makerExchangeRate": "0.003160328237957649"
+        "sequence": 207855,
+        "makerExchangeRate": "330.6364334177034"
       }
     },
     {
@@ -149,86 +45,12 @@
         "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "15",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "4725",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-        "sequence": 429,
-        "makerExchangeRate": "0.003174603174603175"
-      }
-    },
-    {
-      "specification": {
-        "direction": "buy",
-        "quantity": {
-          "currency": "USD",
-          "value": "1.6",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "496.5429474010489",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
-        "sequence": 35627,
-        "makerExchangeRate": "0.003222279177208227"
-      },
-      "state": {
-        "availableQuantity": {
-          "currency": "USD",
-          "value": "0",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "priceOfAvailableQuantity": {
-          "currency": "BTC",
-          "value": "0",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      }
-    },
-    {
-      "specification": {
-        "direction": "buy",
-        "quantity": {
-          "currency": "USD",
-          "value": "10",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
-          "value": "3103",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        }
-      },
-      "properties": {
-        "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
-        "sequence": 431,
-        "makerExchangeRate": "0.003222687721559781"
-      }
-    }
-  ],
-  "asks": [
-    {
-      "specification": {
-        "direction": "sell",
-        "quantity": {
-          "currency": "USD",
-          "value": "0.3",
-          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-        },
-        "totalPrice": {
-          "currency": "BTC",
           "value": "99.34014894048333",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "0.3",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
@@ -240,15 +62,15 @@
     },
     {
       "specification": {
-        "direction": "sell",
+        "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "0.8095",
+          "value": "268.754",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "268.754",
+          "value": "0.8095",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
@@ -258,13 +80,13 @@
         "makerExchangeRate": "332"
       },
       "state": {
-        "availableQuantity": {
-          "currency": "USD",
+        "fundedAmount": {
+          "currency": "BTC",
           "value": "0.8078974385735969",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
-        "priceOfAvailableQuantity": {
-          "currency": "BTC",
+        "priceOfFundedAmount": {
+          "currency": "USD",
           "value": "268.2219496064341",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
@@ -272,15 +94,15 @@
     },
     {
       "specification": {
-        "direction": "sell",
+        "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "0.4499999999999999",
+          "value": "152.0098333185607",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "152.0098333185607",
+          "value": "0.4499999999999999",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
@@ -292,15 +114,15 @@
     },
     {
       "specification": {
-        "direction": "sell",
+        "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "0.003768001830745216",
+          "value": "1.308365894430151",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "1.308365894430151",
+          "value": "0.003768001830745216",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
@@ -312,15 +134,15 @@
     },
     {
       "specification": {
-        "direction": "sell",
+        "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "0.5",
+          "value": "176.3546101589987",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "176.3546101589987",
+          "value": "0.5",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
@@ -332,15 +154,15 @@
     },
     {
       "specification": {
-        "direction": "sell",
+        "direction": "buy",
         "quantity": {
           "currency": "USD",
-          "value": "0.5",
+          "value": "179.48",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "179.48",
+          "value": "0.5",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
@@ -350,14 +172,140 @@
         "makerExchangeRate": "358.96"
       },
       "state": {
-        "availableQuantity": {
-          "currency": "USD",
+        "fundedAmount": {
+          "currency": "BTC",
           "value": "0.499001996007984",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
-        "priceOfAvailableQuantity": {
-          "currency": "BTC",
+        "priceOfFundedAmount": {
+          "currency": "USD",
           "value": "179.1217564870259",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      }
+    },
+    {
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "USD",
+          "value": "288.7710263794967",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "0.8",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "sequence": 35789,
+        "makerExchangeRate": "360.9637829743709"
+      }
+    },
+    {
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "USD",
+          "value": "182.9814890090516",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "0.5",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rUeCeioKJkbYhv4mRGuAbZpPcqkMCoYq6N",
+        "sequence": 5255,
+        "makerExchangeRate": "365.9629780181032"
+      },
+      "state": {
+        "fundedAmount": {
+          "currency": "BTC",
+          "value": "0.2254411038203033",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "priceOfFundedAmount": {
+          "currency": "USD",
+          "value": "82.50309772176658",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      }
+    }
+  ],
+  "asks": [
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "3205.1",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "10",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "sequence": 434,
+        "makerExchangeRate": "0.003120027456241615"
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "1599.063669386278",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "4.99707396683212",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rDYCRhpahKEhCFV25xScg67Bwf4W9sTYAm",
+        "sequence": 233,
+        "makerExchangeRate": "0.003125"
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "143.1050962074379",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "0.4499999999999999",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "sequence": 110104,
+        "makerExchangeRate": "0.003144542101755081"
+      },
+      "state": {
+        "fundedAmount": {
+          "currency": "USD",
+          "value": "0",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "priceOfFundedAmount": {
+          "currency": "BTC",
+          "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       }
@@ -367,118 +315,164 @@
         "direction": "sell",
         "quantity": {
           "currency": "USD",
-          "value": "0.8",
+          "value": "254.329207354604",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         },
         "totalPrice": {
           "currency": "BTC",
-          "value": "288.7710263794967",
+          "value": "0.8",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
       },
       "properties": {
         "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
-        "sequence": 35789,
-        "makerExchangeRate": "360.9637829743709"
+        "sequence": 35625,
+        "makerExchangeRate": "0.003145529403882357"
+      },
+      "state": {
+        "fundedAmount": {
+          "currency": "USD",
+          "value": "0",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "priceOfFundedAmount": {
+          "currency": "BTC",
+          "value": "0",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "390.4979",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "1.23231134568807",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
+        "sequence": 387756,
+        "makerExchangeRate": "0.003155743848271834"
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "1",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "0.003160328237957649",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
+        "sequence": 208927,
+        "makerExchangeRate": "0.003160328237957649"
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "4725",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "15",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "sequence": 429,
+        "makerExchangeRate": "0.003174603174603175"
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "1.24252537879871",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "0.003967400879423823",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
+        "sequence": 110099,
+        "makerExchangeRate": "0.003193013959408667"
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "496.5429474010489",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "1.6",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "sequence": 35627,
+        "makerExchangeRate": "0.003222279177208227"
+      },
+      "state": {
+        "fundedAmount": {
+          "currency": "USD",
+          "value": "0",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "priceOfFundedAmount": {
+          "currency": "BTC",
+          "value": "0",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      }
+    },
+    {
+      "specification": {
+        "direction": "sell",
+        "quantity": {
+          "currency": "USD",
+          "value": "3103",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "10",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "sequence": 431,
+        "makerExchangeRate": "0.003222687721559781"
       }
     }
-  ],
-  "flipped": {
-    "bids": [
-      {
-        "specification": {
-          "direction": "buy",
-          "quantity": {
-            "currency": "BTC",
-            "value": "93.030522464522",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          },
-          "totalPrice": {
-            "currency": "USD",
-            "value": "0.2849323720855092",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          }
-        },
-        "properties": {
-          "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
-          "sequence": 386940,
-          "makerExchangeRate": "326.5003614141928"
-        }
-      },
-      {
-        "specification": {
-          "direction": "buy",
-          "quantity": {
-            "currency": "BTC",
-            "value": "1",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          },
-          "totalPrice": {
-            "currency": "USD",
-            "value": "0.00302447007930511",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          }
-        },
-        "properties": {
-          "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
-          "sequence": 207855,
-          "makerExchangeRate": "330.6364334177034"
-        }
-      },
-      {
-        "specification": {
-          "direction": "buy",
-          "quantity": {
-            "currency": "BTC",
-            "value": "182.9814890090516",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          },
-          "totalPrice": {
-            "currency": "USD",
-            "value": "0.5",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          }
-        },
-        "properties": {
-          "maker": "rUeCeioKJkbYhv4mRGuAbZpPcqkMCoYq6N",
-          "sequence": 5255,
-          "makerExchangeRate": "365.9629780181032"
-        },
-        "state": {
-          "availableQuantity": {
-            "currency": "BTC",
-            "value": "82.50309772176658",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          },
-          "priceOfAvailableQuantity": {
-            "currency": "USD",
-            "value": "0.2254411038203033",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          }
-        }
-      }
-    ],
-    "asks": [
-      {
-        "specification": {
-          "direction": "sell",
-          "quantity": {
-            "currency": "BTC",
-            "value": "1.24252537879871",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          },
-          "totalPrice": {
-            "currency": "USD",
-            "value": "0.003967400879423823",
-            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-          }
-        },
-        "properties": {
-          "maker": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
-          "sequence": 110099,
-          "makerExchangeRate": "0.003193013959408667"
-        }
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Orders in the order book are now "synthetic" in that the specification of the order does not necessarily match the specification used to initially specify the order (buy and sell can be flipped). This allows us to merge the X/Y order book with the Y/X order book, which is good because one of the two order books is redundant.