### PR TITLE
remove redundant abs from MIN_IOU_VALUE

### DIFF
--- a/src/core/amount.js
+++ b/src/core/amount.js
@@ -49,13 +49,13 @@ const consts = {
   // Maximum possible amount for non-XRP currencies using the maximum mantissa
   // with maximum exponent. Corresponds to hex 0xEC6386F26FC0FFFF.
   max_value: '9999999999999999e80',
-  // Minimum possible amount for non-XRP currencies.
-  min_value: '-1000000000000000e-96'
+  // Minimum nonzero absolute value for non-XRP currencies.
+  min_value: '1000000000000000e-96'
 };
 
 const MAX_XRP_VALUE = new XRPValue(1e11);
 const MAX_IOU_VALUE = new IOUValue(consts.max_value);
-const MIN_IOU_VALUE = new IOUValue(consts.min_value).abs();
+const MIN_IOU_VALUE = new IOUValue(consts.min_value);
 
 const bi_xns_unit = new IOUValue(1e6);
 

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -1225,7 +1225,7 @@ describe('Amount', function() {
 
     it('from_json minimum IOU', function() {
       const amt = Amount.from_json('-1e-81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
-      assert.strictEqual(amt.to_text(), '-1000000000000000e-96');
+      assert.strictEqual(amt.to_text(), '1000000000000000e-96');
       assert.strictEqual(amt.to_text(), Amount.min_value);
     });
 

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -1224,15 +1224,21 @@ describe('Amount', function() {
     });
 
     it('from_json minimum IOU', function() {
-      const amt = Amount.from_json('-1e-81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      const amt = Amount.from_json('1e-81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
       assert.strictEqual(amt.to_text(), '1000000000000000e-96');
       assert.strictEqual(amt.to_text(), Amount.min_value);
     });
 
+    it('from_json negative minimum IOU', function() {
+      const amt = Amount.from_json('-1e-81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      assert.strictEqual(amt.to_text(), '-1000000000000000e-96');
+      assert.strictEqual(amt.negate().to_text(), Amount.min_value);
+    });
+
     it('from_json exceed minimum IOU', function() {
       assert.throws(function() {
-        Amount.from_json('-1e-82/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
-      }, 'Exceeding min value of ' + Amount.min_value);
+        Amount.from_json('1e-82/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      }, 'Exceeding min absolute value of ' + Amount.min_value);
     });
 
     it('from_json maximum IOU', function() {

--- a/test/amount-test.js
+++ b/test/amount-test.js
@@ -1223,32 +1223,49 @@ describe('Amount', function() {
       });
     });
 
-    it('from_json minimum IOU', function() {
+    it('from_json minimum positive IOU', function() {
       const amt = Amount.from_json('1e-81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
       assert.strictEqual(amt.to_text(), '1000000000000000e-96');
       assert.strictEqual(amt.to_text(), Amount.min_value);
     });
 
-    it('from_json negative minimum IOU', function() {
+    it('from_json smallest-absolute-value negative IOU', function() {
       const amt = Amount.from_json('-1e-81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
       assert.strictEqual(amt.to_text(), '-1000000000000000e-96');
       assert.strictEqual(amt.negate().to_text(), Amount.min_value);
     });
 
-    it('from_json exceed minimum IOU', function() {
+    it('from_json exceeding minimum positive IOU', function() {
       assert.throws(function() {
         Amount.from_json('1e-82/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
       }, 'Exceeding min absolute value of ' + Amount.min_value);
     });
 
-    it('from_json maximum IOU', function() {
+    it('from_json exceeding minimum-absolute-value negative IOU', function() {
+      assert.throws(function() {
+        Amount.from_json('-1e-82/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      }, 'Exceeding min absolute value of ' + Amount.min_value);
+    });
+
+    it('from_json maximum positive IOU', function() {
       const amt = Amount.from_json('9999999999999999e80/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
       assert.strictEqual(amt.to_text(), '9999999999999999e80');
     });
 
-    it('from_json exceed maximum IOU', function() {
+    it('from_json exceed maximum positive IOU', function() {
       assert.throws(function() {
         Amount.from_json('9999999999999999e81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      }, 'Exceeding max value of ' + Amount.max_value);
+    });
+
+    it('from_json largest-absolute-value negative IOU', function() {
+      const amt = Amount.from_json('-9999999999999999e80/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
+      assert.strictEqual(amt.to_text(), '-9999999999999999e80');
+    });
+
+    it('from_json exceed largest-absolute-value negative IOU', function() {
+      assert.throws(function() {
+        Amount.from_json('-9999999999999999e81/USD/rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh');
       }, 'Exceeding max value of ' + Amount.max_value);
     });
 


### PR DESCRIPTION
First, let it be known I AM NOT SURE THIS WORKS. I am raising this PR in part to ask a question.

I do not see why we the code uses `-1000000000000000e-96` as consts.min_value, only to go and .abs() it a few lines later. Is it not valid to instantiate `IOUValue('1000000000000000e-96')`?