### PR TITLE
getFee returns a string not float

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -740,7 +740,7 @@ This method has no parameters.
 
 ### Return Value
 
-This method returns a promise that resolves with a floating point value representing the estimated fee to submit a transaction, expressed in XRP.
+This method returns a promise that resolves with a string encoded floating point value representing the estimated fee to submit a transaction, expressed in XRP.
 
 ### Example
 
@@ -749,7 +749,7 @@ return api.getFee().then(fee => {/* ... */});
 ```
 
 ```json
-0.012
+"0.012"
 ```
 
 ## getLedgerVersion

--- a/docs/src/getFee.md.ejs
+++ b/docs/src/getFee.md.ejs
@@ -10,7 +10,7 @@ This method has no parameters.
 
 ### Return Value
 
-This method returns a promise that resolves with a floating point value representing the estimated fee to submit a transaction, expressed in XRP.
+This method returns a promise that resolves with a string encoded floating point value representing the estimated fee to submit a transaction, expressed in XRP.
 
 ### Example
 
@@ -19,5 +19,5 @@ return api.getFee().then(fee => {/* ... */});
 ```
 
 ```json
-0.012
+"0.012"
 ```


### PR DESCRIPTION
> api.connect().then(() => api.getFee().then(fee => console.log(typeof fee)));
> string