### PR TITLE
[FIX] fix connection error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "coveralls": "^2.10.0",
     "doctoc": "^0.15.0",
     "ejs": "^2.3.4",
-    "eslint": "^1.3.0",
+    "eslint": "^2.1.0",
     "eventemitter2": "^0.4.14",
     "flow-bin": "^0.14",
     "gulp": "^3.8.10",

--- a/src/common/connection.js
+++ b/src/common/connection.js
@@ -1,4 +1,3 @@
-'use strict';
 const _ = require('lodash');
 const {EventEmitter} = require('events');
 const WebSocket = require('ws');

--- a/test/connection-test.js
+++ b/test/connection-test.js
@@ -1,5 +1,4 @@
 /* eslint-disable max-nested-callbacks */
-'use strict';
 
 const _ = require('lodash');
 const net = require('net');

--- a/test/connection-test.js
+++ b/test/connection-test.js
@@ -106,6 +106,26 @@ describe('Connection', function() {
     });
   });
 
+  it('should throw NotConnectedError if server not responding ', function(
+    done
+  ) {
+    if (process.browser) {
+      const phantomTest = /PhantomJS/;
+      if (phantomTest.test(navigator.userAgent)) {
+        // inside PhantomJS this one just hangs, so skip as not very relevant
+        done();
+        return;
+      }
+    }
+
+    const connection = new utils.common.Connection('ws://127.0.0.1:321');
+    connection.on('error', done);
+    connection.connect().catch(error => {
+      assert(error instanceof this.api.errors.NotConnectedError);
+      done();
+    });
+  });
+
   it('DisconnectedError', function() {
     this.api.connection._send(JSON.stringify({
       command: 'config',


### PR DESCRIPTION
if connection to server can't be established, reject Promise of `connect()` method caller,
instead of throwing error event on base object.