### PR TITLE
Add Remote.closeCurrentPathFind function, so current pathfind can be …

### DIFF
--- a/src/core/remote.js
+++ b/src/core/remote.js
@@ -1814,6 +1814,19 @@ Remote.prototype.findAccount = function(accountID) {
 };
 
 /**
+ * Closes current pathfind, if there is one.
+ * After that new pathfind can be created, without adding to queue.
+ *
+ * @return {void} -
+ */
+Remote.prototype.closeCurrentPathFind = function() {
+  if (this._cur_path_find !== null) {
+    this._cur_path_find.close();
+    this._cur_path_find = null;
+  }
+};
+
+/**
  * Create a pathfind
  *
  * @param {Object} options -
@@ -1822,6 +1835,10 @@ Remote.prototype.findAccount = function(accountID) {
  */
 Remote.prototype.createPathFind = function(options, callback) {
   if (this._cur_path_find !== null) {
+    if (callback === undefined) {
+      throw new Error('Only one streaming pathfind ' +
+                      'request at a time is supported');
+    }
     this._queued_path_finds.push({options, callback});
     return null;
   }

--- a/test/remote-test.js
+++ b/test/remote-test.js
@@ -1927,6 +1927,30 @@ describe('Remote', function() {
     pathfind.on('update', message => console.log(message));
   });
 
+  it('createPathFind - throw error without callback if already running', function() {
+    const servers = [
+      makeServer('wss://localhost:5006'),
+      makeServer('wss://localhost:5007')
+    ];
+
+    remote._servers = servers;
+
+    const pathfindParam = {
+      src_account: 'rGr9PjmVe7MqEXTSbd3njhgJc2s5vpHV54',
+      dst_account: 'rwxBjBC9fPzyQ9GgPZw6YYLNeRTSx5c2W6',
+      dst_amount: '1/USD/rGr9PjmVe7MqEXTSbd3njhgJc2s5vpHV54',
+      src_currencies: [{
+        currency: 'BTC', issuer: 'rwxBjBC9fPzyQ9GgPZw6YYLNeRTSx5c2W6'
+      }]
+    };
+    remote.createPathFind(pathfindParam);
+    remote.createPathFind(pathfindParam, () => {});
+    assert.throws(
+      function() {
+        remote.createPathFind(pathfindParam);
+      }, Error);
+  });
+
   it('Construct path_find create request', function() {
     const request = remote.requestPathFindCreate({
       source_account: 'rGr9PjmVe7MqEXTSbd3njhgJc2s5vpHV54',


### PR DESCRIPTION
…properly closed,

so new can be created without adding to queue