### PR TITLE
Remove UInt#from_bn

### DIFF
--- a/src/core/uint.js
+++ b/src/core/uint.js
@@ -69,15 +69,6 @@ UInt.from_bytes = function(j) {
 };
 
 // Return a new UInt from j.
-UInt.from_bn = function(j) {
-  if (j instanceof this) {
-    return j.clone();
-  }
-
-  return (new this()).parse_bn(j);
-};
-
-// Return a new UInt from j.
 UInt.from_number = function(j) {
   if (j instanceof this) {
     return j.clone();


### PR DESCRIPTION
parse_bn was removed in the move to elliptic so removing from_bn to match

If no one noticed before, and rues the day it was excised, we could always add it back in.