### PR TITLE
FIX: Filtering source_amount pathfind correctly

### DIFF
--- a/src/ledger/pathfind.js
+++ b/src/ledger/pathfind.js
@@ -93,7 +93,7 @@ function filterSourceFundsLowPaths(pathfind: PathFind,
     paths.alternatives = _.filter(paths.alternatives, alt => {
       return alt.source_amount &&
         pathfind.source.amount &&
-        alt.source_amount.value === pathfind.source.amount.value;
+        new BigNumber(alt.source_amount.value).eq(pathfind.source.amount.value);
     });
   }
   return paths;

--- a/test/fixtures/requests/getpaths/send-all.json
+++ b/test/fixtures/requests/getpaths/send-all.json
@@ -3,7 +3,7 @@
     "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
     "amount": {
       "currency": "USD",
-      "value": "5"
+      "value": "5.00"
     }
   },
   "destination": {


### PR DESCRIPTION
Bug:

```js
api.connect().then(() => {
  const pathfind = {
    source: {
      address: USDCold,
      amount: {
        currency: 'USD',
        value: '1.00' // <<<< Rippled response has "1" not "1.00"
      }
    },
    destination: {
      address: EURCold,
      amount: {currency: 'EUR'}
    }
  };
  return api.getPaths(pathfind).then(paths => {
    console.log('PATHS: \n', JSON.stringify(paths, null, 2));
  });
}).catch(console.log);

```