### PR TITLE
Fix: Specify send_max when pathfinding with a source amount

### DIFF
--- a/src/ledger/pathfind-types.js
+++ b/src/ledger/pathfind-types.js
@@ -30,8 +30,8 @@ export type PathFindRequest = {
   source_account: string,
   destination_amount: RippledAmount,
   destination_account: string,
-  source_amount?: RippledAmount,
-  source_currencies?: Array<string>
+  source_currencies?: Array<string>,
+  send_max?: RippledAmount
 }
 
 export type RippledPathsResponse = {

--- a/src/ledger/pathfind.js
+++ b/src/ledger/pathfind.js
@@ -46,9 +46,9 @@ function requestPathFind(connection: Connection, pathfind: PathFind): Promise {
       throw new ValidationError('Cannot specify both source.amount'
         + ' and destination.amount.value in getPaths');
     }
-    request.source_amount = toRippledAmount(pathfind.source.amount);
-    if (request.source_amount.currency && !request.source_amount.issuer) {
-      request.source_amount.issuer = pathfind.source.address;
+    request.send_max = toRippledAmount(pathfind.source.amount);
+    if (request.send_max.currency && !request.send_max.issuer) {
+      request.send_max.issuer = pathfind.source.address;
     }
   }
 

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -289,6 +289,21 @@ describe('integration tests', function() {
     });
   });
 
+  it('getPaths - send all', function() {
+    const pathfind = requests.getPaths.sendAll;
+    return this.api.getPaths(pathfind).then(data => {
+      assert(data && data.length > 0);
+      assert(_.every(data, path => {
+        return parseFloat(path.source.amount.value)
+        <= parseFloat(pathfind.source.amount.value);
+      }));
+      const path = data[0];
+      assert(path && path.source);
+      assert.strictEqual(path.source.address, pathfind.source.address);
+      assert(path.paths && path.paths.length > 0);
+    });
+  });
+
 
   it('generateWallet', function() {
     const newWallet = this.api.generateAddress();


### PR DESCRIPTION
When specifying a fixed sending amount during a pathfind request, the source
amount is specified as a `send_max` field. This fixes a bug where the amount was
specified as `source_amount`. Leading to strange pathfinding behavior.

Example bad behavior (rippled pathfind request/response):

```json
 {
  "command": "ripple_path_find",
  "source_account": "rM21sWyMAJY1oqzgnweDatURxGMurBs7Kf",
  "destination_account": "raDjTrcEtyMqZT6s3PyKGcikUJqYNXUPPv",
  "destination_amount": {
    "currency": "EUR",
    "issuer": "raDjTrcEtyMqZT6s3PyKGcikUJqYNXUPPv",
    "value": -1
  },
  "source_amount": {
    "currency": "USD",
    "issuer": "rM21sWyMAJY1oqzgnweDatURxGMurBs7Kf",
    "value": "9.9"
  },
  "id": 2
}
{
  "id": 2,
  "result": {
    "alternatives": [
      {
        "destination_amount": {
          "currency": "EUR",
          "issuer": "raDjTrcEtyMqZT6s3PyKGcikUJqYNXUPPv",
          "value": "147520.7583553951"
        },
        "paths_canonical": [],
        "paths_computed": [
          [
            {
              "account": "r9HqF3wexBb1vtu2DfZKiFuyy3HoTAwUnH",
              "type": 1,
              "type_hex": "0000000000000001"
            },
            {
              "currency": "EUR",
              "issuer": "raDjTrcEtyMqZT6s3PyKGcikUJqYNXUPPv",
              "type": 48,
              "type_hex": "0000000000000030"
            }
          ]
        ],
        "source_amount": {
          "currency": "USD",
          "issuer": "rM21sWyMAJY1oqzgnweDatURxGMurBs7Kf",
          "value": "160510.6025237665"
        }
      }
    ],
    "destination_account": "raDjTrcEtyMqZT6s3PyKGcikUJqYNXUPPv",
    "destination_currencies": [
      "EUR",
      "XRP"
    ],
    "ledger_current_index": 2771044,
    "validated": false
  },
  "status": "success",
  "type": "response"
}
```

https://ripple.com/build/rippled-apis/#ripple-path-find