### PR TITLE
Docs: suspay and other clarifications

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 
 - [Introduction](#introduction)
   - [Boilerplate](#boilerplate)
+  - [Offline functionality](#offline-functionality)
 - [Basic Types](#basic-types)
   - [Ripple Address](#ripple-address)
   - [Account Sequence Number](#account-sequence-number)
@@ -93,7 +94,7 @@ api.connect().then(() => {
 
 RippleAPI is designed to work in [NodeJS](https://nodejs.org) (version `0.12.0` or greater) using [Babel](https://babeljs.io/) for [ECMAScript 6](https://babeljs.io/docs/learn-es2015/) support.
 
-The code samples in this documentation are written in ES6, but `RippleAPI` will work with ES5 also. Regardless of whether you use ES5 or ES6, the methods that return promises will return [ES6-style promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise_).
+The code samples in this documentation are written in ES6, but `RippleAPI` will work with ES5 also. Regardless of whether you use ES5 or ES6, the methods that return promises will return [ES6-style promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 <aside class="notice">
 All the code snippets in this documentation assume that you have surrounded them with this boilerplate.
@@ -105,6 +106,8 @@ If you omit the "catch" section, errors may not be visible.
 
 ### Parameters
 
+The RippleAPI constructor optionally takes one argument, an object with the following options:
+
 Name | Type | Description
 ---- | ---- | -----------
 authorization | string | *Optional* Username and password for HTTP basic authentication to the rippled server in the format **username:password**.
@@ -114,6 +117,8 @@ proxyAuthorization | string | *Optional* Username and password for HTTP basic au
 servers | array\<uri string\> | *Optional* Array of rippled servers to connect to. Currently only one server is supported.
 trace | boolean | *Optional* If true, log rippled requests and responses to stdout.
 trustedCertificates | array\<string\> | *Optional* Array of PEM-formatted SSL certificates to trust when connecting to a proxy. This is useful if you want to use a self-signed certificate on the proxy server. Note: Each element must contain a single certificate; concatenated certificates are not valid.
+
+If you omit the `servers` parameter, RippleAPI operates [offline](#offline-functionality).
 
 
 ### Installation ###
@@ -130,6 +135,34 @@ After you have installed ripple-lib, you can create scripts using the [boilerpla
 <aside class="notice">
 Instead of using babel-node in production, we recommend using Babel to transpile to ECMAScript 5 first.
 </aside>
+
+
+## Offline functionality
+
+RippleAPI can also function without internet connectivity. This can be useful in order to generate secrets and sign transactions from a secure, isolated machine.
+
+To instantiate RippleAPI in offline mode, use the following boilerplate code:
+
+```javascript
+const {RippleAPI} = require('ripple-lib');
+
+const api = new RippleAPI();
+/* insert code here */
+```
+
+Methods that depend on the state of the Ripple Consensus Ledger are unavailable in offline mode. To prepare transactions offline, you **must** specify  the `fee`, `sequence`, and `maxLedgerVersion` parameters in the [transaction instructions](#transaction-instructions). The following methods should work offline:
+
+* [preparePayment](#preparepayment)
+* [prepareTrustline](#preparetrustline)
+* [prepareOrder](#prepareorder)
+* [prepareOrderCancellation](#prepareordercancellation)
+* [prepareSettings](#preparesettings)
+* [prepareSuspendedPaymentCreation](#preparesuspendedpaymentcreation)
+* [prepareSuspendedPaymentCancellation](#preparesuspendedpaymentcancellation)
+* [prepareSuspendedPaymentExecution](#preparesuspendedpaymentexecution)
+* [sign](#sign)
+* [generateAddress](#generateaddress)
+* [computeLedgerHash](#computeledgerhash)
 
 
 # Basic Types
@@ -209,6 +242,8 @@ Type | Description
 [suspendedPaymentCancellation](#suspended-payment-cancellation) | A `suspendedPaymentCancellation` transaction unlocks the funds in a suspended payment and sends them back to the creator of the suspended payment, but it will only work after the suspended payment expires.
 [suspendedPaymentExecution](#suspended-payment-execution) | A `suspendedPaymentExecution` transaction unlocks the funds in a suspended payment and sends them to the destination of the suspended payment, but it will only work if the cryptographic condition is provided.
 
+The three "suspended payment" transaction types are not supported by the production Ripple peer-to-peer network at this time. They are available for testing purposes if you [configure RippleAPI](#boilerplate) to connect to the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) instead.
+
 ## Transaction Flow
 
 Executing a transaction with `RippleAPI` requires the following four steps:
@@ -244,7 +279,7 @@ maxLedgerVersion | integer | *Optional* The highest ledger version that the tran
 maxLedgerVersionOffset | integer | *Optional* Offset from current legder version to highest ledger version that the transaction can be included in.
 sequence | [sequence](#account-sequence-number) | *Optional* The initiating account's sequence number for this transaction.
 
-We recommended that you specify a `maxLedgerVersion` because without it there is no way to know that a failed transaction will never succeeed in the future. It is impossible for a transaction to succeed after the network ledger version exceeds the transaction's `maxLedgerVersion`.
+We recommended that you specify a `maxLedgerVersion` so that you can quickly determine that a failed transaction will never succeeed in the future. It is impossible for a transaction to succeed after the network ledger version exceeds the transaction's `maxLedgerVersion`.
 
 ## Transaction ID
 
@@ -269,12 +304,12 @@ Name | Type | Description
 source | object | The source of the funds to be sent.
 *source.* address | [address](#ripple-address) | The address to send from.
 *source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
-*source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.
+*source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 *source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
 destination | object | The destination of the funds to be sent.
 *destination.* address | [address](#ripple-address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).
-*destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.
+*destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 *destination.* address | [address](#ripple-address) | The address to send to.
 *destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field is exclusive with destination.amount)
 allowPartialPayment | boolean | *Optional* A boolean that, if set to true, indicates that this payment should go through even if the whole amount cannot be delivered because of a lack of liquidity or funds in the source account account
@@ -436,11 +471,11 @@ Name | Type | Description
 source | object | Fields pertaining to the source of the payment.
 *source.* address | [address](#ripple-address) | The address to send from.
 *source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
-*source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.
+*source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 destination | object | Fields pertaining to the destination of the payment.
 *destination.* address | [address](#ripple-address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).
-*destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.
+*destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 allowCancelAfter | date-time string | *Optional* If present, the suspended payment may be cancelled after this time.
 allowExecuteAfter | date-time string | *Optional* If present, the suspended payment can not be executed before this time.
 digest | string | *Optional* If present, proof is required upon execution.
@@ -1526,12 +1561,12 @@ Name | Type | Description
 source | object | Properties of the source of the payment.
 *source.* address | [address](#ripple-address) | The address to send from.
 *source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
-*source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.
+*source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 *source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
 destination | object | Properties of the destination of the payment.
 *destination.* address | [address](#ripple-address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).
-*destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.
+*destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 *destination.* address | [address](#ripple-address) | The address to send to.
 *destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field is exclusive with destination.amount)
 paths | string | The paths of trustlines and orders to use in executing the payment.
@@ -3014,6 +3049,8 @@ return api.prepareSettings(address, settings)
 
 Prepare a suspended payment creation transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 
+**Caution:** Suspended Payments are currently available on the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) only.
+
 ### Parameters
 
 Name | Type | Description
@@ -3084,6 +3121,8 @@ return api.prepareSuspendedPaymentCreation(address, suspendedPaymentCreation).th
 
 Prepare a suspended payment cancellation transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 
+**Caution:** Suspended Payments are currently available on the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) only.
+
 ### Parameters
 
 Name | Type | Description
@@ -3138,6 +3177,8 @@ return api.prepareSuspendedPaymentCancellation(address, suspendedPaymentCancella
 `prepareSuspendedPaymentExecution(address: string, suspendedPaymentExecution: Object, instructions: Object): Promise<Object>`
 
 Prepare a suspended payment execution transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
+
+**Caution:** Suspended Payments are currently available on the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) only.
 
 ### Parameters
 

--- a/docs/src/boilerplate.md.ejs
+++ b/docs/src/boilerplate.md.ejs
@@ -17,7 +17,7 @@ api.connect().then(() => {
 
 RippleAPI is designed to work in [NodeJS](https://nodejs.org) (version `0.12.0` or greater) using [Babel](https://babeljs.io/) for [ECMAScript 6](https://babeljs.io/docs/learn-es2015/) support.
 
-The code samples in this documentation are written in ES6, but `RippleAPI` will work with ES5 also. Regardless of whether you use ES5 or ES6, the methods that return promises will return [ES6-style promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise_).
+The code samples in this documentation are written in ES6, but `RippleAPI` will work with ES5 also. Regardless of whether you use ES5 or ES6, the methods that return promises will return [ES6-style promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 <aside class="notice">
 All the code snippets in this documentation assume that you have surrounded them with this boilerplate.
@@ -29,7 +29,11 @@ If you omit the "catch" section, errors may not be visible.
 
 ### Parameters
 
+The RippleAPI constructor optionally takes one argument, an object with the following options:
+
 <%- renderSchema('input/api-options.json') %>
+
+If you omit the `servers` parameter, RippleAPI operates [offline](#offline-functionality).
 
 
 ### Installation ###

--- a/docs/src/index.md.ejs
+++ b/docs/src/index.md.ejs
@@ -1,5 +1,6 @@
 <% include introduction.md.ejs %>
 <% include boilerplate.md.ejs %>
+<% include offline.md.ejs %>
 <% include basictypes.md.ejs %>
 <% include transactions.md.ejs %>
 <% include specifications.md.ejs %>

--- a/docs/src/offline.md.ejs
+++ b/docs/src/offline.md.ejs
@@ -1,0 +1,27 @@
+## Offline functionality
+
+RippleAPI can also function without internet connectivity. This can be useful in order to generate secrets and sign transactions from a secure, isolated machine.
+
+To instantiate RippleAPI in offline mode, use the following boilerplate code:
+
+```javascript
+const {RippleAPI} = require('ripple-lib');
+
+const api = new RippleAPI();
+/* insert code here */
+```
+
+Methods that depend on the state of the Ripple Consensus Ledger are unavailable in offline mode. To prepare transactions offline, you **must** specify  the `fee`, `sequence`, and `maxLedgerVersion` parameters in the [transaction instructions](#transaction-instructions). The following methods should work offline:
+
+* [preparePayment](#preparepayment)
+* [prepareTrustline](#preparetrustline)
+* [prepareOrder](#prepareorder)
+* [prepareOrderCancellation](#prepareordercancellation)
+* [prepareSettings](#preparesettings)
+* [prepareSuspendedPaymentCreation](#preparesuspendedpaymentcreation)
+* [prepareSuspendedPaymentCancellation](#preparesuspendedpaymentcancellation)
+* [prepareSuspendedPaymentExecution](#preparesuspendedpaymentexecution)
+* [sign](#sign)
+* [generateAddress](#generateaddress)
+* [computeLedgerHash](#computeledgerhash)
+

--- a/docs/src/prepareSuspendedPaymentCancellation.md.ejs
+++ b/docs/src/prepareSuspendedPaymentCancellation.md.ejs
@@ -4,6 +4,8 @@
 
 Prepare a suspended payment cancellation transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 
+**Caution:** Suspended Payments are currently available on the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) only.
+
 ### Parameters
 
 <%- renderSchema('input/prepare-suspended-payment-cancellation.json') %>

--- a/docs/src/prepareSuspendedPaymentCreation.md.ejs
+++ b/docs/src/prepareSuspendedPaymentCreation.md.ejs
@@ -4,6 +4,8 @@
 
 Prepare a suspended payment creation transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 
+**Caution:** Suspended Payments are currently available on the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) only.
+
 ### Parameters
 
 <%- renderSchema('input/prepare-suspended-payment-creation.json') %>

--- a/docs/src/prepareSuspendedPaymentExecution.md.ejs
+++ b/docs/src/prepareSuspendedPaymentExecution.md.ejs
@@ -4,6 +4,8 @@
 
 Prepare a suspended payment execution transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 
+**Caution:** Suspended Payments are currently available on the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) only.
+
 ### Parameters
 
 <%- renderSchema('input/prepare-suspended-payment-execution.json') %>

--- a/docs/src/transactions.md.ejs
+++ b/docs/src/transactions.md.ejs
@@ -15,6 +15,8 @@ Type | Description
 [suspendedPaymentCancellation](#suspended-payment-cancellation) | A `suspendedPaymentCancellation` transaction unlocks the funds in a suspended payment and sends them back to the creator of the suspended payment, but it will only work after the suspended payment expires.
 [suspendedPaymentExecution](#suspended-payment-execution) | A `suspendedPaymentExecution` transaction unlocks the funds in a suspended payment and sends them to the destination of the suspended payment, but it will only work if the cryptographic condition is provided.
 
+The three "suspended payment" transaction types are not supported by the production Ripple peer-to-peer network at this time. They are available for testing purposes if you [configure RippleAPI](#boilerplate) to connect to the [Ripple Test Net](https://ripple.com/build/ripple-test-net/) instead.
+
 ## Transaction Flow
 
 Executing a transaction with `RippleAPI` requires the following four steps:
@@ -44,7 +46,7 @@ Transaction instructions indicate how to execute a transaction, complementary wi
 
 <%- renderSchema("objects/instructions.json") %>
 
-We recommended that you specify a `maxLedgerVersion` because without it there is no way to know that a failed transaction will never succeeed in the future. It is impossible for a transaction to succeed after the network ledger version exceeds the transaction's `maxLedgerVersion`.
+We recommended that you specify a `maxLedgerVersion` so that you can quickly determine that a failed transaction will never succeeed in the future. It is impossible for a transaction to succeed after the network ledger version exceeds the transaction's `maxLedgerVersion`.
 
 ## Transaction ID
 

--- a/src/common/schemas/objects/tag.json
+++ b/src/common/schemas/objects/tag.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "tag",
-  "description": "An arbitrary unsigned 32-bit integer most commonly used to identify a non-Ripple account.",
+  "description": "An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.",
   "type": "integer",
   "$ref": "uint32"
 }


### PR DESCRIPTION
- SusPays are not available in prod right now, so I added a warning. (More might be warranted in other places, because people skim.)
- maxLedgerVersion is not the "only" way you can know a transaction won't be viable later (you could also cancel by using up the seq. num), so I rephrased.
- I felt that the Src/Dst Tag description was misleading, so I tweaked it.