### PR TITLE
fix settings.json schema to allow empty stings to

### DIFF
--- a/src/api/common/schemas/settings.json
+++ b/src/api/common/schemas/settings.json
@@ -12,12 +12,22 @@
     "noFreeze": {"type": "boolean"},
     "globalFreeze": {"type": "boolean"},
     "defaultRipple": {"type": "boolean"},
-    "emailHash": {"$ref": "hash128"},
-    "walletLocator": {"$ref": "hash256"},
-    "walletSize": {"type": "integer"},
+    "emailHash": {
+      "oneOf": [
+        {"type": "null"},
+        {"$ref": "hash128"}
+      ]
+    },
+    "walletLocator": {
+      "oneOf": [
+        {"type": "null"},
+        {"$ref": "hash256"}
+      ]
+    },
+    "walletSize": {"type": ["integer", "null"]},
     "messageKey": {"type": "string"},
     "domain": {"type": "string"},
-    "transferRate": {"type": "integer"},
+    "transferRate": {"type": ["integer", "null"]},
     "signers": {"type": "string"},
     "regularKey": {"$ref": "address"}
   },

--- a/src/api/transaction/settings.js
+++ b/src/api/transaction/settings.js
@@ -9,7 +9,7 @@ const AccountFields = utils.common.constants.AccountFields;
 const Transaction = utils.common.core.Transaction;
 
 // Emptry string passed to setting will clear it
-const CLEAR_SETTING = '';
+const CLEAR_SETTING = null;
 
 function setTransactionFlags(transaction, values) {
   const keys = Object.keys(values);

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -93,6 +93,39 @@ describe('RippleAPI', function() {
       _.partial(checkResult, responses.prepareSettings.regularKey, done));
   });
 
+  it('prepareSettings - flag set', function(done) {
+    const settings = {requireDestinationTag: true};
+    this.api.prepareSettings(address, settings, instructions,
+      _.partial(checkResult, responses.prepareSettings.flagSet, done));
+  });
+
+  it('prepareSettings - flag clear', function(done) {
+    const settings = {requireDestinationTag: false};
+    this.api.prepareSettings(address, settings, instructions,
+      _.partial(checkResult, responses.prepareSettings.flagClear, done));
+  });
+
+  it('prepareSettings - string field clear', function(done) {
+    const settings = {walletLocator: null};
+    this.api.prepareSettings(address, settings, instructions,
+      _.partial(checkResult, responses.prepareSettings.fieldClear, done));
+  });
+
+  it('prepareSettings - integer field clear', function(done) {
+    const settings = {walletSize: null};
+    this.api.prepareSettings(address, settings, instructions, (e, data) => {
+      assert(data);
+      assert.strictEqual(data.WalletSize, 0);
+      done(e);
+    });
+  });
+
+  it('prepareSettings - set transferRate', function(done) {
+    const settings = {transferRate: 1};
+    this.api.prepareSettings(address, settings, instructions,
+      _.partial(checkResult, responses.prepareSettings.setTransferRate, done));
+  });
+
   it('sign', function() {
     const secret = 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV';
     withDeterministicPRNG(() => {

--- a/test/fixtures/api/responses/index.js
+++ b/test/fixtures/api/responses/index.js
@@ -27,7 +27,11 @@ module.exports = {
     require('./prepare-payment-no-counterparty.json'),
   prepareSettings: {
     regularKey: require('./prepare-settings-regular-key.json'),
-    flags: require('./prepare-settings.json')
+    flags: require('./prepare-settings.json'),
+    flagSet: require('./prepare-settings-flag-set.json'),
+    flagClear: require('./prepare-settings-flag-clear.json'),
+    setTransferRate: require('./prepare-settings-set-transfer-rate.json'),
+    fieldClear: require('./prepare-settings-field-clear.json')
   },
   prepareTrustline: require('./prepare-trustline.json'),
   sign: require('./sign.json'),

--- a/test/fixtures/api/responses/prepare-settings-field-clear.json
+++ b/test/fixtures/api/responses/prepare-settings-field-clear.json
@@ -1,0 +1,9 @@
+{
+  "Flags": 0,
+  "TransactionType": "AccountSet",
+  "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "WalletLocator": "0",
+  "LastLedgerSequence": 8820051,
+  "Fee": "12",
+  "Sequence": 23
+}

--- a/test/fixtures/api/responses/prepare-settings-flag-clear.json
+++ b/test/fixtures/api/responses/prepare-settings-flag-clear.json
@@ -1,0 +1,9 @@
+{
+  "Flags": 0,
+  "TransactionType": "AccountSet",
+  "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "ClearFlag": 1,
+  "LastLedgerSequence": 8820051,
+  "Fee": "12",
+  "Sequence": 23
+}

--- a/test/fixtures/api/responses/prepare-settings-flag-set.json
+++ b/test/fixtures/api/responses/prepare-settings-flag-set.json
@@ -1,0 +1,9 @@
+{
+  "Flags": 0,
+  "TransactionType": "AccountSet",
+  "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "SetFlag": 1,
+  "LastLedgerSequence": 8820051,
+  "Fee": "12",
+  "Sequence": 23
+}

--- a/test/fixtures/api/responses/prepare-settings-set-transfer-rate.json
+++ b/test/fixtures/api/responses/prepare-settings-set-transfer-rate.json
@@ -1,0 +1,9 @@
+{
+  "Flags": 0,
+  "TransactionType": "AccountSet",
+  "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+  "TransferRate": 1000000000,
+  "LastLedgerSequence": 8820051,
+  "Fee": "12",
+  "Sequence": 23
+}


### PR DESCRIPTION
'emailHash' and 'walletLocator' fields so they
can be cleared

cover api/transaction/settings.js with tests