### PR TITLE
rename metaData to meta

### DIFF
--- a/src/api/ledger/parse/ledger.js
+++ b/src/api/ledger/parse/ledger.js
@@ -5,6 +5,12 @@ const removeUndefined = require('./utils').removeUndefined;
 const parseTransaction = require('./transaction');
 import type {GetLedger} from '../types.js';
 
+function parseTransactionWrapper(tx) {
+  const transaction = _.assign({}, _.omit(tx, 'metaData'),
+    {meta: tx.metaData});
+  return parseTransaction(transaction);
+}
+
 function parseTransactions(transactions) {
   if (_.isEmpty(transactions)) {
     return {};
@@ -13,7 +19,7 @@ function parseTransactions(transactions) {
     return {transactionHashes: transactions};
   }
   return {
-    transactions: _.map(transactions, parseTransaction),
+    transactions: _.map(transactions, parseTransactionWrapper),
     rawTransactions: JSON.stringify(transactions)
   };
 }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -702,6 +702,16 @@ describe('RippleAPI', function() {
       _.partial(checkResult, responses.getLedger.header, 'getLedger'));
   });
 
+  it('getLedger - with settings transaction', function() {
+    const request = {
+      includeTransactions: true,
+      includeAllData: true,
+      ledgerVersion: 4181996
+    };
+    return this.api.getLedger(request).then(
+      _.partial(checkResult, responses.getLedger.withSettingsTx, 'getLedger'));
+  });
+
   it('getLedger - full, then computeLedgerHash', function() {
     const request = {
       includeTransactions: true,

--- a/test/fixtures/api/responses/get-ledger-with-settings-tx.json
+++ b/test/fixtures/api/responses/get-ledger-with-settings-tx.json
@@ -1,0 +1,24 @@
+{
+  "accepted": true,
+  "closed": true,
+  "stateHash": "2FC964BBFE22DF77A132FE12B5D2B58A09226EBCA73EF2CFF5BE29E56B3315F5",
+  "closeTime": 441849810,
+  "closeTimeResolution": 10,
+  "closeFlags": 0,
+  "ledgerHash": "B52AC083396E9119B6CEED69C155B663D58FCA9245917B904BE57FB089E677A4",
+  "ledgerVersion": 4181996,
+  "parentLedgerHash": "599820AB83EF490BA04019E88A90202516D7F39CA169CF639ADCD0A434C7D7DF",
+  "parentCloseTime": 441849790,
+  "totalDrops": "99999998243206519",
+  "transactionHash": "49B500E719BB3AC7CB74E3E0D028A01BFE626484F4659CDD98CB4E32BFE0D601",
+  "transactions": [
+    {
+      "type": "settings",
+      "address": "rEGy9CxMTFGXFgUHUMreTy2FbqArabGy38",
+      "sequence": 6478,
+      "id": "FEEFC959B0351156F58A2275F5A6B37B07AA85CCCE2C4AF8A1342A0196A3CD4D",
+      "specification": {}
+    }
+  ],
+  "rawTransactions": "[{\"Account\":\"rEGy9CxMTFGXFgUHUMreTy2FbqArabGy38\",\"Fee\":\"10\",\"Flags\":0,\"Sequence\":6478,\"SigningPubKey\":\"02CAB6F3A798712136DB5F105A98B0DE27C99AEDB68500181706B087CF1B6D0F2D\",\"TransactionType\":\"AccountSet\",\"TxnSignature\":\"304402202144BD33CC30793455B0F90954576EEE80F13C4C73538D2AEE012564C48E522E02207A8A4AD2CF2B4DB549FB2F05D38E065B5DD1EAA386310698E5247F1BB515E99F\",\"hash\":\"FEEFC959B0351156F58A2275F5A6B37B07AA85CCCE2C4AF8A1342A0196A3CD4D\",\"metaData\":{\"AffectedNodes\":[{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rEGy9CxMTFGXFgUHUMreTy2FbqArabGy38\",\"Balance\":\"403657865\",\"Flags\":0,\"OwnerCount\":2,\"Sequence\":6479},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"F64FAA4CAFDB9931DC06890FE30B4E29C32F7AD574FC7C3362B81265682BFAEA\",\"PreviousFields\":{\"Balance\":\"403657875\",\"Sequence\":6478},\"PreviousTxnID\":\"B257B95A637C6C396507AD0AE122161A849C701F065B67009BB939690DB74BC9\",\"PreviousTxnLgrSeq\":4181972}}],\"TransactionIndex\":0,\"TransactionResult\":\"tesSUCCESS\"}}]"
+}

--- a/test/fixtures/api/responses/index.js
+++ b/test/fixtures/api/responses/index.js
@@ -32,7 +32,8 @@ module.exports = {
   getTrustlines: require('./get-trustlines.json'),
   getLedger: {
     header: require('./get-ledger'),
-    full: require('./get-ledger-full')
+    full: require('./get-ledger-full'),
+    withSettingsTx: require('./get-ledger-with-settings-tx')
   },
   prepareOrderCancellation: require('./prepare-order-cancellation.json'),
   prepareOrder: require('./prepare-order.json'),

--- a/test/fixtures/api/rippled/index.js
+++ b/test/fixtures/api/rippled/index.js
@@ -8,6 +8,7 @@ module.exports = {
   ledger: require('./ledger'),
   ledgerNotFound: require('./ledger-not-found'),
   ledgerWithoutCloseTime: require('./ledger-without-close-time'),
+  ledgerWithSettingsTx: require('./ledger-with-settings-tx'),
   subscribe: require('./subscribe'),
   unsubscribe: require('./unsubscribe'),
   account_info: {

--- a/test/fixtures/api/rippled/ledger-with-settings-tx.json
+++ b/test/fixtures/api/rippled/ledger-with-settings-tx.json
@@ -1,0 +1,64 @@
+{
+  "id": 1,
+  "status": "success",
+  "type": "response",
+  "result": {
+    "ledger": {
+      "accepted": true,
+      "account_hash": "2FC964BBFE22DF77A132FE12B5D2B58A09226EBCA73EF2CFF5BE29E56B3315F5",
+      "close_time": 441849810,
+      "parent_close_time": 441849790,
+      "close_time_human": "2014-Jan-01 00:03:30",
+      "close_time_resolution": 10,
+      "closed": true,
+      "hash": "B52AC083396E9119B6CEED69C155B663D58FCA9245917B904BE57FB089E677A4",
+      "ledger_hash": "B52AC083396E9119B6CEED69C155B663D58FCA9245917B904BE57FB089E677A4",
+      "ledger_index": "4181996",
+      "parent_hash": "599820AB83EF490BA04019E88A90202516D7F39CA169CF639ADCD0A434C7D7DF",
+      "seqNum": "4181996",
+      "totalCoins": "99999998243206519",
+      "total_coins": "99999998243206519",
+      "transaction_hash": "49B500E719BB3AC7CB74E3E0D028A01BFE626484F4659CDD98CB4E32BFE0D601",
+      "transactions": [
+        {
+          "Account": "rEGy9CxMTFGXFgUHUMreTy2FbqArabGy38",
+          "Fee": "10",
+          "Flags": 0,
+          "Sequence": 6478,
+          "SigningPubKey": "02CAB6F3A798712136DB5F105A98B0DE27C99AEDB68500181706B087CF1B6D0F2D",
+          "TransactionType": "AccountSet",
+          "TxnSignature": "304402202144BD33CC30793455B0F90954576EEE80F13C4C73538D2AEE012564C48E522E02207A8A4AD2CF2B4DB549FB2F05D38E065B5DD1EAA386310698E5247F1BB515E99F",
+          "hash": "FEEFC959B0351156F58A2275F5A6B37B07AA85CCCE2C4AF8A1342A0196A3CD4D",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rEGy9CxMTFGXFgUHUMreTy2FbqArabGy38",
+                    "Balance": "403657865",
+                    "Flags": 0,
+                    "OwnerCount": 2,
+                    "Sequence": 6479
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "F64FAA4CAFDB9931DC06890FE30B4E29C32F7AD574FC7C3362B81265682BFAEA",
+                  "PreviousFields": {
+                    "Balance": "403657875",
+                    "Sequence": 6478
+                  },
+                  "PreviousTxnID": "B257B95A637C6C396507AD0AE122161A849C701F065B67009BB939690DB74BC9",
+                  "PreviousTxnLgrSeq": 4181972
+                }
+              }
+            ],
+            "TransactionIndex": 0,
+            "TransactionResult": "tesSUCCESS"
+          }
+        }
+      ]
+    },
+    "ledger_hash": "B52AC083396E9119B6CEED69C155B663D58FCA9245917B904BE57FB089E677A4",
+    "ledger_index": 4181996,
+    "validated": true
+  }
+}

--- a/test/mock-rippled.js
+++ b/test/mock-rippled.js
@@ -144,6 +144,8 @@ module.exports = function(port) {
       conn.send(createLedgerResponse(request, fixtures.ledgerNotFound));
     } else if (request.ledger_index === 9038215) {
       conn.send(createLedgerResponse(request, fixtures.ledgerWithoutCloseTime));
+    } else if (request.ledger_index === 4181996) {
+      conn.send(createLedgerResponse(request, fixtures.ledgerWithSettingsTx));
     } else if (request.ledger_index === 38129) {
       const response = _.assign({}, fixtures.ledger,
         {result: {ledger: fullLedger}});


### PR DESCRIPTION
from rippled's `ledger` command, `metaData` must be renamed to `meta` to conform with the response from the `tx` command