### PR TITLE
Autofill LastLedgerSequence for multisigned transactions

### DIFF
--- a/test/transaction-manager-test.js
+++ b/test/transaction-manager-test.js
@@ -518,7 +518,9 @@ describe('TransactionManager', function() {
           break;
       }
     });
+    /* eslint-disable  no-unused-vars */
     rippled.once('request_submit', function(m, req) {
+    /* eslint-enable  no-unused-vars */
       req.sendJSON(lodash.extend({}, LEDGER, {
         ledger_index: transaction.tx_json.LastLedgerSequence + 1
       }));
@@ -574,7 +576,9 @@ describe('TransactionManager', function() {
       req.sendResponse(SUBMIT_TEF_RESPONSE, {id: m.id});
     });
 
+    /* eslint-disable  no-unused-vars */
     rippled.once('request_submit', function(m, req) {
+    /* eslint-enable  no-unused-vars */
       transaction.once('resubmitted', function() {
         receivedResubmitted = true;
         req.sendJSON(lodash.extend({}, LEDGER, {
@@ -634,7 +638,9 @@ describe('TransactionManager', function() {
       req.sendResponse(SUBMIT_TEL_RESPONSE, {id: m.id});
     });
 
+    /* eslint-disable  no-unused-vars */
     rippled.once('request_submit', function(m, req) {
+    /* eslint-enable  no-unused-vars */
       transaction.once('resubmitted', function() {
         receivedResubmitted = true;
         req.sendJSON(lodash.extend({}, LEDGER, {
@@ -690,7 +696,7 @@ describe('TransactionManager', function() {
       assert.strictEqual(summary.submissionAttempts, 0);
       assert.strictEqual(summary.submitIndex, undefined);
       assert.strictEqual(summary.initialSubmitIndex, undefined);
-      assert.strictEqual(summary.lastLedgerSequence, undefined);
+      assert.strictEqual(summary.lastLedgerSequence, remote.getLedgerSequence() + 1 + Remote.DEFAULTS.last_ledger_offset);
       assert.strictEqual(summary.state, 'failed');
       assert.strictEqual(summary.finalized, true);
       assert.deepEqual(summary.result, {
@@ -799,7 +805,9 @@ describe('TransactionManager', function() {
       req.sendResponse(SUBMIT_TEL_RESPONSE, {id: m.id});
     });
 
+    /* eslint-disable  no-unused-vars */
     rippled.once('request_submit', function(m, req) {
+    /* eslint-enable  no-unused-vars */
       transaction.once('resubmitted', function() {
         receivedResubmitted = true;
       });
@@ -857,6 +865,7 @@ describe('TransactionManager', function() {
       receivedSubmitted = true;
     });
 
+    /* eslint-disable  no-unused-vars */
     rippled.on('request_submit', function(m, req) {
       assert.strictEqual(m.tx_blob, SerializedObject.from_json(
         transaction.tx_json).to_hex());
@@ -867,7 +876,9 @@ describe('TransactionManager', function() {
       req.sendResponse(SUBMIT_TOO_BUSY_ERROR, {id: m.id});
     });
 
+    /* eslint-disable  no-unused-vars */
     rippled.once('request_submit', function(m, req) {
+    /* eslint-enable  no-unused-vars */
       transaction.once('resubmitted', function() {
         receivedResubmitted = true;
         req.sendJSON(lodash.extend({}, LEDGER, {

--- a/test/transaction-test.js
+++ b/test/transaction-test.js
@@ -984,9 +984,6 @@ describe('Transaction', function() {
     const transaction = new Transaction();
 
     assert.throws(function() {
-      transaction.lastLedger('a');
-    }, /Error: LastLedgerSequence must be a valid UInt32/);
-    assert.throws(function() {
       transaction.setLastLedgerSequence('a');
     }, /Error: LastLedgerSequence must be a valid UInt32/);
     assert.throws(function() {
@@ -1945,6 +1942,8 @@ describe('Transaction', function() {
 
   it('Submit transaction', function(done) {
     const remote = new Remote();
+    remote._ledger_current_index = 1;
+
     const transaction = new Transaction(remote).accountSet('r36xtKNKR43SeXnGn7kN4r4JdQzcrkqpWe');
 
     assert.strictEqual(transaction.callback, undefined);
@@ -1988,6 +1987,8 @@ describe('Transaction', function() {
 
   it('Submit transaction - submission error', function(done) {
     const remote = new Remote();
+
+    remote._ledger_current_index = 1;
 
     const transaction = new Transaction(remote).accountSet('r36xtKNKR43SeXnGn7kN4r4JdQzcrkqpWe');
 
@@ -2107,82 +2108,6 @@ describe('Transaction', function() {
     });
   });
 
-  it('Add multisigner', function() {
-    const transaction = new Transaction();
-    const s1 = {
-      Account: 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK',
-      TxnSignature: '304402203020865BDC995431325C371E6A3CE89BFC40597D9CFAF77DBB16E9D159824EA402203645A6462A6DCEC7B5D0811882DC54CEA66258A227A2762BE6EFCD9EB62C27BF',
-      SigningPubKey: '02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6EF808F3AFC006E3FE'
-    };
-    const s2 = {
-      Account: 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW',
-      TxnSignature: '30450221009C84E455DC199A7DB4B800D68C92269D60972E8850AFC0D50B1AE6B08BBB02EA02206FA93A560BE96844DF7D96D07F6400EF9534A32FBA352DD10E855DA8923A3AF8',
-      SigningPubKey: '028949021029D5CC87E78BCF053AFEC0CAFD15108EC119EAAFEC466F5C095407BF'
-    };
-
-    transaction.addMultiSigner(s1);
-    transaction.addMultiSigner(s2);
-
-    assert.deepEqual(transaction.getMultiSigners(), [
-                     {Signer: s2}, {Signer: s1}]);
-  });
-
-  it('Get multisign data', function() {
-    const transaction = Transaction.from_json({
-      Account: 'rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn',
-      Sequence: 1,
-      Fee: '100',
-      TransactionType: 'AccountSet',
-      Flags: 0
-    });
-
-    transaction.setSigningPubKey('');
-
-    const a1 = 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK';
-    const d1 = transaction.multiSigningData(a1);
-
-    const tbytes = ripple.SerializedObject.from_json(
-      lodash.merge(transaction.tx_json, {SigningPubKey: ''})).buffer;
-    const abytes = ripple.UInt160.from_json(a1).to_bytes();
-    const prefix = require('ripple-lib')._test.HashPrefixes.HASH_TX_MULTISIGN_BYTES;
-
-    assert.deepEqual(d1.buffer, prefix.concat(tbytes, abytes));
-  });
-
-  it('Multisign', function() {
-    const transaction = Transaction.from_json({
-      Account: 'rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn',
-      Sequence: 1,
-      Fee: '100',
-      TransactionType: 'AccountSet',
-      Flags: 0
-    });
-
-    const multiSigningJson = transaction.getMultiSigningJson();
-    const t1 = Transaction.from_json(multiSigningJson);
-
-    const a1 = 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK';
-    const a2 = 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW';
-
-    const s1 = t1.multiSign(a1, 'alice');
-    assert.strictEqual(s1.Account, a1);
-    assert.strictEqual(s1.SigningPubKey, '0388935426E0D08083314842EDFBB2D517BD47699F9A4527318A8E10468C97C052');
-    assert.strictEqual(s1.TxnSignature, '30440220611256E46B2946152695FFEF34D5C71BB3AE569C3D919A270BFBCA9ADF260D9202202FAE24FC8A575FE3265A6D7CFA596094A7950E0011706431A11C2A9ABEF60B3B');
-
-    const s2 = t1.multiSign(a2, 'bob');
-    assert.strictEqual(s2.Account, a2);
-    assert.strictEqual(s2.SigningPubKey, '02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6EF808F3AFC006E3FE');
-    assert.strictEqual(s2.TxnSignature, '3044022067F769BE0A4CC2B4F26E7B52B366F861FED02DA0F564F98B44009C8181A9655702206D882919139DF8E9D7F2FC1DD54D8B4FEAC40203349AE21519FD388925A4DE83');
-
-    transaction.addMultiSigner(s1);
-    transaction.addMultiSigner(s2);
-
-    assert.deepEqual(transaction.getMultiSigners(), [
-    {Signer: s2},
-    {Signer: s1}
-    ]);
-  });
-
   it('Construct SuspendedPaymentCreate transaction', function() {
     const transaction = new Transaction().suspendedPaymentCreate({
       account: 'rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm',
@@ -2292,6 +2217,103 @@ describe('Transaction', function() {
       Account: 'rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm',
       Owner: 'rsLEU1TPdCJPPysqhWYw9jD97xtG5WqSJm',
       OfferSequence: 1234
+    });
+  });
+
+  it('Add multisigner', function() {
+    const transaction = new Transaction();
+    const s1 = {
+      Account: 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK',
+      TxnSignature: '304402203020865BDC995431325C371E6A3CE89BFC40597D9CFAF77DBB16E9D159824EA402203645A6462A6DCEC7B5D0811882DC54CEA66258A227A2762BE6EFCD9EB62C27BF',
+      SigningPubKey: '02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6EF808F3AFC006E3FE'
+    };
+    const s2 = {
+      Account: 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW',
+      TxnSignature: '30450221009C84E455DC199A7DB4B800D68C92269D60972E8850AFC0D50B1AE6B08BBB02EA02206FA93A560BE96844DF7D96D07F6400EF9534A32FBA352DD10E855DA8923A3AF8',
+      SigningPubKey: '028949021029D5CC87E78BCF053AFEC0CAFD15108EC119EAAFEC466F5C095407BF'
+    };
+
+    transaction.addMultiSigner(s1);
+    transaction.addMultiSigner(s2);
+
+    assert.deepEqual(transaction.getMultiSigners(), [
+                     {Signer: s2}, {Signer: s1}]);
+  });
+
+  it('Get multisign data', function() {
+    const transaction = Transaction.from_json({
+      Account: 'rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn',
+      Sequence: 1,
+      Fee: '100',
+      TransactionType: 'AccountSet',
+      Flags: 0
+    });
+
+    transaction.setSigningPubKey('');
+
+    const a1 = 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK';
+    const d1 = transaction.multiSigningData(a1);
+
+    const tbytes = ripple.SerializedObject.from_json(
+      lodash.merge(transaction.tx_json, {SigningPubKey: ''})).buffer;
+    const abytes = ripple.UInt160.from_json(a1).to_bytes();
+    const prefix = require('ripple-lib')._test.HashPrefixes.HASH_TX_MULTISIGN_BYTES;
+
+    assert.deepEqual(d1.buffer, prefix.concat(tbytes, abytes));
+  });
+
+  it('Multisign', function() {
+    const transaction = Transaction.from_json({
+      Account: 'rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn',
+      Sequence: 1,
+      Fee: '100',
+      TransactionType: 'AccountSet',
+      Flags: 0,
+      LastLedgerSequence: 1
+    });
+
+    const multiSigningJson = transaction.getMultiSigningJson();
+    const t1 = Transaction.from_json(multiSigningJson);
+
+    const a1 = 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK';
+    const a2 = 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW';
+
+    const s1 = t1.multiSign(a1, 'alice');
+    assert.deepEqual(s1, {
+      Account: 'rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK',
+      TxnSignature: '3045022100DB13DC794DDFA1E27D099CDBFC7DB5B1EE892AD1725B0CEEE97D8B1C4C2055C7022030B3372C96D08106594B3CF8CDF88E05CC6260C51954F02387289CB69B839D7A',
+      SigningPubKey: '0388935426E0D08083314842EDFBB2D517BD47699F9A4527318A8E10468C97C052'
+
+    });
+
+    const s2 = t1.multiSign(a2, 'bob');
+    assert.deepEqual(s2, {
+      Account: 'rH4KEcG9dEwGwpn6AyoWK9cZPLL4RLSmWW',
+      TxnSignature: '304402207A22109088069C5ABE3E961C2F85B2B8111C5666C869E8BA3F2A57C2ECEA7FC402205F9D87FB42266CC498FCE9B4904955D0E6D5F44D092596F5DE3E25843F6D10AB',
+      SigningPubKey: '02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6EF808F3AFC006E3FE'
+
+    });
+
+    transaction.addMultiSigner(s1);
+    transaction.addMultiSigner(s2);
+
+    assert.deepEqual(transaction.getMultiSigners(), [
+    {Signer: s2},
+    {Signer: s1}
+    ]);
+  });
+
+  it('Multisign -- missing LastLedgerSequence', function() {
+    const transaction = Transaction.from_json({
+      Account: 'rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn',
+      Sequence: 1,
+      Fee: '100',
+      TransactionType: 'AccountSet',
+      Flags: 0
+    });
+
+    assert.throws(function() {
+      transaction.getMultiSigningJson();
     });
   });
 });


### PR DESCRIPTION
+ `Signers` has been moved to tx_json for submit/submit_multisigned
+ Automatically set LastLedgerSequence, honor existing values
+ By default, LastLedgerSequence offset is unrealistically low. Users should call either `tx.setLastLedgerSequence()` or `tx.setLastLedgerSequenceOffset()` before `tx.getMultiSigningJson()` / multisigning