### PR TITLE
Fix orderbook notification while disconnected

### DIFF
--- a/test/fixtures/orderbook.js
+++ b/test/fixtures/orderbook.js
@@ -1,10 +1,10 @@
-/*eslint-disable max-len */
+/*eslint-disable max-len, no-param-reassign*/
 
 'use strict';
 
-var _ = require('lodash');
-var addresses = require('./addresses');
-var Meta = require('ripple-lib').Meta;
+const _ = require('lodash');
+const addresses = require('./addresses');
+const Meta = require('ripple-lib').Meta;
 
 module.exports.FIAT_BALANCE = '10';
 module.exports.NATIVE_BALANCE = '55';
@@ -816,7 +816,7 @@ module.exports.transactionWithCreatedOffer = function(options) {
     amount: '1.9951'
   });
 
-  var meta = new Meta({
+  const meta = new Meta({
     AffectedNodes: [
       {
         CreatedNode: {
@@ -856,7 +856,7 @@ module.exports.transactionWithDeletedOffer = function(options) {
     transaction_type: 'OfferCreate'
   });
 
-  var meta = new Meta({
+  const meta = new Meta({
     AffectedNodes: [
       {
         DeletedNode: {
@@ -895,8 +895,53 @@ module.exports.transactionWithDeletedOffer = function(options) {
   };
 };
 
+module.exports.transactionWithDeletedOfferR = function(options) {
+  options = options || {};
+  _.defaults(options, {
+    transaction_type: 'OfferCreate'
+  });
+
+  const meta = new Meta({
+    AffectedNodes: [
+      {
+        DeletedNode: {
+          FinalFields: {
+            Account: addresses.ACCOUNT,
+            BookDirectory: '3B95C29205977C2136BBC70F21895F8C8F471C8522BF446E570463F9CDB31517',
+            BookNode: '0000000000000000',
+            Expiration: 477086871,
+            Flags: 131072,
+            OwnerNode: '0000000000000979',
+            PreviousTxnID: 'DDD2AB60A2AA1690A6CB99B094BFD2E39A81AFF2AA91B5E4049D2C96A4BC8EBA',
+            PreviousTxnLgrSeq: 11674760,
+            Sequence: 85006,
+            TakerPays: {
+              currency: 'USD',
+              issuer: addresses.ISSUER,
+              value: module.exports.TAKER_GETS
+            },
+            TakerGets: module.exports.TAKER_PAYS
+          },
+          LedgerEntryType: 'Offer',
+          LedgerIndex: 'B6BC3B0F87976370EE11F5575593FE63AA5DC1D602830DC96F04B2D597F044BF'
+        }
+      }
+    ]
+  });
+
+  meta.getAffectedBooks();
+
+  return {
+    mmeta: meta,
+    transaction: {
+      TransactionType: options.transaction_type,
+      owner_funds: '2010.027702881682'
+    }
+  };
+};
+
 module.exports.transactionWithModifiedOffer = function() {
-  var meta = new Meta({
+  const meta = new Meta({
     AffectedNodes: module.exports.MODIFIED_NODES.slice(0, 1)
   });
 
@@ -912,7 +957,7 @@ module.exports.transactionWithModifiedOffer = function() {
 };
 
 module.exports.transactionWithModifiedOffers = function() {
-  var meta = new Meta({
+  const meta = new Meta({
     AffectedNodes: module.exports.MODIFIED_NODES
   });
 
@@ -928,7 +973,7 @@ module.exports.transactionWithModifiedOffers = function() {
 };
 
 module.exports.transactionWithNoNodes = function() {
-  var meta = new Meta({
+  const meta = new Meta({
     AffectedNodes: []
   });
 

--- a/test/orderbook-test.js
+++ b/test/orderbook-test.js
@@ -2,19 +2,19 @@
 
 'use strict';
 
-var assert = require('assert-diff');
-var Remote = require('ripple-lib').Remote;
-var Currency = require('ripple-lib').Currency;
-var Amount = require('ripple-lib').Amount;
-var Meta = require('ripple-lib').Meta;
-var addresses = require('./fixtures/addresses');
-var fixtures = require('./fixtures/orderbook');
+const assert = require('assert-diff');
+const Remote = require('ripple-lib').Remote;
+const Currency = require('ripple-lib').Currency;
+const Amount = require('ripple-lib').Amount;
+const Meta = require('ripple-lib').Meta;
+const addresses = require('./fixtures/addresses');
+const fixtures = require('./fixtures/orderbook');
 
 describe('OrderBook', function() {
   this.timeout(0);
 
   it('toJSON', function() {
-    var book = new Remote().createOrderBook({
+    let book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -48,7 +48,7 @@ describe('OrderBook', function() {
   });
 
   it('Check orderbook validity', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -58,7 +58,7 @@ describe('OrderBook', function() {
   });
 
   it('Automatic subscription (based on listeners)', function(done) {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -72,13 +72,13 @@ describe('OrderBook', function() {
   });
 
   it('Subscribe', function(done) {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
     });
 
-    var requestedOffers = false;
+    let requestedOffers = false;
 
     book.subscribeTransactions = function() {
       assert(requestedOffers);
@@ -94,7 +94,7 @@ describe('OrderBook', function() {
   });
 
   it('Unsubscribe', function(done) {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -114,7 +114,7 @@ describe('OrderBook', function() {
   });
 
   it('Automatic unsubscription - remove all listeners', function(done) {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -129,7 +129,7 @@ describe('OrderBook', function() {
   });
 
   it('Automatic unsubscription - once listener', function(done) {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -144,7 +144,7 @@ describe('OrderBook', function() {
   });
 
   it('Set owner funds', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -157,7 +157,7 @@ describe('OrderBook', function() {
   });
 
   it('Set owner funds - unadjusted funds', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -170,7 +170,7 @@ describe('OrderBook', function() {
   });
 
   it('Set owner funds - invalid account', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -182,7 +182,7 @@ describe('OrderBook', function() {
   });
 
   it('Set owner funds - invalid amount', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -194,7 +194,7 @@ describe('OrderBook', function() {
   });
 
   it('Has owner funds', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -205,7 +205,7 @@ describe('OrderBook', function() {
   });
 
   it('Delete owner funds', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -219,7 +219,7 @@ describe('OrderBook', function() {
   });
 
   it('Delete owner funds', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -234,7 +234,7 @@ describe('OrderBook', function() {
   });
 
   it('Increment owner offer count', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -245,7 +245,7 @@ describe('OrderBook', function() {
   });
 
   it('Increment owner offer count - invalid address', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -257,7 +257,7 @@ describe('OrderBook', function() {
   });
 
   it('Decrement owner offer count', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -270,7 +270,7 @@ describe('OrderBook', function() {
   });
 
   it('Decrement owner offer count - no more offers', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -284,7 +284,7 @@ describe('OrderBook', function() {
   });
 
   it('Decrement owner offer count - invalid address', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -296,7 +296,7 @@ describe('OrderBook', function() {
   });
 
   it('Subtract owner offer total', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -308,13 +308,13 @@ describe('OrderBook', function() {
       issuer: addresses.ISSUER
     });
 
-    var newAmount = book.subtractOwnerOfferTotal(addresses.ACCOUNT, {
+    const newAmount = book.subtractOwnerOfferTotal(addresses.ACCOUNT, {
       value: 2,
       currency: 'BTC',
       issuer: addresses.ISSUER
     });
 
-    var offerTotal = Amount.from_json({
+    const offerTotal = Amount.from_json({
       value: 1,
       currency: 'BTC',
       issuer: addresses.ISSUER
@@ -324,7 +324,7 @@ describe('OrderBook', function() {
   });
 
   it('Subtract owner offer total - negative total', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -340,7 +340,7 @@ describe('OrderBook', function() {
   });
 
   it('Get owner offer total', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -355,7 +355,7 @@ describe('OrderBook', function() {
   });
 
   it('Get owner offer total - native', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -367,7 +367,7 @@ describe('OrderBook', function() {
   });
 
   it('Get owner offer total - no total', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -377,7 +377,7 @@ describe('OrderBook', function() {
   });
 
   it('Get owner offer total - native - no total', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -387,7 +387,7 @@ describe('OrderBook', function() {
   });
 
   it('Apply transfer rate - cached transfer rate', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -399,7 +399,7 @@ describe('OrderBook', function() {
   });
 
   it('Apply transfer rate - native currency', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -411,7 +411,7 @@ describe('OrderBook', function() {
   });
 
   it('Apply transfer rate - invalid balance', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -423,7 +423,7 @@ describe('OrderBook', function() {
   });
 
   it('Apply transfer rate - invalid transfer rate', function() {
-    var book = new Remote().createOrderBook({
+    const book = new Remote().createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -435,8 +435,8 @@ describe('OrderBook', function() {
   });
 
   it('Request transfer rate', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -463,8 +463,8 @@ describe('OrderBook', function() {
   });
 
   it('Request transfer rate - not set', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -490,8 +490,8 @@ describe('OrderBook', function() {
   });
 
   it('Request transfer rate - cached transfer rate', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -510,8 +510,8 @@ describe('OrderBook', function() {
   });
 
   it('Request transfer rate - native currency', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -529,8 +529,8 @@ describe('OrderBook', function() {
   });
 
   it('Set offer funded amount - iou/xrp - fully funded', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'BTC',
       currency_pays: 'XRP',
       issuer_gets: addresses.ISSUER
@@ -538,7 +538,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1000000000;
 
-    var offer = {
+    const offer = {
       Account: addresses.ACCOUNT,
       TakerGets: {
         value: '100',
@@ -551,7 +551,7 @@ describe('OrderBook', function() {
     book.setOwnerFunds(addresses.ACCOUNT, '100.1234');
     book.setOfferFundedAmount(offer);
 
-    var expected = {
+    const expected = {
       Account: addresses.ACCOUNT,
       TakerGets: offer.TakerGets,
       TakerPays: offer.TakerPays,
@@ -565,8 +565,8 @@ describe('OrderBook', function() {
   });
 
   it('Set offer funded amount - iou/xrp - unfunded', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'BTC',
       currency_pays: 'XRP',
       issuer_gets: addresses.ISSUER
@@ -574,7 +574,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1000000000;
 
-    var offer = {
+    const offer = {
       Account: addresses.ACCOUNT,
       TakerGets: {
         value: '100',
@@ -588,7 +588,7 @@ describe('OrderBook', function() {
     book.setOwnerFunds(addresses.ACCOUNT, '99');
     book.setOfferFundedAmount(offer);
 
-    var expected = {
+    const expected = {
       Account: addresses.ACCOUNT,
       TakerGets: offer.TakerGets,
       TakerPays: offer.TakerPays,
@@ -603,8 +603,8 @@ describe('OrderBook', function() {
   });
 
   it('Set offer funded amount - xrp/iou - funded', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -612,7 +612,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1000000000;
 
-    var offer = {
+    const offer = {
       Account: addresses.ACCOUNT,
       TakerGets: '100',
       TakerPays: {
@@ -625,7 +625,7 @@ describe('OrderBook', function() {
     book.setOwnerFunds(addresses.ACCOUNT, '100100000');
     book.setOfferFundedAmount(offer);
 
-    var expected = {
+    const expected = {
       Account: addresses.ACCOUNT,
       TakerGets: offer.TakerGets,
       TakerPays: offer.TakerPays,
@@ -639,8 +639,8 @@ describe('OrderBook', function() {
   });
 
   it('Set offer funded amount - xrp/iou - unfunded', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -648,7 +648,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1000000000;
 
-    var offer = {
+    const offer = {
       Account: addresses.ACCOUNT,
       TakerGets: '100',
       TakerPays: {
@@ -662,7 +662,7 @@ describe('OrderBook', function() {
     book.setOwnerFunds(addresses.ACCOUNT, '99');
     book.setOfferFundedAmount(offer);
 
-    var expected = {
+    const expected = {
       Account: addresses.ACCOUNT,
       TakerGets: offer.TakerGets,
       TakerPays: offer.TakerPays,
@@ -677,8 +677,8 @@ describe('OrderBook', function() {
   });
 
   it('Set offer funded amount - zero funds', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
@@ -686,7 +686,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1000000000;
 
-    var offer = {
+    const offer = {
       Account: addresses.ACCOUNT,
       TakerGets: {
         value: '100',
@@ -711,15 +711,15 @@ describe('OrderBook', function() {
   });
 
   it('Check is balance change node', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -761,15 +761,15 @@ describe('OrderBook', function() {
   });
 
   it('Check is balance change node - not balance change', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -804,15 +804,15 @@ describe('OrderBook', function() {
   });
 
   it('Check is balance change node - different currency', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'BTC',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -854,15 +854,15 @@ describe('OrderBook', function() {
   });
 
   it('Check is balance change node - different issuer', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -904,15 +904,15 @@ describe('OrderBook', function() {
   });
 
   it('Check is balance change node - native currency', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -939,15 +939,15 @@ describe('OrderBook', function() {
   });
 
   it('Check is balance change node - native currency - not balance change', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'BTC'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -969,15 +969,15 @@ describe('OrderBook', function() {
   });
 
   it('Parse account balance from node', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [
         {
           ModifiedNode: {
@@ -1064,15 +1064,15 @@ describe('OrderBook', function() {
   });
 
   it('Parse account balance from node - native currency', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
-    var meta = new Meta({
+    const meta = new Meta({
       AffectedNodes: [{
         ModifiedNode: {
           FinalFields: {
@@ -1102,21 +1102,20 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts', function(done) {
-    var receivedChangedEvents = 0;
-    var receivedFundsChangedEvents = 0;
+    let receivedChangedEvents = 0;
+    let receivedFundsChangedEvents = 0;
 
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var message = fixtures.transactionWithRippleState();
+    const message = fixtures.transactionWithRippleState();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book._issuerTransferRate = 1000000000;
-    book._synchronized = true;
 
     book._offers = fixtures.fiatOffers();
 
@@ -1154,22 +1153,21 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - increase funds', function() {
-    var receivedFundsChangedEvents = 0;
+    let receivedFundsChangedEvents = 0;
 
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var message = fixtures.transactionWithRippleState({
+    const message = fixtures.transactionWithRippleState({
       balance: '50'
     });
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book._issuerTransferRate = 1000000000;
-    book._synchronized = true;
 
     book.setOffers(fixtures.fiatOffers({
       account_funds: '19'
@@ -1198,18 +1196,17 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - owner_funds', function(done) {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var message = fixtures.transactionWithRippleState();
+    const message = fixtures.transactionWithRippleState();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book._issuerTransferRate = 1002000000;
-    book._synchronized = true;
 
     book._offers = fixtures.fiatOffers();
 
@@ -1225,18 +1222,17 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - issuer transfer rate set', function(done) {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var message = fixtures.transactionWithRippleState();
+    const message = fixtures.transactionWithRippleState();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book._issuerTransferRate = 1002000000;
-    book._synchronized = true;
 
     book._ownerFunds[addresses.ACCOUNT] = '100';
     book._offers = fixtures.fiatOffers();
@@ -1251,20 +1247,19 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - native currency', function(done) {
-    var receivedChangedEvents = 0;
-    var receivedFundsChangedEvents = 0;
+    let receivedChangedEvents = 0;
+    let receivedFundsChangedEvents = 0;
 
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var message = fixtures.transactionWithAccountRoot();
+    const message = fixtures.transactionWithAccountRoot();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'USD'
     });
 
-    book._synchronized = true;
     book._offers = fixtures.NATIVE_OFFERS;
 
     book.on('offer_changed', function() {
@@ -1297,19 +1292,17 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - no affected account', function(done) {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var message = fixtures.transactionWithAccountRoot({
+    const message = fixtures.transactionWithAccountRoot({
       account: addresses.ACCOUNT
     });
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'USD'
     });
-
-    book._synchronized = true;
 
     book._offers = fixtures.NATIVE_OFFERS;
 
@@ -1331,17 +1324,15 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - no balance change', function(done) {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       issuer_pays: addresses.ISSUER,
       currency_pays: 'USD'
     });
 
-    var message = fixtures.transactionWithInvalidAccountRoot();
-
-    book._synchronized = true;
+    const message = fixtures.transactionWithInvalidAccountRoot();
 
     book._offers = fixtures.NATIVE_OFFERS;
 
@@ -1366,15 +1357,15 @@ describe('OrderBook', function() {
   });
 
   it('Update funded amounts - deferred TransferRate', function(done) {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
-    var message = fixtures.transactionWithRippleState();
+    const message = fixtures.transactionWithRippleState();
 
     remote.request = function(request) {
       assert.deepEqual(request.message, {
@@ -1394,9 +1385,9 @@ describe('OrderBook', function() {
   });
 
   it('Set offers - issuer transfer rate set - iou/xrp', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1404,7 +1395,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1002000000;
 
-    var offers = fixtures.bookOffersResponse().offers;
+    const offers = fixtures.bookOffersResponse().offers;
 
     book.setOffers(offers);
 
@@ -1427,9 +1418,9 @@ describe('OrderBook', function() {
   });
 
   it('Set offers - issuer transfer rate set - iou/xrp - funded amounts', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1437,19 +1428,19 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1002000000;
 
-    var offers = fixtures.bookOffersResponse({
+    const offers = fixtures.bookOffersResponse({
       account_funds: '233.13532'
     }).offers;
 
     book.setOffers(offers);
 
-    var offerOneTakerGetsFunded = Amount.from_json({
+    const offerOneTakerGetsFunded = Amount.from_json({
       value: book._offers[0].taker_gets_funded,
       currency: 'USD',
       issuer: addresses.ISSUER
     });
 
-    var offerOneTakerGetsFundedExpected = Amount.from_json({
+    const offerOneTakerGetsFundedExpected = Amount.from_json({
       value: '79.39192374',
       currency: 'USD',
       issuer: addresses.ISSUER
@@ -1458,41 +1449,41 @@ describe('OrderBook', function() {
     assert.strictEqual(offerOneTakerGetsFunded.equals(offerOneTakerGetsFundedExpected), true);
     assert.strictEqual(book._offers[0].is_fully_funded, true);
 
-    var offerTwoTakerGetsFunded = Amount.from_json({
+    const offerTwoTakerGetsFunded = Amount.from_json({
       value: book._offers[1].taker_gets_funded,
       currency: 'USD',
       issuer: addresses.ISSUER
     });
 
-    var offerTwoTakerGetsFundedExpected = Amount.from_json({
+    const offerTwoTakerGetsFundedExpected = Amount.from_json({
       value: '24.01284027983332',
       currency: 'USD',
       issuer: addresses.ISSUER
     });
 
-    var offerTwoTakerPaysFunded = Amount.from_json(book._offers[1].taker_pays_funded);
+    const offerTwoTakerPaysFunded = Amount.from_json(book._offers[1].taker_pays_funded);
 
-    var offerTwoTakerPaysFundedExpected = Amount.from_json('1661400177');
+    const offerTwoTakerPaysFundedExpected = Amount.from_json('1661400177');
 
     assert.strictEqual(offerTwoTakerGetsFunded.equals(offerTwoTakerGetsFundedExpected), true);
     assert.strictEqual(offerTwoTakerPaysFunded.equals(offerTwoTakerPaysFundedExpected), true);
     assert.strictEqual(book._offers[1].is_fully_funded, false);
 
-    var offerFiveTakerGetsFunded = Amount.from_json({
+    const offerFiveTakerGetsFunded = Amount.from_json({
       value: book._offers[4].taker_gets_funded,
       currency: 'USD',
       issuer: addresses.ISSUER
     });
 
-    var offerFiveTakerGetsFundedExpected = Amount.from_json({
+    const offerFiveTakerGetsFundedExpected = Amount.from_json({
       value: '153.2780562999202',
       currency: 'USD',
       issuer: addresses.ISSUER
     });
 
-    var offerFiveTakerPaysFunded = Amount.from_json(book._offers[4].taker_pays_funded);
+    const offerFiveTakerPaysFunded = Amount.from_json(book._offers[4].taker_pays_funded);
 
-    var offerFiveTakerPaysFundedExpected = Amount.from_json('10684615137');
+    const offerFiveTakerPaysFundedExpected = Amount.from_json('10684615137');
 
     assert.strictEqual(offerFiveTakerGetsFunded.equals(offerFiveTakerGetsFundedExpected), true);
     assert.strictEqual(offerFiveTakerPaysFunded.equals(offerFiveTakerPaysFundedExpected), true);
@@ -1500,9 +1491,9 @@ describe('OrderBook', function() {
   });
 
   it('Set offers - multiple calls', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1510,7 +1501,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1002000000;
 
-    var offers = fixtures.bookOffersResponse().offers;
+    const offers = fixtures.bookOffersResponse().offers;
 
     book.setOffers(offers);
     book.setOffers(offers);
@@ -1534,9 +1525,9 @@ describe('OrderBook', function() {
   });
 
   it('Set offers - incorrect taker pays funded', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1544,7 +1535,7 @@ describe('OrderBook', function() {
 
     book._issuerTransferRate = 1002000000;
 
-    var offers = fixtures.DECIMAL_TAKER_PAYS_FUNDED_OFFERS;
+    const offers = fixtures.DECIMAL_TAKER_PAYS_FUNDED_OFFERS;
 
     book.setOffers(offers);
 
@@ -1555,18 +1546,18 @@ describe('OrderBook', function() {
   });
 
   it('Notify - created node', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book._issuerTransferRate = 1002000000;
-    book._subscribed = true;
+    book._subscribed = book._synced = true;
 
-    var message = fixtures.transactionWithCreatedOffer();
+    const message = fixtures.transactionWithCreatedOffer();
 
     book.notify(message);
 
@@ -1577,25 +1568,25 @@ describe('OrderBook', function() {
   });
 
   it('Notify - created nodes - correct sorting', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book._issuerTransferRate = 1002000000;
-    book._subscribed = true;
+    book._subscribed = book._synced = true;
 
-    var offer = fixtures.transactionWithCreatedOffer();
+    const offer = fixtures.transactionWithCreatedOffer();
 
-    var lowQualityOffer = fixtures.transactionWithCreatedOffer({
+    const lowQualityOffer = fixtures.transactionWithCreatedOffer({
       account: addresses.OTHER_ACCOUNT,
       amount: '1.5'
     });
 
-    var highQualityOffer = fixtures.transactionWithCreatedOffer({
+    const highQualityOffer = fixtures.transactionWithCreatedOffer({
       account: addresses.THIRD_ACCOUNT,
       amount: '3.83'
     });
@@ -1611,13 +1602,13 @@ describe('OrderBook', function() {
   });
 
   it('Notify - created nodes - events', function() {
-    var numTransactionEvents = 0;
-    var numModelEvents = 0;
-    var numOfferAddedEvents = 0;
+    let numTransactionEvents = 0;
+    let numModelEvents = 0;
+    let numOfferAddedEvents = 0;
 
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1636,11 +1627,11 @@ describe('OrderBook', function() {
     });
 
     book._issuerTransferRate = 1002000000;
-    book._subscribed = true;
+    book._subscribed = book._synced = true;
 
-    var offer = fixtures.transactionWithCreatedOffer();
-    var offer2 = fixtures.transactionWithCreatedOffer();
-    var offer3 = fixtures.transactionWithCreatedOffer();
+    const offer = fixtures.transactionWithCreatedOffer();
+    const offer2 = fixtures.transactionWithCreatedOffer();
+    const offer3 = fixtures.transactionWithCreatedOffer();
 
     book.notify(offer);
     book.notify(offer2);
@@ -1652,9 +1643,9 @@ describe('OrderBook', function() {
   });
 
   it('Notify - deleted node', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1665,7 +1656,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithDeletedOffer();
+    const message = fixtures.transactionWithDeletedOffer();
 
     book.notify(message);
 
@@ -1675,9 +1666,9 @@ describe('OrderBook', function() {
   });
 
   it('Notify - deleted node - last offer', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1688,7 +1679,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers().slice(0, 1));
 
-    var message = fixtures.transactionWithDeletedOffer();
+    const message = fixtures.transactionWithDeletedOffer();
 
     book.notify(message);
 
@@ -1697,13 +1688,13 @@ describe('OrderBook', function() {
   });
 
   it('Notify - deleted node - events', function() {
-    var numTransactionEvents = 0;
-    var numModelEvents = 0;
-    var numTradeEvents = 0;
-    var numOfferRemovedEvents = 0;
+    let numTransactionEvents = 0;
+    let numModelEvents = 0;
+    let numTradeEvents = 0;
+    let numOfferRemovedEvents = 0;
 
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1730,7 +1721,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithDeletedOffer();
+    const message = fixtures.transactionWithDeletedOffer();
 
     book.notify(message);
 
@@ -1741,16 +1732,16 @@ describe('OrderBook', function() {
   });
 
   it('Notify - deleted node - trade', function(done) {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book.on('trade', function(tradePays, tradeGets) {
-      var expectedTradePays = Amount.from_json(fixtures.TAKER_PAYS);
-      var expectedTradeGets = Amount.from_json({
+      const expectedTradePays = Amount.from_json(fixtures.TAKER_PAYS);
+      const expectedTradeGets = Amount.from_json({
         value: fixtures.TAKER_GETS,
         currency: 'USD',
         issuer: addresses.ISSUER
@@ -1767,15 +1758,15 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithDeletedOffer();
+    const message = fixtures.transactionWithDeletedOffer();
 
     book.notify(message);
   });
 
   it('Notify - deleted node - offer cancel', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1786,7 +1777,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithDeletedOffer({
+    const message = fixtures.transactionWithDeletedOffer({
       transaction_type: 'OfferCancel'
     });
 
@@ -1798,9 +1789,9 @@ describe('OrderBook', function() {
   });
 
   it('Notify - deleted node - offer cancel - last offer', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1811,7 +1802,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers().slice(0, 1));
 
-    var message = fixtures.transactionWithDeletedOffer({
+    const message = fixtures.transactionWithDeletedOffer({
       transaction_type: 'OfferCancel'
     });
 
@@ -1822,9 +1813,9 @@ describe('OrderBook', function() {
   });
 
   it('Notify - modified node', function() {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1835,7 +1826,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithModifiedOffer();
+    const message = fixtures.transactionWithModifiedOffer();
 
     book.notify(message);
 
@@ -1853,13 +1844,13 @@ describe('OrderBook', function() {
   });
 
   it('Notify - modified node - events', function() {
-    var numTransactionEvents = 0;
-    var numModelEvents = 0;
-    var numTradeEvents = 0;
-    var numOfferChangedEvents = 0;
+    let numTransactionEvents = 0;
+    let numModelEvents = 0;
+    let numTradeEvents = 0;
+    let numOfferChangedEvents = 0;
 
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1886,7 +1877,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithModifiedOffer();
+    const message = fixtures.transactionWithModifiedOffer();
 
     book.notify(message);
 
@@ -1897,16 +1888,16 @@ describe('OrderBook', function() {
   });
 
   it('Notify - modified node - trade', function(done) {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book.on('trade', function(tradePays, tradeGets) {
-      var expectedTradePays = Amount.from_json('800000000');
-      var expectedTradeGets = Amount.from_json({
+      const expectedTradePays = Amount.from_json('800000000');
+      const expectedTradeGets = Amount.from_json({
         value: 1,
         currency: 'USD',
         issuer: addresses.ISSUER
@@ -1923,22 +1914,22 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithModifiedOffer();
+    const message = fixtures.transactionWithModifiedOffer();
 
     book.notify(message);
   });
 
   it('Notify - modified nodes - trade', function(done) {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
     });
 
     book.on('trade', function(tradePays, tradeGets) {
-      var expectedTradePays = Amount.from_json('870000000');
-      var expectedTradeGets = Amount.from_json({
+      const expectedTradePays = Amount.from_json('870000000');
+      const expectedTradeGets = Amount.from_json({
         value: 2,
         currency: 'USD',
         issuer: addresses.ISSUER
@@ -1955,19 +1946,19 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithModifiedOffers();
+    const message = fixtures.transactionWithModifiedOffers();
 
     book.notify(message);
   });
 
   it('Notify - no nodes', function() {
-    var numTransactionEvents = 0;
-    var numModelEvents = 0;
-    var numTradeEvents = 0;
-    var numOfferChangedEvents = 0;
+    let numTransactionEvents = 0;
+    let numModelEvents = 0;
+    let numTradeEvents = 0;
+    let numOfferChangedEvents = 0;
 
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -1994,7 +1985,7 @@ describe('OrderBook', function() {
 
     book.setOffers(fixtures.fiatOffers());
 
-    var message = fixtures.transactionWithNoNodes();
+    const message = fixtures.transactionWithNoNodes();
 
     book.notify(message);
 
@@ -2004,9 +1995,56 @@ describe('OrderBook', function() {
     assert.strictEqual(numOfferChangedEvents, 0);
   });
 
+  it('Notify - in disconnected state', function(done) {
+    this.timeout(100);
+
+    const remote = new Remote();
+    const transaction = fixtures.transactionWithDeletedOfferR();
+    const offers = {
+      offers: fixtures.REQUEST_OFFERS_NATIVE
+    };
+
+    function handleRequest(request) {
+      switch (request.message.command) {
+        case 'book_offers':
+          request.emit('success', offers);
+          break;
+        case 'subscribe':
+          request.emit('success', {});
+          break;
+      }
+    }
+
+    remote.request = function(request) {
+      setImmediate(function() {
+        handleRequest(request);
+      });
+    };
+
+    const book = remote.createOrderBook({
+      currency_gets: 'XRP',
+      currency_pays: 'USD',
+      issuer_pays: addresses.ISSUER
+    });
+
+    book.on('model', function() {
+      remote.emit('disconnect');
+
+      // Check cache reset
+      assert.strictEqual(book._synced, false);
+      assert.deepEqual(book._ownerFunds, {});
+      assert.deepEqual(book._ownerOffersTotal, {});
+
+      setTimeout(function() {
+        // Notification should be dropped if not synced
+        book.notify(transaction);
+        done();
+      }, 10);
+    });
+  });
   it('Delete offer - offer cancel - funded after delete', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -2032,8 +2070,8 @@ describe('OrderBook', function() {
   });
 
   it('Delete offer - offer cancel - not fully funded after delete', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -2061,8 +2099,8 @@ describe('OrderBook', function() {
   });
 
   it('Insert offer - best quality', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -2085,8 +2123,8 @@ describe('OrderBook', function() {
   });
 
   it('Insert offer - best quality - insufficient funds for all offers', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -2120,8 +2158,8 @@ describe('OrderBook', function() {
   });
 
   it('Insert offer - worst quality - insufficient funds for all orders', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -2157,8 +2195,8 @@ describe('OrderBook', function() {
   });
 
   it('Insert offer - middle quality - insufficient funds for all offers', function() {
-    var remote = new Remote();
-    var book = remote.createOrderBook({
+    const remote = new Remote();
+    const book = remote.createOrderBook({
       currency_gets: 'USD',
       issuer_gets: addresses.ISSUER,
       currency_pays: 'XRP'
@@ -2194,13 +2232,13 @@ describe('OrderBook', function() {
   });
 
   it('Request offers - native currency', function(done) {
-    var remote = new Remote();
+    const remote = new Remote();
 
-    var offers = {
+    const offers = {
       offers: fixtures.REQUEST_OFFERS_NATIVE
     };
 
-    var expected = [
+    const expected = [
       {
         Account: addresses.ACCOUNT,
         BookDirectory: '6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985711A3A4254F5000',
@@ -2303,7 +2341,8 @@ describe('OrderBook', function() {
               currency: '0000000000000000000000005553440000000000',
               issuer: addresses.ISSUER
             },
-            taker: 'rrrrrrrrrrrrrrrrrrrrBZbvji'
+            taker: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
+            ledger_index: 'validated'
           });
 
           setImmediate(function() {
@@ -2313,7 +2352,7 @@ describe('OrderBook', function() {
       }
     };
 
-    var book = remote.createOrderBook({
+    const book = remote.createOrderBook({
       currency_gets: 'XRP',
       currency_pays: 'USD',
       issuer_pays: addresses.ISSUER
@@ -2321,7 +2360,7 @@ describe('OrderBook', function() {
 
     book.on('model', function(model) {
       assert.deepEqual(model, expected);
-      assert.strictEqual(book._synchronized, true);
+      assert.strictEqual(book._synced, true);
       done();
     });
   });

--- a/test/remote-test.js
+++ b/test/remote-test.js
@@ -712,6 +712,8 @@ describe('Remote', function() {
     });
 
     orderbook._subscribed = true;
+    orderbook._synced = true;
+
     orderbook.once('transaction', function(t) {
       assert.deepEqual(t.transaction, message.transaction);
       assert.deepEqual(t.meta, message.meta);


### PR DESCRIPTION
OrderBook's `notify()` function is the entry point for orderbook notifications (created, modified, deleted offers). In this function,  `_subscribed` property is checked to be truthy, however, this property only means that the end user subscribed or unsubscribed. The orderbook can also disconnect automatically, if a connection to rippled is lost. When this happens, all of the orderbook's account funds caches are cleared, but `notify()` would still execute as normal, because the end user hasn't unsubscribed. So, with cleared caches, the default return value for cached account funds is `0`. But if `notify()` detects a deleted offer... you get it. The error is `Offer total cannot be negative` https://github.com/ripple/ripple-lib/issues/352

This pull request simply adds a check for `_synced` property, which is set to `false` on disconnect