### PR TITLE
Fix counterparty logic in pathfind parsing

### DIFF
--- a/src/api/common/schemas/adjustment.json
+++ b/src/api/common/schemas/adjustment.json
@@ -4,7 +4,16 @@
   "type": "object",
   "properties": {
     "address": {"$ref": "address"},
-    "amount": {"$ref": "amount"},
+    "amount": {
+      "type": "object",
+      "properties": {
+        "currency": {"$ref": "currency"},
+        "counterparty": {"$ref": "address"},
+        "value": {"$ref": "$value"}
+      },
+      "required": ["currency", "value"],
+      "additionalProperties": false
+    },
     "tag": {
       "description": "A string representing an unsigned 32-bit integer most commonly used to refer to a sender's hosted account at a Ripple gateway",
       "$ref": "uint32"

--- a/src/api/common/schemas/pathfind.json
+++ b/src/api/common/schemas/pathfind.json
@@ -24,32 +24,7 @@
       "additionalProperties": false,
       "required": ["address"]
     },
-    "destination": {
-      "type": "object",
-      "properties": {
-        "address": {"$ref": "address"},
-        "amount": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "description": "The quantity of the currency, denoted as a string to retain floating point precision",
-              "$ref": "value"
-            },
-            "currency": {
-              "description": "The three-character code or hex string used to denote currencies",
-              "$ref": "currency"
-            },
-            "counterparty": {
-              "description": "The Ripple account address of the currency's issuer or gateway",
-              "$ref": "address"
-            },
-            "required": ["currency", "value"]
-          },
-          "additionalProperties": false
-        }
-      },
-      "required": ["address", "amount"]
-    }
+    "destination": {"$ref": "adjustment"}
   },
   "required": ["source", "destination"],
   "additionalProperties": false

--- a/src/api/ledger/parse/payment.js
+++ b/src/api/ledger/parse/payment.js
@@ -1,5 +1,6 @@
 /* @flow */
 'use strict';
+const _ = require('lodash');
 const assert = require('assert');
 const utils = require('./utils');
 const parseAmount = require('./amount');
@@ -30,18 +31,24 @@ function parsePaymentMemos(tx) {
   });
 }
 
+function removeGenericCounterparty(amount, address) {
+  return amount.counterparty === address ?
+    _.omit(amount, 'counterparty') : amount;
+}
+
 function parsePayment(tx: Object): Object {
   assert(tx.TransactionType === 'Payment');
 
   const source = {
     address: tx.Account,
-    amount: parseAmount(tx.SendMax || tx.Amount),
+    amount: removeGenericCounterparty(
+      parseAmount(tx.SendMax || tx.Amount), tx.Account),
     tag: tx.SourceTag
   };
 
   const destination = {
     address: tx.Destination,
-    amount: parseAmount(tx.Amount),
+    amount: removeGenericCounterparty(parseAmount(tx.Amount), tx.Destination),
     tag: tx.DestinationTag
   };
 

--- a/src/api/ledger/pathfind.js
+++ b/src/api/ledger/pathfind.js
@@ -78,17 +78,10 @@ function conditionallyAddDirectXRPPath(remote, address, paths, callback) {
   }
 }
 
-function addDestinationCounterparty(amount, address) {
-  return amount.currency === 'XRP' || amount.counterparty ? amount :
-    _.assign({counterparty: address}, amount);
-}
-
 function formatResponse(pathfind, paths) {
   if (paths.alternatives && paths.alternatives.length > 0) {
     const address = pathfind.source.address;
-    const destinationAmount = addDestinationCounterparty(
-      pathfind.destination.amount, pathfind.destination.address);
-    return parsePathfind(address, destinationAmount, paths);
+    return parsePathfind(address, pathfind.destination.amount, paths);
   }
   if (!_.includes(paths.destination_currencies,
       pathfind.destination.amount.currency)) {

--- a/test/fixtures/api/responses/get-paths-send-usd.json
+++ b/test/fixtures/api/responses/get-paths-send-usd.json
@@ -12,7 +12,6 @@
       "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
       "amount": {
         "value": "0.000001",
-        "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
         "currency": "USD"
       }
     },

--- a/test/fixtures/api/responses/get-transaction-payment.json
+++ b/test/fixtures/api/responses/get-transaction-payment.json
@@ -15,8 +15,7 @@
       "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
       "amount": {
         "currency": "USD",
-        "value": "0.001",
-        "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
+        "value": "0.001"
       }
     },
     "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"type\":49,\"type_hex\":\"0000000000000031\"}]]"

--- a/test/fixtures/api/responses/get-transactions.json
+++ b/test/fixtures/api/responses/get-transactions.json
@@ -22,8 +22,7 @@
         "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
         "amount": {
           "currency": "USD",
-          "value": "0.001",
-          "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
+          "value": "0.001"
         }
       },
       "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"type\":49,\"type_hex\":\"0000000000000031\"}]]"
@@ -113,8 +112,7 @@
         "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
         "amount": {
           "currency": "USD",
-          "value": "0.001",
-          "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
+          "value": "0.001"
         }
       },
       "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"type\":49,\"type_hex\":\"0000000000000031\"}]]"


### PR DESCRIPTION
I'm not entirely sure this is the correct way to do it, but I'm pretty sure the previous behavior was wrong.