### PR TITLE
Fix: Check for destination_currencies property

### DIFF
--- a/src/api/ledger/pathfind.js
+++ b/src/api/ledger/pathfind.js
@@ -84,7 +84,8 @@ function formatResponse(pathfind, paths) {
     const address = pathfind.source.address;
     return parsePathfind(address, pathfind.destination.amount, paths);
   }
-  if (!_.includes(paths.destination_currencies,
+  if (paths.destination_currencies !== undefined &&
+      !_.includes(paths.destination_currencies,
       pathfind.destination.amount.currency)) {
     throw new NotFoundError('No paths found. ' +
       'The destination_account does not accept ' +


### PR DESCRIPTION
Example stack:

```
TypeError: Cannot read property 'join' of undefined
    at formatResponse
    (ripple-lib/dist/npm/api/ledger/pathfind.js:75:187)
```