### PR TITLE
Add multisign helpers

### DIFF
--- a/src/core/binformat.js
+++ b/src/core/binformat.js
@@ -1,6 +1,8 @@
 'use strict';
 
-/*eslint no-multi-spaces:0,space-in-brackets:0,key-spacing:0,comma-spacing:0*/
+/*eslint-disable max-len,spaced-comment,array-bracket-spacing,key-spacing*/
+/*eslint-disable no-multi-spaces,comma-spacing*/
+/*eslint-disable no-multi-spaces:0,space-in-brackets:0,key-spacing:0,comma-spacing:0*/
 
 /**
  * Data type map.
@@ -52,7 +54,8 @@ const FIELDS_MAP = exports.fields = {
   // Common types
   1: { // Int16
     1: 'LedgerEntryType',
-    2: 'TransactionType'
+    2: 'TransactionType',
+    3: 'SignerWeight'
   },
   2: { // Int32
     2: 'Flags',
@@ -87,7 +90,9 @@ const FIELDS_MAP = exports.fields = {
     31: 'ReserveBase',
     32: 'ReserveIncrement',
     33: 'SetFlag',
-    34: 'ClearFlag'
+    34: 'ClearFlag',
+    35: 'SignerQuorum',
+    38: 'SignerListID'
   },
   3: { // Int64
     1: 'IndexNext',
@@ -166,13 +171,15 @@ const FIELDS_MAP = exports.fields = {
     7: 'FinalFields',
     8: 'NewFields',
     9: 'TemplateEntry',
-    10: 'Memo'
+    10: 'Memo',
+    11: 'SignerEntry',
+    16: 'Signer'
   },
   15: { // Array
     1: undefined,  // end of Array
     2: 'SigningAccounts',
-    3: 'TxnSignatures',
-    4: 'Signatures',
+    3: 'Signers',
+    4: 'SignerEntries',
     5: 'Template',
     6: 'Necessary',
     7: 'Sufficient',
@@ -202,7 +209,7 @@ const FIELDS_MAP = exports.fields = {
   }
 };
 
-let INVERSE_FIELDS_MAP = exports.fieldsInverseMap = { };
+const INVERSE_FIELDS_MAP = exports.fieldsInverseMap = { };
 
 Object.keys(FIELDS_MAP).forEach(function(k1) {
   Object.keys(FIELDS_MAP[k1]).forEach(function(k2) {
@@ -211,8 +218,8 @@ Object.keys(FIELDS_MAP).forEach(function(k1) {
 });
 
 const REQUIRED = exports.REQUIRED = 0,
-      OPTIONAL = exports.OPTIONAL = 1,
-      DEFAULT  = exports.DEFAULT  = 2;
+  OPTIONAL = exports.OPTIONAL = 1,
+  DEFAULT  = exports.DEFAULT  = 2;
 
 const base = [
   [ 'TransactionType'    , REQUIRED ],
@@ -226,7 +233,8 @@ const base = [
   [ 'SigningPubKey'      , REQUIRED ],
   [ 'TxnSignature'       , OPTIONAL ],
   [ 'AccountTxnID'       , OPTIONAL ],
-  [ 'Memos'              , OPTIONAL ]
+  [ 'Memos'              , OPTIONAL ],
+  [ 'Signers'            , OPTIONAL ]
 ];
 
 exports.tx = {
@@ -296,6 +304,10 @@ exports.tx = {
   ]),
   TicketCancel: [11].concat(base, [
     [ 'TicketID'           , REQUIRED ]
+  ]),
+  SignerListSet: [12].concat(base, [
+    ['SignerQuorum', REQUIRED],
+    ['SignerEntries', OPTIONAL]
   ])
 };
 
@@ -396,7 +408,15 @@ exports.ledger = {
     ['LedgerIndex',         OPTIONAL],
     ['Balance',             REQUIRED],
     ['LowLimit',            REQUIRED],
-    ['HighLimit',           REQUIRED]])
+    ['HighLimit',           REQUIRED]]),
+  SignerList: [83].concat(sleBase,[
+    ['OwnerNode',           REQUIRED],
+    ['SignerQuorum',        REQUIRED],
+    ['SignerEntries',       REQUIRED],
+    ['SignerListID',        REQUIRED],
+    ['PreviousTxnID',       REQUIRED],
+    ['PreviousTxnLgrSeq',   REQUIRED]
+  ])
 };
 
 exports.metadata = [

--- a/src/core/hashprefixes.js
+++ b/src/core/hashprefixes.js
@@ -30,6 +30,8 @@ exports.HASH_LEAF_NODE = 0x4D4C4E00; // 'MLN'
 exports.HASH_TX_SIGN = 0x53545800; // 'STX'
 // inner transaction to sign (TESTNET)
 exports.HASH_TX_SIGN_TESTNET = 0x73747800; // 'stx'
+// inner transaction to multisign
+exports.HASH_TX_MULTISIGN = 0x534D5400; // 'SMT'
 
 Object.keys(exports).forEach(function(k) {
   exports[k + '_BYTES'] = toBytes(exports[k]);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -24,7 +24,8 @@ exports._test = {
   Log: require('./log'),
   PathFind: require('./pathfind').PathFind,
   TransactionManager: require('./transactionmanager').TransactionManager,
-  RangeSet: require('./rangeset').RangeSet
+  RangeSet: require('./rangeset').RangeSet,
+  HashPrefixes: require('./hashprefixes')
 };
 
 exports.types = require('./serializedtypes');

--- a/src/core/remote.js
+++ b/src/core/remote.js
@@ -2271,7 +2271,8 @@ Remote.prototype.createTransaction = function(type, options = {}) {
     TrustSet: transaction.trustSet,
     OfferCreate: transaction.offerCreate,
     OfferCancel: transaction.offerCancel,
-    SetRegularKey: transaction.setRegularKey
+    SetRegularKey: transaction.setRegularKey,
+    SignerListSet: transaction.setSignerList
   };
 
   const transactionConstructor = constructorMap[type];

--- a/test/remote-test.js
+++ b/test/remote-test.js
@@ -2057,4 +2057,42 @@ describe('Remote', function() {
       RegularKey: TX_JSON.Destination
     });
   });
+
+  it('Construct SignerListSet transaction', function() {
+    const tx = remote.createTransaction('SignerListSet', {
+      account: 'rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm',
+      signerQuorum: 3,
+      signers: [
+        {
+          account: 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW',
+          weight: 1
+        },
+        {
+          account: 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK',
+          weight: 2
+        }
+      ]
+    });
+    assert(tx instanceof Transaction);
+    assert.deepEqual(tx.tx_json, {
+      Flags: 0,
+      TransactionType: 'SignerListSet',
+      Account: 'rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm',
+      SignerQuorum: 3,
+      SignerEntries: [
+        {
+          SignerEntry: {
+            Account: 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW',
+            SignerWeight: 1
+          }
+        },
+        {
+          SignerEntry: {
+            Account: 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK',
+            SignerWeight: 2
+          }
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
Re: https://github.com/ripple/rippled/commit/9e69bd5c56ae8b4ceb44b353fc75d8d9f6b21834

+ Update binformat
+ Add `SignerListSet` transaction constructors
+ Add transaction methods

**New transaction methods**

`multiSigningData(signing account) -> serializedobject` Internal method, called in multiSign() from reconstituted transaction to prepare signing data

 `getMultiSigningJson() -> tx_json` Returns a normalized tx_json with empty SigningPubKey and canonical signature flag auto-filled

`multiSign(account, secret) -> signer` Multi-signs a transaction reconstituted from getMultiSigningJson()

`addMultiSigner(signer)` Add and sort new multi-signer in the format returned by multiSign(): {Account, SigningPubKey, TxnSignature}

 `hasMultiSigners() -> boolean` Self-explanatory

`getMultiSigners() -> array` Self-explanatory

**Proposed "flow"**

```js
var tx = remote.createTransaction('AccountSet', {
  account: accountID1
});

tx.setSequence(1);
tx.setFee(1000);

// Auto-fill SigningPubKey and possibly set canonical signing flag
// Return normalized tx_json & don't tamper with tx.tx_json
var multiSigningJson = tx.getMultiSigningJson();

// Reconstitute transaction
var multiSigningTx = Transaction.from_json(multiSigningJson);

// Multisign
var signer = multiSigningTx.multiSign(accountID2, seed2);

// Back at the origin tx, attach signer
tx.addSigner(signer);

// Transaction should be submittable as normal
tx.submit(function(err, res) {});
```

**Note**

+ Tested successfully with `local_signing` enabled/disabled
+ Multi-signed transactions are marked as non-resubmittable. Resubmission can be allowed in the future
+ `LastLedgerSequence` isn't set automatically
+ The signers array is indeed uppercase `Signers` and outside `submit_multisigned` request tx_json (unconventional but probably changed soon)
+ `Transaction.from_json()` will now clone the argument

@sublimator @scottschurr 