### PR TITLE
Add flow to api

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/src/core/.*
 .*/dist/.*
 .*/test/fixtures/.*
+.*/node_modules/flow-bin/.*
 
 [include]
 ./node_modules/

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -11,7 +11,7 @@ typecheck() {
 lint() {
   REPO_URL="https://raw.githubusercontent.com/ripple/javascript-style-guide"
   curl "$REPO_URL/es6/eslintrc" > ./eslintrc
-  echo "parser: babel-eslint" >> ./eslintrc
+  echo "plugins: [flowtype]" >> ./eslintrc
   node_modules/.bin/eslint --reset -c ./eslintrc $(git --no-pager diff --name-only -M100% --diff-filter=AM --relative $(git merge-base FETCH_HEAD origin/HEAD) FETCH_HEAD | grep "\.js$")
 }
 

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "assert-diff": "^1.0.1",
     "babel": "^5.5.4",
     "babel-core": "^5.5.4",
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^3.1.23",
     "babel-loader": "^5.0.0",
     "coveralls": "~2.10.0",
     "eslint": "^0.24.0",
+    "eslint-plugin-flowtype": "^1.0.0",
     "eventemitter2": "^0.4.14",
+    "flow-bin": "^0.13.1",
     "gulp": "~3.8.10",
     "gulp-bump": "~0.1.13",
     "gulp-rename": "~1.2.0",
@@ -55,7 +57,7 @@
     "prepublish": "npm run clean && npm run compile",
     "test": "istanbul test _mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "lint": "if ! [ -f eslintrc ]; then curl -o eslintrc 'https://raw.githubusercontent.com/ripple/javascript-style-guide/es6/eslintrc'; echo 'parser: babel-eslint' >> eslintrc; fi; eslint --reset -c eslintrc src/",
+    "lint": "if ! [ -f eslintrc ]; then curl -o eslintrc 'https://raw.githubusercontent.com/ripple/javascript-style-guide/es6/eslintrc'; echo 'plugins:\n  - flowtype' >> eslintrc; fi; eslint --reset -c eslintrc src/",
     "perf": "./scripts/perf_test.sh"
   },
   "repository": {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 'use strict';
 const _ = require('lodash');
 const core = require('./common').core;
@@ -28,7 +30,7 @@ const errors = require('./common').errors;
 const convertExceptions = require('./common').convertExceptions;
 const generateWallet = convertExceptions(core.Wallet.generate);
 
-function RippleAPI(options) {
+function RippleAPI(options: {}) {
   const _options = _.assign({}, options, {automatic_resubmission: false});
   this.remote = new core.Remote(_options);
 }

--- a/src/api/ledger/accountinfo.js
+++ b/src/api/ledger/accountinfo.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 'use strict';
 const utils = require('./utils');
 const removeUndefined = require('./parse/utils').removeUndefined;

--- a/src/api/ledger/balances.js
+++ b/src/api/ledger/balances.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const async = require('async');

--- a/src/api/ledger/orderbook.js
+++ b/src/api/ledger/orderbook.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const async = require('async');

--- a/src/api/ledger/orders.js
+++ b/src/api/ledger/orders.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const utils = require('./utils');

--- a/src/api/ledger/parse/account-order.js
+++ b/src/api/ledger/parse/account-order.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const utils = require('./utils');
 const flags = utils.core.Remote.flags.offer;

--- a/src/api/ledger/parse/account-trustline.js
+++ b/src/api/ledger/parse/account-trustline.js
@@ -1,9 +1,25 @@
+/* @flow */
 'use strict';
 const utils = require('./utils');
 
+type Trustline = {
+  account: string, limit: number, currency: string, quality_in: ?number,
+  quality_out: ?number, no_ripple: boolean, freeze: boolean, authorized: boolean,
+  limit_peer: string, no_ripple_peer: boolean, freeze_peer: boolean,
+  peer_authorized: boolean, balance: any
+}
+
+type TrustlineSpecification = {}
+type TrustlineCounterParty = {}
+type TrustlineState = {balance: number}
+type AccountTrustline = {
+  specification: TrustlineSpecification, counterparty: TrustlineCounterParty,
+  state: TrustlineState
+}
+
 // rippled 'account_lines' returns a different format for
 // trustlines than 'tx'
-function parseAccountTrustline(trustline) {
+function parseAccountTrustline(trustline: Trustline): AccountTrustline {
   const specification = utils.removeUndefined({
     limit: trustline.limit,
     currency: trustline.currency,

--- a/src/api/ledger/parse/amount.js
+++ b/src/api/ledger/parse/amount.js
@@ -2,10 +2,11 @@
 'use strict';
 const utils = require('./utils');
 
-/*:: type Amount = string | {currency: string, issuer: string, value: string} */
-/*:: type XRPAmount = {currency: string, value: string} */
-/*:: type IOUAmount = {currency: string, value: string, counterparty: string} */
-/*:: type Output = XRPAmount | IOUAmount */
+type Amount = string | {currency: string, issuer: string, value: string}
+type XRPAmount = {currency: string, value: string}
+type IOUAmount = {currency: string, value: string, counterparty: string}
+type Output = XRPAmount | IOUAmount
+
 function parseAmount(amount: Amount): Output {
   if (typeof amount === 'string') {
     return {

--- a/src/api/ledger/parse/orderbook-order.js
+++ b/src/api/ledger/parse/orderbook-order.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const utils = require('./utils');

--- a/src/api/ledger/pathfind.js
+++ b/src/api/ledger/pathfind.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const async = require('async');
@@ -8,7 +9,12 @@ const parsePathfind = require('./parse/pathfind');
 const NotFoundError = utils.common.errors.NotFoundError;
 const composeAsync = utils.common.composeAsync;
 
-function addParams(params, result) {
+type PathFindParams = {
+  src_currencies?: Array<string>, src_account: string, dst_amount: string,
+  dst_account?: string
+}
+
+function addParams(params: PathFindParams, result: {}) {
   return _.assign({}, result, {
     source_account: params.src_account,
     source_currencies: params.src_currencies,
@@ -16,8 +22,13 @@ function addParams(params, result) {
   });
 }
 
-function requestPathFind(remote, pathfind, callback) {
-  const params = {
+type PathFind = {
+  source: {address: string, currencies: Array<string>},
+  destination: {address: string, amount: string}
+}
+
+function requestPathFind(remote, pathfind: PathFind, callback) {
+  const params: PathFindParams = {
     src_account: pathfind.source.address,
     dst_account: pathfind.destination.address,
     dst_amount: utils.common.toRippledAmount(pathfind.destination.amount)

--- a/src/api/ledger/settings.js
+++ b/src/api/ledger/settings.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const utils = require('./utils');

--- a/src/api/ledger/transaction.js
+++ b/src/api/ledger/transaction.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const async = require('async');

--- a/src/api/ledger/transactions.js
+++ b/src/api/ledger/transactions.js
@@ -1,3 +1,4 @@
+/* @flow */
 'use strict';
 const _ = require('lodash');
 const utils = require('./utils');

--- a/src/api/server/server.js
+++ b/src/api/server/server.js
@@ -1,28 +1,31 @@
+/* @flow */
+
 'use strict';
+
 const common = require('../common');
 
 // If a ledger is not received in this time, consider the connection offline
 const CONNECTION_TIMEOUT = 1000 * 30;
 
-function connect(callback) {
+function connect(callback: (err: any, data: any) => void): void {
   this.remote.connect(callback);
 }
 
-function disconnect(callback) {
+function disconnect(callback: (err: any, data: any) => void): void {
   this.remote.disconnect(callback);
 }
 
-function isUpToDate(remote) {
+function isUpToDate(remote): boolean {
   const server = remote.getServer();
   return Boolean(server) && (remote._stand_alone
     || (Date.now() - server._lastLedgerClose) <= CONNECTION_TIMEOUT);
 }
 
-function isConnected() {
+function isConnected(): boolean {
   return Boolean(this.remote._ledger_current_index) && isUpToDate(this.remote);
 }
 
-function getServerInfo(callback) {
+function getServerInfo(callback: (err: any, data: any) => void): void {
   this.remote.requestServerInfo((error, response) => {
     if (error) {
       callback(new common.errors.RippledNetworkError(error.message));
@@ -32,11 +35,11 @@ function getServerInfo(callback) {
   });
 }
 
-function getFee() {
+function getFee(): number {
   return common.dropsToXrp(this.remote.createTransaction()._computeFee());
 }
 
-function getLedgerVersion() {
+function getLedgerVersion(): number {
   return this.remote.getLedgerSequence();
 }
 


### PR DESCRIPTION
1. Add flow to ledger/parse/account-order, trustline, orderbook-order
Use eslint plugin flowtype to allow flow type annotations. Babel-eslint emits errors when using the type keyword. This plugin works around the issue by stripping flow annotations before linting. Source: https://www.npmjs.com/package/eslint-plugin-flowtype

2. Add flow typecheck to api/ledger/pathfind

3. Add flow check to src/api: index, accountinfo, balances, orderbook-orders, settings, transaction, transactions

4. Add flow to api/server/server.js

5. Add flow-bin to dev dependencies and ignore it in flowconfig
