### PR TITLE
fix missing deliveredAmount data from getLedger requests

### DIFF
--- a/src/ledger/parse/ledger.js
+++ b/src/ledger/parse/ledger.js
@@ -1,5 +1,5 @@
 /* @flow */
-'use strict';
+'use strict'; // eslint-disable-line
 const _ = require('lodash');
 const {removeUndefined, rippleTimeToISO8601} = require('./utils');
 const parseTransaction = require('./transaction');
@@ -8,6 +8,11 @@ import type {GetLedger} from '../types.js';
 function parseTransactionWrapper(ledgerVersion, tx) {
   const transaction = _.assign({}, _.omit(tx, 'metaData'),
     {meta: tx.metaData});
+
+  // normalize format from rippled
+  transaction.meta.delivered_amount = transaction.meta.DeliveredAmount;
+  delete transaction.meta.DeliveredAmount;
+
   const result = parseTransaction(transaction);
   if (!result.outcome.ledgerVersion) {
     result.outcome.ledgerVersion = ledgerVersion;

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1171,6 +1171,16 @@ describe('RippleAPI', function() {
       _.partial(checkResult, responses.getLedger.withSettingsTx, 'getLedger'));
   });
 
+  it('getLedger - with partial payment', function() {
+    const request = {
+      includeTransactions: true,
+      includeAllData: true,
+      ledgerVersion: 100000
+    };
+    return this.api.getLedger(request).then(
+      _.partial(checkResult, responses.getLedger.withPartial, 'getLedger'));
+  });
+
   it('getLedger - full, then computeLedgerHash', function() {
     const request = {
       includeTransactions: true,

--- a/test/fixtures/responses/get-ledger-with-partial-payment.json
+++ b/test/fixtures/responses/get-ledger-with-partial-payment.json
@@ -1,0 +1,391 @@
+{
+  "stateHash": "334EE5F2209538C3099E133D25725E5BFEB40A198EA7028E6317F13E95D533DF",
+  "closeTime": "2016-07-07T16:53:51.000Z",
+  "closeTimeResolution": 10,
+  "closeFlags": 0,
+  "ledgerHash": "4F6C0495378FF68A15749C0D51D097EB638DA70319FDAC7A97A27CE63E0BFFED",
+  "ledgerVersion": 22420574,
+  "parentLedgerHash": "4F636662B714CD9CCE965E9C23BB2E1058A2DF496F5A2416299317AE03F1CD35",
+  "parentCloseTime": "2016-07-07T16:53:50.000Z",
+  "totalDrops": "99997302532397566",
+  "transactionHash": "C72A2BDCB471F3AEEB917ABC6019407CAE6DA4B858903A8AB2335A0EB077125D",
+  "transactions": [
+    {
+      "type": "orderCancellation",
+      "address": "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR",
+      "sequence": 84384,
+      "id": "1257EB8C80DE5AF6ACE91E0C05407CC1329E7B6FFBBBFFE9F734682871BD7655",
+      "specification": {
+        "orderSequence": 84383
+      },
+      "outcome": {
+        "result": "tesSUCCESS",
+        "fee": "0.000015",
+        "balanceChanges": {
+          "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR": [
+            {
+              "currency": "XRP",
+              "value": "-0.000015"
+            }
+          ]
+        },
+        "orderbookChanges": {
+          "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR": [
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "XRP",
+                "value": "42843.541733"
+              },
+              "totalPrice": {
+                "currency": "EUR",
+                "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                "value": "243.16481874"
+              },
+              "sequence": 84383,
+              "status": "cancelled",
+              "makerExchangeRate": "176.1913666417745"
+            }
+          ]
+        },
+        "indexInLedger": 4,
+        "ledgerVersion": 22420574
+      }
+    },
+    {
+      "type": "order",
+      "address": "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG",
+      "sequence": 771390,
+      "id": "43A53F005AF1AE095B39244D3C56E49150C43D16D89B7DA8673937E142858D38",
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "USD",
+          "value": "3000",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "JPY",
+          "value": "302728.16600853",
+          "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN"
+        }
+      },
+      "outcome": {
+        "result": "tesSUCCESS",
+        "fee": "0.01",
+        "balanceChanges": {
+          "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG": [
+            {
+              "currency": "XRP",
+              "value": "-0.01"
+            }
+          ]
+        },
+        "orderbookChanges": {
+          "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG": [
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "3000"
+              },
+              "totalPrice": {
+                "currency": "JPY",
+                "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                "value": "302728.16600853"
+              },
+              "sequence": 771390,
+              "status": "created",
+              "makerExchangeRate": "0.009909880668042856"
+            },
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "3000"
+              },
+              "totalPrice": {
+                "currency": "JPY",
+                "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                "value": "304004.98984125"
+              },
+              "sequence": 771388,
+              "status": "cancelled",
+              "makerExchangeRate": "0.009868259075505919"
+            }
+          ]
+        },
+        "indexInLedger": 0,
+        "ledgerVersion": 22420574
+      }
+    },
+    {
+      "type": "order",
+      "address": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+      "sequence": 15817540,
+      "id": "54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5",
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "JPY",
+          "value": "22148.5780242286",
+          "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN"
+        },
+        "totalPrice": {
+          "currency": "USD",
+          "value": "214",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "expirationTime": "2016-07-07T17:03:46.000Z"
+      },
+      "outcome": {
+        "result": "tesSUCCESS",
+        "fee": "0.00003",
+        "balanceChanges": {
+          "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw": [
+            {
+              "currency": "XRP",
+              "value": "-0.00003"
+            }
+          ]
+        },
+        "orderbookChanges": {
+          "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw": [
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "JPY",
+                "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                "value": "22148.5780242286"
+              },
+              "totalPrice": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "214"
+              },
+              "sequence": 15817540,
+              "status": "created",
+              "makerExchangeRate": "103.4980281506009",
+              "expirationTime": "2016-07-07T17:03:46.000Z"
+            }
+          ]
+        },
+        "indexInLedger": 1,
+        "ledgerVersion": 22420574
+      }
+    },
+    {
+      "type": "order",
+      "address": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+      "sequence": 15817541,
+      "id": "5B79A66B1FD0619159783A8A85F43E14B159D91D3ACB36AEB954A101026BB68E",
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "USD",
+          "value": "2954.92952861701",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "BTC",
+          "value": "4.7",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "expirationTime": "2016-07-07T17:03:46.000Z"
+      },
+      "outcome": {
+        "result": "tesSUCCESS",
+        "fee": "0.00003",
+        "balanceChanges": {
+          "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw": [
+            {
+              "currency": "XRP",
+              "value": "-0.00003"
+            }
+          ]
+        },
+        "orderbookChanges": {
+          "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw": [
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "2954.92952861701"
+              },
+              "totalPrice": {
+                "currency": "BTC",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "4.7"
+              },
+              "sequence": 15817541,
+              "status": "created",
+              "makerExchangeRate": "628.7084103440447",
+              "expirationTime": "2016-07-07T17:03:46.000Z"
+            },
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "2955.46645977528"
+              },
+              "totalPrice": {
+                "currency": "BTC",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "4.7"
+              },
+              "sequence": 15817525,
+              "status": "cancelled",
+              "makerExchangeRate": "628.822651016017",
+              "expirationTime": "2016-07-07T17:03:34.000Z"
+            }
+          ]
+        },
+        "indexInLedger": 2,
+        "ledgerVersion": 22420574
+      }
+    },
+    {
+      "type": "payment",
+      "address": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX",
+      "sequence": 23295,
+      "id": "A0A074D10355223CBE2520A42F93A52E3CC8B4D692570EB4841084F9BBB39F7A",
+      "specification": {
+        "source": {
+          "address": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX",
+          "maxAmount": {
+            "currency": "USD",
+            "value": "10",
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+          }
+        },
+        "destination": {
+          "address": "rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4",
+          "amount": {
+            "currency": "USD",
+            "value": "10",
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+          }
+        },
+        "allowPartialPayment": true
+      },
+      "outcome": {
+        "result": "tesSUCCESS",
+        "fee": "0.01",
+        "balanceChanges": {
+          "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX": [
+            {
+              "currency": "XRP",
+              "value": "-0.01"
+            },
+            {
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "value": "-10"
+            }
+          ],
+          "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+            {
+              "counterparty": "rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4",
+              "currency": "USD",
+              "value": "-9.980039920159681"
+            },
+            {
+              "counterparty": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX",
+              "currency": "USD",
+              "value": "10"
+            }
+          ],
+          "rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4": [
+            {
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "value": "9.980039920159681"
+            }
+          ]
+        },
+        "orderbookChanges": {},
+        "indexInLedger": 5,
+        "deliveredAmount": {
+          "currency": "USD",
+          "value": "9.980039920159681",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "ledgerVersion": 22420574
+      }
+    },
+    {
+      "type": "order",
+      "address": "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp",
+      "sequence": 1294410,
+      "id": "B1B959CA2B3B46F07B2F1373C84E927C46B124E9728C79A2736F32AA3F2DB7FB",
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "USD",
+          "value": "2500",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        "totalPrice": {
+          "currency": "JPY",
+          "value": "254121.4048342",
+          "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN"
+        }
+      },
+      "outcome": {
+        "result": "tesSUCCESS",
+        "fee": "0.01",
+        "balanceChanges": {
+          "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp": [
+            {
+              "currency": "XRP",
+              "value": "-0.01"
+            }
+          ]
+        },
+        "orderbookChanges": {
+          "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp": [
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "2500"
+              },
+              "totalPrice": {
+                "currency": "JPY",
+                "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                "value": "255397.84578255"
+              },
+              "sequence": 1294409,
+              "status": "cancelled",
+              "makerExchangeRate": "0.009788649517931102"
+            },
+            {
+              "direction": "buy",
+              "quantity": {
+                "currency": "USD",
+                "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                "value": "2500"
+              },
+              "totalPrice": {
+                "currency": "JPY",
+                "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                "value": "254121.4048342"
+              },
+              "sequence": 1294410,
+              "status": "created",
+              "makerExchangeRate": "0.009837817485823794"
+            }
+          ]
+        },
+        "indexInLedger": 3,
+        "ledgerVersion": 22420574
+      }
+    }
+  ],
+  "rawTransactions": "[{\"Account\":\"rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR\",\"Fee\":\"15\",\"Flags\":2147483648,\"LastLedgerSequence\":22420576,\"OfferSequence\":84383,\"Sequence\":84384,\"SigningPubKey\":\"0219D7F97CA3C7BDF0982B0CCFE613761BE563C049A876596B5365A975C669D1A2\",\"TransactionType\":\"OfferCancel\",\"TxnSignature\":\"3045022100D270AC3BAB933C22E88DC557B86BF04BF2A101C2474E0FD6DA5991DB996010EB022071C6571C3031F2B1A0F91106CAFB5C8E766220CFC57676D467258A3A3B966F28\",\"hash\":\"1257EB8C80DE5AF6ACE91E0C05407CC1329E7B6FFBBBFFE9F734682871BD7655\",\"metaData\":{\"AffectedNodes\":[{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR\",\"Balance\":\"170452281963\",\"Flags\":0,\"OwnerCount\":3,\"Sequence\":84385},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"4CC1921751937D88A7BFF74B5EA2C67673B349EA86C52CE918EED279075EB6E6\",\"PreviousFields\":{\"Balance\":\"170452281978\",\"OwnerCount\":4,\"Sequence\":84384},\"PreviousTxnID\":\"400E30CB98BF337449A69D221B7159484B6EC18002A9285AFB871D60326C81A9\",\"PreviousTxnLgrSeq\":22420562}},{\"DeletedNode\":{\"FinalFields\":{\"Account\":\"rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR\",\"BookDirectory\":\"CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5D0642737E363451\",\"BookNode\":\"0000000000000000\",\"Flags\":0,\"OwnerNode\":\"0000000000000000\",\"PreviousTxnID\":\"400E30CB98BF337449A69D221B7159484B6EC18002A9285AFB871D60326C81A9\",\"PreviousTxnLgrSeq\":22420562,\"Sequence\":84383,\"TakerGets\":{\"currency\":\"EUR\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"value\":\"243.16481874\"},\"TakerPays\":\"42843541733\"},\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"86FFBBEC167E8E6D9540637C12BE2D28808F724B969631E00E506DE279389B8B\"}},{\"DeletedNode\":{\"FinalFields\":{\"ExchangeRate\":\"5D0642737E363451\",\"Flags\":0,\"RootIndex\":\"CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5D0642737E363451\",\"TakerGetsCurrency\":\"0000000000000000000000004555520000000000\",\"TakerGetsIssuer\":\"2ADB0B3959D60A6E6991F729E1918B7163925230\",\"TakerPaysCurrency\":\"0000000000000000000000000000000000000000\",\"TakerPaysIssuer\":\"0000000000000000000000000000000000000000\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5D0642737E363451\"}},{\"ModifiedNode\":{\"FinalFields\":{\"Flags\":0,\"Owner\":\"rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR\",\"RootIndex\":\"D84063896F704906662E7D93637D579485E19914088FA6F4F929D93CD2163B18\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"D84063896F704906662E7D93637D579485E19914088FA6F4F929D93CD2163B18\"}}],\"TransactionIndex\":4,\"TransactionResult\":\"tesSUCCESS\"}},{\"Account\":\"rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG\",\"Fee\":\"10000\",\"LastLedgerSequence\":22420577,\"Memos\":[{\"Memo\":{\"MemoData\":\"535F72665F6A70795F7573645F746F6B796F5F6269745F676623715F726970706C65\",\"MemoType\":\"6F666665725F636F6D6D656E74\"}}],\"OfferSequence\":771388,\"Sequence\":771390,\"SigningPubKey\":\"02CEC39D51583C89A46804CAA7956503E41919022BF4BC842D4FA9CF076783AFCE\",\"TakerGets\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"302728.16600853\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"3000\"},\"TransactionType\":\"OfferCreate\",\"TxnSignature\":\"3045022100CAE6228D3D6729E60222B2453DE13C35CAB7049FB430543BB819161F059511E60220371FD55EDF0396A207E57C40114C004B92F6697A260A0CFBC2704E85B255CCEE\",\"hash\":\"43A53F005AF1AE095B39244D3C56E49150C43D16D89B7DA8673937E142858D38\",\"metaData\":{\"AffectedNodes\":[{\"CreatedNode\":{\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"1FB6961BD982103CBFD57FA73F30110CE1ED31C85A35A8FB987591CAD1A28C6C\",\"NewFields\":{\"Account\":\"rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG\",\"BookDirectory\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF4522334FBE4FC3668\",\"Sequence\":771390,\"TakerGets\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"302728.16600853\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"3000\"}}}},{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG\",\"Balance\":\"2048885453\",\"Flags\":0,\"OwnerCount\":22,\"RegularKey\":\"rNXYnXu27dPzQyXxVV6iNBNrJwSz8y5Wzc\",\"Sequence\":771391},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"7118386A4D8C55902FD814D62E2F4D7CE90E3B4F44E6B23CAD4C874B9A5771C9\",\"PreviousFields\":{\"Balance\":\"2048895453\",\"Sequence\":771390},\"PreviousTxnID\":\"19EB03F21D86C9B225FB6ADACF489BF66C1482C3B05DAAD59C114965FB13A59C\",\"PreviousTxnLgrSeq\":22420570}},{\"DeletedNode\":{\"FinalFields\":{\"ExchangeRate\":\"52230F211CBF3EFF\",\"Flags\":0,\"RootIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF452230F211CBF3EFF\",\"TakerGetsCurrency\":\"0000000000000000000000004A50590000000000\",\"TakerGetsIssuer\":\"5BBC0F22F61D9224A110650CFE21CC0C4BE13098\",\"TakerPaysCurrency\":\"0000000000000000000000005553440000000000\",\"TakerPaysIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF452230F211CBF3EFF\"}},{\"CreatedNode\":{\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF4522334FBE4FC3668\",\"NewFields\":{\"ExchangeRate\":\"522334FBE4FC3668\",\"RootIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF4522334FBE4FC3668\",\"TakerGetsCurrency\":\"0000000000000000000000004A50590000000000\",\"TakerGetsIssuer\":\"5BBC0F22F61D9224A110650CFE21CC0C4BE13098\",\"TakerPaysCurrency\":\"0000000000000000000000005553440000000000\",\"TakerPaysIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\"}}},{\"ModifiedNode\":{\"FinalFields\":{\"Flags\":0,\"Owner\":\"rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG\",\"RootIndex\":\"A187A05FE957F5953846DF21A742F20FBFFACF3196D8FFEA85C3E062EA3B7A69\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"A187A05FE957F5953846DF21A742F20FBFFACF3196D8FFEA85C3E062EA3B7A69\"}},{\"DeletedNode\":{\"FinalFields\":{\"Account\":\"rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG\",\"BookDirectory\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF452230F211CBF3EFF\",\"BookNode\":\"0000000000000000\",\"Flags\":0,\"OwnerNode\":\"0000000000000000\",\"PreviousTxnID\":\"2073CD805F40D44BADD32EF138FE9782A5D9DF1E9C0700EA41C4D45163ED1FE6\",\"PreviousTxnLgrSeq\":22420569,\"Sequence\":771388,\"TakerGets\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"304004.98984125\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"3000\"}},\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"F5ACC7F4D8253666AB5AF39E812107E7CFC5B7A686E7C24F560F84AA3150BDF0\"}}],\"TransactionIndex\":0,\"TransactionResult\":\"tesSUCCESS\"}},{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"Expiration\":521226226,\"Fee\":\"30\",\"Flags\":2147483648,\"LastLedgerSequence\":22420575,\"Sequence\":15817540,\"SigningPubKey\":\"034841BF24BD72C7CC371EBD87CCBF258D8ADB05C18DE207130364A97D8A3EA524\",\"TakerGets\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"214\"},\"TakerPays\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"22148.5780242286\"},\"TransactionType\":\"OfferCreate\",\"TxnSignature\":\"304402204DF95ADF23D6F5727E573BA085DDE08FB5B7AE9A23CF5709708FE190D87B851A02200C0D7F21C4F989C2B81171B11CE3224F7DB594A413C45CCA5E505ED86ED91418\",\"hash\":\"54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5\",\"metaData\":{\"AffectedNodes\":[{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"AccountTxnID\":\"54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5\",\"Balance\":\"2690753645214\",\"Flags\":0,\"OwnerCount\":25,\"RegularKey\":\"r9S56zu6QeJD5d8A7QMfLAeYavgB9dhaX4\",\"Sequence\":15817541},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"2880A9B4FB90A306B576C2D532BFE390AB3904642647DCF739492AA244EF46D1\",\"PreviousFields\":{\"AccountTxnID\":\"05408DE689A1D9454DE31BFE586F210C1AB78FBB71D5A096CDA7B453F9E8733C\",\"Balance\":\"2690753645244\",\"OwnerCount\":24,\"Sequence\":15817540},\"PreviousTxnID\":\"05408DE689A1D9454DE31BFE586F210C1AB78FBB71D5A096CDA7B453F9E8733C\",\"PreviousTxnLgrSeq\":22420573}},{\"ModifiedNode\":{\"FinalFields\":{\"Flags\":0,\"IndexPrevious\":\"00000000000022F7\",\"Owner\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"RootIndex\":\"F435FBBEC9654204D7151A01E686BAA8CB325A472D7B61C7916EA58B59355767\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"88048321517F5E225D2963BC749F9F9853D348679406839659056E67D2D374C9\"}},{\"CreatedNode\":{\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"9422BBC577CBDD1ED2C13D4C7CC6581BB10EAC3E968D44C2D7FB98E15B2B37F3\",\"NewFields\":{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"BookDirectory\":\"FB9B9ED334DD7AFC1145AE485D86FB101C07F583CDE55EB95703AD4F200758D9\",\"Expiration\":521226226,\"OwnerNode\":\"00000000000024CB\",\"Sequence\":15817540,\"TakerGets\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"214\"},\"TakerPays\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"22148.5780242286\"}}}},{\"CreatedNode\":{\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"FB9B9ED334DD7AFC1145AE485D86FB101C07F583CDE55EB95703AD4F200758D9\",\"NewFields\":{\"ExchangeRate\":\"5703AD4F200758D9\",\"RootIndex\":\"FB9B9ED334DD7AFC1145AE485D86FB101C07F583CDE55EB95703AD4F200758D9\",\"TakerGetsCurrency\":\"0000000000000000000000005553440000000000\",\"TakerGetsIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\",\"TakerPaysCurrency\":\"0000000000000000000000004A50590000000000\",\"TakerPaysIssuer\":\"5BBC0F22F61D9224A110650CFE21CC0C4BE13098\"}}}],\"TransactionIndex\":1,\"TransactionResult\":\"tesSUCCESS\"}},{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"Expiration\":521226226,\"Fee\":\"30\",\"Flags\":2147483648,\"LastLedgerSequence\":22420575,\"OfferSequence\":15817525,\"Sequence\":15817541,\"SigningPubKey\":\"034841BF24BD72C7CC371EBD87CCBF258D8ADB05C18DE207130364A97D8A3EA524\",\"TakerGets\":{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"4.7\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"2954.92952861701\"},\"TransactionType\":\"OfferCreate\",\"TxnSignature\":\"3045022100C63DFE5D3A27D42DC87439948C6692C0015B6891FC531F27A58ECA319D388FCF02202CE4E60D940E168250E612A45331134937AD71911DFF8C042FEBB91833332F94\",\"hash\":\"5B79A66B1FD0619159783A8A85F43E14B159D91D3ACB36AEB954A101026BB68E\",\"metaData\":{\"AffectedNodes\":[{\"CreatedNode\":{\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"20046290D68FFFC3AC8DB8B725F2BF0FD4CBAF45C719C76245F247E9C7EDCBFE\",\"NewFields\":{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"BookDirectory\":\"6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC9857165611D6A8983F\",\"Expiration\":521226226,\"OwnerNode\":\"00000000000024CB\",\"Sequence\":15817541,\"TakerGets\":{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"4.7\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"2954.92952861701\"}}}},{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"AccountTxnID\":\"5B79A66B1FD0619159783A8A85F43E14B159D91D3ACB36AEB954A101026BB68E\",\"Balance\":\"2690753645184\",\"Flags\":0,\"OwnerCount\":25,\"RegularKey\":\"r9S56zu6QeJD5d8A7QMfLAeYavgB9dhaX4\",\"Sequence\":15817542},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"2880A9B4FB90A306B576C2D532BFE390AB3904642647DCF739492AA244EF46D1\",\"PreviousFields\":{\"AccountTxnID\":\"54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5\",\"Balance\":\"2690753645214\",\"Sequence\":15817541},\"PreviousTxnID\":\"54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5\",\"PreviousTxnLgrSeq\":22420574}},{\"DeletedNode\":{\"FinalFields\":{\"Account\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"BookDirectory\":\"6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985716571BD367C12A\",\"BookNode\":\"0000000000000000\",\"Expiration\":521226214,\"Flags\":0,\"OwnerNode\":\"00000000000024CB\",\"PreviousTxnID\":\"EB843063BD289BBFBD376602780A83F5CBA07AAADF65392683B9DE90E43B59C7\",\"PreviousTxnLgrSeq\":22420570,\"Sequence\":15817525,\"TakerGets\":{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"4.7\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"2955.46645977528\"}},\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"3E26BB816F8D8FE43F01D10284AAC2A2E340AF8B20AD37B125C098A8BCAEF601\"}},{\"CreatedNode\":{\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC9857165611D6A8983F\",\"NewFields\":{\"ExchangeRate\":\"57165611D6A8983F\",\"RootIndex\":\"6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC9857165611D6A8983F\",\"TakerGetsCurrency\":\"0000000000000000000000004254430000000000\",\"TakerGetsIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\",\"TakerPaysCurrency\":\"0000000000000000000000005553440000000000\",\"TakerPaysIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\"}}},{\"DeletedNode\":{\"FinalFields\":{\"ExchangeRate\":\"5716571BD367C12A\",\"Flags\":0,\"RootIndex\":\"6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985716571BD367C12A\",\"TakerGetsCurrency\":\"0000000000000000000000004254430000000000\",\"TakerGetsIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\",\"TakerPaysCurrency\":\"0000000000000000000000005553440000000000\",\"TakerPaysIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985716571BD367C12A\"}},{\"ModifiedNode\":{\"FinalFields\":{\"Flags\":0,\"IndexPrevious\":\"00000000000022F7\",\"Owner\":\"rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw\",\"RootIndex\":\"F435FBBEC9654204D7151A01E686BAA8CB325A472D7B61C7916EA58B59355767\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"88048321517F5E225D2963BC749F9F9853D348679406839659056E67D2D374C9\"}}],\"TransactionIndex\":2,\"TransactionResult\":\"tesSUCCESS\"}},{\"Account\":\"rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX\",\"Amount\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"10\"},\"Destination\":\"rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4\",\"Fee\":\"10000\",\"Flags\":131072,\"Sequence\":23295,\"SigningPubKey\":\"02B205F4B92351AC0EEB04254B636F4C49EF922CFA3CAAD03C6477DA1E04E94B53\",\"TransactionType\":\"Payment\",\"TxnSignature\":\"3045022100FAF247A836D601DE74A515B2AADE31186D8B0DA9C23DE489E09753F5CF4BB81F0220477C5B5BC3AC89F2347744F9E00CCA62267E198489D747578162C4C7D156211D\",\"hash\":\"A0A074D10355223CBE2520A42F93A52E3CC8B4D692570EB4841084F9BBB39F7A\",\"metaData\":{\"AffectedNodes\":[{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX\",\"Balance\":\"1930599790\",\"Flags\":0,\"OwnerCount\":2,\"Sequence\":23296},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"267C16D24EC42EEF8B03D5BE4E94266B1675FA54AFCE42DE795E02AB61031CBD\",\"PreviousFields\":{\"Balance\":\"1930609790\",\"Sequence\":23295},\"PreviousTxnID\":\"0F5396388E91D37BB26C8E24073A57E7C5D51E79AEE4CD855653B8499AE4E3DD\",\"PreviousTxnLgrSeq\":22419806}},{\"ModifiedNode\":{\"FinalFields\":{\"Balance\":{\"currency\":\"USD\",\"issuer\":\"rrrrrrrrrrrrrrrrrrrrBZbvji\",\"value\":\"-9.980959751659681\"},\"Flags\":2228224,\"HighLimit\":{\"currency\":\"USD\",\"issuer\":\"rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4\",\"value\":\"1000000\"},\"HighNode\":\"0000000000000000\",\"LowLimit\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"0\"},\"LowNode\":\"0000000000000423\"},\"LedgerEntryType\":\"RippleState\",\"LedgerIndex\":\"C66957AF25229357F9C2D2BA17CE47D88169788EDA7610AD0F29AD5BCB225EE5\",\"PreviousFields\":{\"Balance\":{\"currency\":\"USD\",\"issuer\":\"rrrrrrrrrrrrrrrrrrrrBZbvji\",\"value\":\"-0.0009198315\"}},\"PreviousTxnID\":\"2A01E994D7000000B43DD63825A081B4440A44AB2F6FA0D506158AC9CA6B2869\",\"PreviousTxnLgrSeq\":22420532}},{\"ModifiedNode\":{\"FinalFields\":{\"Balance\":{\"currency\":\"USD\",\"issuer\":\"rrrrrrrrrrrrrrrrrrrrBZbvji\",\"value\":\"-276666.975959\"},\"Flags\":131072,\"HighLimit\":{\"currency\":\"USD\",\"issuer\":\"rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX\",\"value\":\"1000000\"},\"HighNode\":\"0000000000000000\",\"LowLimit\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"0\"},\"LowNode\":\"00000000000002D7\"},\"LedgerEntryType\":\"RippleState\",\"LedgerIndex\":\"FFD710AE2074A98D920D00CC352F25744899F069A6C1B9E31DD32D2C6606E615\",\"PreviousFields\":{\"Balance\":{\"currency\":\"USD\",\"issuer\":\"rrrrrrrrrrrrrrrrrrrrBZbvji\",\"value\":\"-276676.975959\"}},\"PreviousTxnID\":\"BB9DFC87E9D4ED09CA2726DDFE83A4A396ED0D6545536322DE17CDACF45C0D5B\",\"PreviousTxnLgrSeq\":22419307}}],\"TransactionIndex\":5,\"TransactionResult\":\"tesSUCCESS\",\"delivered_amount\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"9.980039920159681\"}}},{\"Account\":\"rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp\",\"Fee\":\"10000\",\"LastLedgerSequence\":22420577,\"Memos\":[{\"Memo\":{\"MemoData\":\"535F72665F6A70795F7573645F746F6B796F5F6269745F6D6178696D23715F726970706C65\",\"MemoType\":\"6F666665725F636F6D6D656E74\"}}],\"OfferSequence\":1294409,\"Sequence\":1294410,\"SigningPubKey\":\"020D9B49DBB6583827CC36E86BF13EDFA600367BE26DB09759AD08890A13CD92F9\",\"TakerGets\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"254121.4048342\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"2500\"},\"TransactionType\":\"OfferCreate\",\"TxnSignature\":\"304402202EB6221AFBD704EF9E79C8DC69ED1B1B1219DB2239779A1B759CC9C42C759742022024C97FE2E4242C3B687416C1C518CDE1A06956347315B8AAFC45DE0CAC918FA6\",\"hash\":\"B1B959CA2B3B46F07B2F1373C84E927C46B124E9728C79A2736F32AA3F2DB7FB\",\"metaData\":{\"AffectedNodes\":[{\"DeletedNode\":{\"FinalFields\":{\"Account\":\"rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp\",\"BookDirectory\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222C6B99158DA5E\",\"BookNode\":\"0000000000000000\",\"Flags\":0,\"OwnerNode\":\"0000000000000000\",\"PreviousTxnID\":\"050C1BD88A98FD6F5771EF04D76B1070FA9C3359FB3DB0F0E2518E0CB9BEE1FE\",\"PreviousTxnLgrSeq\":22420573,\"Sequence\":1294409,\"TakerGets\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"255397.84578255\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"2500\"}},\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"1343E6606ABEBB1F9A67C509F0D6AD6BC8E5BB6233A52E1477C8B3EE9B56F22D\"}},{\"CreatedNode\":{\"LedgerEntryType\":\"Offer\",\"LedgerIndex\":\"1AE025735533090254CF26482318847923FF38E72606182926B36482D9D51C68\",\"NewFields\":{\"Account\":\"rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp\",\"BookDirectory\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222F371609B8F32\",\"Sequence\":1294410,\"TakerGets\":{\"currency\":\"JPY\",\"issuer\":\"r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN\",\"value\":\"254121.4048342\"},\"TakerPays\":{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"value\":\"2500\"}}}},{\"ModifiedNode\":{\"FinalFields\":{\"Account\":\"rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp\",\"Balance\":\"2298060996\",\"Flags\":0,\"OwnerCount\":24,\"Sequence\":1294411},\"LedgerEntryType\":\"AccountRoot\",\"LedgerIndex\":\"6F30F56C9326728173DD7A6FD9D3D84E5E4F95FE552D8F67C2C2BC154C596D53\",\"PreviousFields\":{\"Balance\":\"2298070996\",\"Sequence\":1294410},\"PreviousTxnID\":\"050C1BD88A98FD6F5771EF04D76B1070FA9C3359FB3DB0F0E2518E0CB9BEE1FE\",\"PreviousTxnLgrSeq\":22420573}},{\"DeletedNode\":{\"FinalFields\":{\"ExchangeRate\":\"5222C6B99158DA5E\",\"Flags\":0,\"RootIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222C6B99158DA5E\",\"TakerGetsCurrency\":\"0000000000000000000000004A50590000000000\",\"TakerGetsIssuer\":\"5BBC0F22F61D9224A110650CFE21CC0C4BE13098\",\"TakerPaysCurrency\":\"0000000000000000000000005553440000000000\",\"TakerPaysIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222C6B99158DA5E\"}},{\"CreatedNode\":{\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222F371609B8F32\",\"NewFields\":{\"ExchangeRate\":\"5222F371609B8F32\",\"RootIndex\":\"95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222F371609B8F32\",\"TakerGetsCurrency\":\"0000000000000000000000004A50590000000000\",\"TakerGetsIssuer\":\"5BBC0F22F61D9224A110650CFE21CC0C4BE13098\",\"TakerPaysCurrency\":\"0000000000000000000000005553440000000000\",\"TakerPaysIssuer\":\"0A20B3C85F482532A9578DBB3950B85CA06594D1\"}}},{\"ModifiedNode\":{\"FinalFields\":{\"Flags\":0,\"Owner\":\"rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp\",\"RootIndex\":\"987A5375A496B811965A54979A1E1A29F474CBA2D133F0587347B9B58E599666\"},\"LedgerEntryType\":\"DirectoryNode\",\"LedgerIndex\":\"987A5375A496B811965A54979A1E1A29F474CBA2D133F0587347B9B58E599666\"}}],\"TransactionIndex\":3,\"TransactionResult\":\"tesSUCCESS\"}}]"
+}

--- a/test/fixtures/responses/index.js
+++ b/test/fixtures/responses/index.js
@@ -59,7 +59,8 @@ module.exports = {
     header: require('./get-ledger'),
     full: require('./get-ledger-full'),
     withSettingsTx: require('./get-ledger-with-settings-tx'),
-    withStateAsHashes: require('./get-ledger-with-state-as-hashes')
+    withStateAsHashes: require('./get-ledger-with-state-as-hashes'),
+    withPartial: require('./get-ledger-with-partial-payment')
   },
   prepareOrder: {
     buy: require('./prepare-order.json'),

--- a/test/fixtures/rippled/index.js
+++ b/test/fixtures/rippled/index.js
@@ -1,4 +1,4 @@
-'use strict'; // eslint-disable-line 
+'use strict'; // eslint-disable-line
 
 module.exports = {
   submit: {
@@ -10,7 +10,8 @@ module.exports = {
     notFound: require('./ledger-not-found'),
     withoutCloseTime: require('./ledger-without-close-time'),
     withSettingsTx: require('./ledger-with-settings-tx'),
-    withStateAsHashes: require('./ledger-with-state-as-hashes')
+    withStateAsHashes: require('./ledger-with-state-as-hashes'),
+    withPartialPayment: require('./ledger-with-partial-payment')
   },
   empty: require('./empty'),
   subscribe: require('./subscribe'),

--- a/test/fixtures/rippled/ledger-with-partial-payment.json
+++ b/test/fixtures/rippled/ledger-with-partial-payment.json
@@ -1,0 +1,757 @@
+{
+  "id": 1,
+  "status": "success",
+  "type": "response",
+  "result": {
+    "ledger": {
+      "accepted": true,
+      "account_hash": "334EE5F2209538C3099E133D25725E5BFEB40A198EA7028E6317F13E95D533DF",
+      "close_flags": 0,
+      "close_time": 521225631,
+      "close_time_human": "2016-Jul-07 16:53:51",
+      "close_time_resolution": 10,
+      "closed": true,
+      "hash": "4F6C0495378FF68A15749C0D51D097EB638DA70319FDAC7A97A27CE63E0BFFED",
+      "ledger_hash": "4F6C0495378FF68A15749C0D51D097EB638DA70319FDAC7A97A27CE63E0BFFED",
+      "ledger_index": "22420574",
+      "parent_close_time": 521225630,
+      "parent_hash": "4F636662B714CD9CCE965E9C23BB2E1058A2DF496F5A2416299317AE03F1CD35",
+      "seqNum": "22420574",
+      "totalCoins": "99997302532397566",
+      "total_coins": "99997302532397566",
+      "transaction_hash": "C72A2BDCB471F3AEEB917ABC6019407CAE6DA4B858903A8AB2335A0EB077125D",
+      "transactions": [
+        {
+          "Account": "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR",
+          "Fee": "15",
+          "Flags": 2147483648,
+          "LastLedgerSequence": 22420576,
+          "OfferSequence": 84383,
+          "Sequence": 84384,
+          "SigningPubKey": "0219D7F97CA3C7BDF0982B0CCFE613761BE563C049A876596B5365A975C669D1A2",
+          "TransactionType": "OfferCancel",
+          "TxnSignature": "3045022100D270AC3BAB933C22E88DC557B86BF04BF2A101C2474E0FD6DA5991DB996010EB022071C6571C3031F2B1A0F91106CAFB5C8E766220CFC57676D467258A3A3B966F28",
+          "hash": "1257EB8C80DE5AF6ACE91E0C05407CC1329E7B6FFBBBFFE9F734682871BD7655",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR",
+                    "Balance": "170452281963",
+                    "Flags": 0,
+                    "OwnerCount": 3,
+                    "Sequence": 84385
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "4CC1921751937D88A7BFF74B5EA2C67673B349EA86C52CE918EED279075EB6E6",
+                  "PreviousFields": {
+                    "Balance": "170452281978",
+                    "OwnerCount": 4,
+                    "Sequence": 84384
+                  },
+                  "PreviousTxnID": "400E30CB98BF337449A69D221B7159484B6EC18002A9285AFB871D60326C81A9",
+                  "PreviousTxnLgrSeq": 22420562
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "Account": "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR",
+                    "BookDirectory": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5D0642737E363451",
+                    "BookNode": "0000000000000000",
+                    "Flags": 0,
+                    "OwnerNode": "0000000000000000",
+                    "PreviousTxnID": "400E30CB98BF337449A69D221B7159484B6EC18002A9285AFB871D60326C81A9",
+                    "PreviousTxnLgrSeq": 22420562,
+                    "Sequence": 84383,
+                    "TakerGets": {
+                      "currency": "EUR",
+                      "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                      "value": "243.16481874"
+                    },
+                    "TakerPays": "42843541733"
+                  },
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "86FFBBEC167E8E6D9540637C12BE2D28808F724B969631E00E506DE279389B8B"
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "ExchangeRate": "5D0642737E363451",
+                    "Flags": 0,
+                    "RootIndex": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5D0642737E363451",
+                    "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                    "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                    "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                    "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5D0642737E363451"
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Flags": 0,
+                    "Owner": "rJXJEvVxWSG2xVp62AoE7rM3PKUF9S1GSR",
+                    "RootIndex": "D84063896F704906662E7D93637D579485E19914088FA6F4F929D93CD2163B18"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "D84063896F704906662E7D93637D579485E19914088FA6F4F929D93CD2163B18"
+                }
+              }
+            ],
+            "TransactionIndex": 4,
+            "TransactionResult": "tesSUCCESS"
+          }
+        },
+        {
+          "Account": "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG",
+          "Fee": "10000",
+          "LastLedgerSequence": 22420577,
+          "Memos": [
+            {
+              "Memo": {
+                "MemoData": "535F72665F6A70795F7573645F746F6B796F5F6269745F676623715F726970706C65",
+                "MemoType": "6F666665725F636F6D6D656E74"
+              }
+            }
+          ],
+          "OfferSequence": 771388,
+          "Sequence": 771390,
+          "SigningPubKey": "02CEC39D51583C89A46804CAA7956503E41919022BF4BC842D4FA9CF076783AFCE",
+          "TakerGets": {
+            "currency": "JPY",
+            "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+            "value": "302728.16600853"
+          },
+          "TakerPays": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "3000"
+          },
+          "TransactionType": "OfferCreate",
+          "TxnSignature": "3045022100CAE6228D3D6729E60222B2453DE13C35CAB7049FB430543BB819161F059511E60220371FD55EDF0396A207E57C40114C004B92F6697A260A0CFBC2704E85B255CCEE",
+          "hash": "43A53F005AF1AE095B39244D3C56E49150C43D16D89B7DA8673937E142858D38",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "1FB6961BD982103CBFD57FA73F30110CE1ED31C85A35A8FB987591CAD1A28C6C",
+                  "NewFields": {
+                    "Account": "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG",
+                    "BookDirectory": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF4522334FBE4FC3668",
+                    "Sequence": 771390,
+                    "TakerGets": {
+                      "currency": "JPY",
+                      "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                      "value": "302728.16600853"
+                    },
+                    "TakerPays": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "3000"
+                    }
+                  }
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG",
+                    "Balance": "2048885453",
+                    "Flags": 0,
+                    "OwnerCount": 22,
+                    "RegularKey": "rNXYnXu27dPzQyXxVV6iNBNrJwSz8y5Wzc",
+                    "Sequence": 771391
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "7118386A4D8C55902FD814D62E2F4D7CE90E3B4F44E6B23CAD4C874B9A5771C9",
+                  "PreviousFields": {
+                    "Balance": "2048895453",
+                    "Sequence": 771390
+                  },
+                  "PreviousTxnID": "19EB03F21D86C9B225FB6ADACF489BF66C1482C3B05DAAD59C114965FB13A59C",
+                  "PreviousTxnLgrSeq": 22420570
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "ExchangeRate": "52230F211CBF3EFF",
+                    "Flags": 0,
+                    "RootIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF452230F211CBF3EFF",
+                    "TakerGetsCurrency": "0000000000000000000000004A50590000000000",
+                    "TakerGetsIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
+                    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                    "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF452230F211CBF3EFF"
+                }
+              },
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF4522334FBE4FC3668",
+                  "NewFields": {
+                    "ExchangeRate": "522334FBE4FC3668",
+                    "RootIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF4522334FBE4FC3668",
+                    "TakerGetsCurrency": "0000000000000000000000004A50590000000000",
+                    "TakerGetsIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
+                    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                    "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                  }
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Flags": 0,
+                    "Owner": "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG",
+                    "RootIndex": "A187A05FE957F5953846DF21A742F20FBFFACF3196D8FFEA85C3E062EA3B7A69"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "A187A05FE957F5953846DF21A742F20FBFFACF3196D8FFEA85C3E062EA3B7A69"
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "Account": "rUp8CvtneUUL6qYaxfZwUHg2cwYuo5jugG",
+                    "BookDirectory": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF452230F211CBF3EFF",
+                    "BookNode": "0000000000000000",
+                    "Flags": 0,
+                    "OwnerNode": "0000000000000000",
+                    "PreviousTxnID": "2073CD805F40D44BADD32EF138FE9782A5D9DF1E9C0700EA41C4D45163ED1FE6",
+                    "PreviousTxnLgrSeq": 22420569,
+                    "Sequence": 771388,
+                    "TakerGets": {
+                      "currency": "JPY",
+                      "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                      "value": "304004.98984125"
+                    },
+                    "TakerPays": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "3000"
+                    }
+                  },
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "F5ACC7F4D8253666AB5AF39E812107E7CFC5B7A686E7C24F560F84AA3150BDF0"
+                }
+              }
+            ],
+            "TransactionIndex": 0,
+            "TransactionResult": "tesSUCCESS"
+          }
+        },
+        {
+          "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+          "Expiration": 521226226,
+          "Fee": "30",
+          "Flags": 2147483648,
+          "LastLedgerSequence": 22420575,
+          "Sequence": 15817540,
+          "SigningPubKey": "034841BF24BD72C7CC371EBD87CCBF258D8ADB05C18DE207130364A97D8A3EA524",
+          "TakerGets": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "214"
+          },
+          "TakerPays": {
+            "currency": "JPY",
+            "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+            "value": "22148.5780242286"
+          },
+          "TransactionType": "OfferCreate",
+          "TxnSignature": "304402204DF95ADF23D6F5727E573BA085DDE08FB5B7AE9A23CF5709708FE190D87B851A02200C0D7F21C4F989C2B81171B11CE3224F7DB594A413C45CCA5E505ED86ED91418",
+          "hash": "54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "AccountTxnID": "54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5",
+                    "Balance": "2690753645214",
+                    "Flags": 0,
+                    "OwnerCount": 25,
+                    "RegularKey": "r9S56zu6QeJD5d8A7QMfLAeYavgB9dhaX4",
+                    "Sequence": 15817541
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "2880A9B4FB90A306B576C2D532BFE390AB3904642647DCF739492AA244EF46D1",
+                  "PreviousFields": {
+                    "AccountTxnID": "05408DE689A1D9454DE31BFE586F210C1AB78FBB71D5A096CDA7B453F9E8733C",
+                    "Balance": "2690753645244",
+                    "OwnerCount": 24,
+                    "Sequence": 15817540
+                  },
+                  "PreviousTxnID": "05408DE689A1D9454DE31BFE586F210C1AB78FBB71D5A096CDA7B453F9E8733C",
+                  "PreviousTxnLgrSeq": 22420573
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Flags": 0,
+                    "IndexPrevious": "00000000000022F7",
+                    "Owner": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "RootIndex": "F435FBBEC9654204D7151A01E686BAA8CB325A472D7B61C7916EA58B59355767"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "88048321517F5E225D2963BC749F9F9853D348679406839659056E67D2D374C9"
+                }
+              },
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "9422BBC577CBDD1ED2C13D4C7CC6581BB10EAC3E968D44C2D7FB98E15B2B37F3",
+                  "NewFields": {
+                    "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "BookDirectory": "FB9B9ED334DD7AFC1145AE485D86FB101C07F583CDE55EB95703AD4F200758D9",
+                    "Expiration": 521226226,
+                    "OwnerNode": "00000000000024CB",
+                    "Sequence": 15817540,
+                    "TakerGets": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "214"
+                    },
+                    "TakerPays": {
+                      "currency": "JPY",
+                      "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                      "value": "22148.5780242286"
+                    }
+                  }
+                }
+              },
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "FB9B9ED334DD7AFC1145AE485D86FB101C07F583CDE55EB95703AD4F200758D9",
+                  "NewFields": {
+                    "ExchangeRate": "5703AD4F200758D9",
+                    "RootIndex": "FB9B9ED334DD7AFC1145AE485D86FB101C07F583CDE55EB95703AD4F200758D9",
+                    "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                    "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                    "TakerPaysCurrency": "0000000000000000000000004A50590000000000",
+                    "TakerPaysIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098"
+                  }
+                }
+              }
+            ],
+            "TransactionIndex": 1,
+            "TransactionResult": "tesSUCCESS"
+          }
+        },
+        {
+          "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+          "Expiration": 521226226,
+          "Fee": "30",
+          "Flags": 2147483648,
+          "LastLedgerSequence": 22420575,
+          "OfferSequence": 15817525,
+          "Sequence": 15817541,
+          "SigningPubKey": "034841BF24BD72C7CC371EBD87CCBF258D8ADB05C18DE207130364A97D8A3EA524",
+          "TakerGets": {
+            "currency": "BTC",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "4.7"
+          },
+          "TakerPays": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "2954.92952861701"
+          },
+          "TransactionType": "OfferCreate",
+          "TxnSignature": "3045022100C63DFE5D3A27D42DC87439948C6692C0015B6891FC531F27A58ECA319D388FCF02202CE4E60D940E168250E612A45331134937AD71911DFF8C042FEBB91833332F94",
+          "hash": "5B79A66B1FD0619159783A8A85F43E14B159D91D3ACB36AEB954A101026BB68E",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "20046290D68FFFC3AC8DB8B725F2BF0FD4CBAF45C719C76245F247E9C7EDCBFE",
+                  "NewFields": {
+                    "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC9857165611D6A8983F",
+                    "Expiration": 521226226,
+                    "OwnerNode": "00000000000024CB",
+                    "Sequence": 15817541,
+                    "TakerGets": {
+                      "currency": "BTC",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "4.7"
+                    },
+                    "TakerPays": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "2954.92952861701"
+                    }
+                  }
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "AccountTxnID": "5B79A66B1FD0619159783A8A85F43E14B159D91D3ACB36AEB954A101026BB68E",
+                    "Balance": "2690753645184",
+                    "Flags": 0,
+                    "OwnerCount": 25,
+                    "RegularKey": "r9S56zu6QeJD5d8A7QMfLAeYavgB9dhaX4",
+                    "Sequence": 15817542
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "2880A9B4FB90A306B576C2D532BFE390AB3904642647DCF739492AA244EF46D1",
+                  "PreviousFields": {
+                    "AccountTxnID": "54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5",
+                    "Balance": "2690753645214",
+                    "Sequence": 15817541
+                  },
+                  "PreviousTxnID": "54DE214FAD77DB326E00100B0112612AC3D7BA3BE17C2AF3480CF919A13DA4A5",
+                  "PreviousTxnLgrSeq": 22420574
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985716571BD367C12A",
+                    "BookNode": "0000000000000000",
+                    "Expiration": 521226214,
+                    "Flags": 0,
+                    "OwnerNode": "00000000000024CB",
+                    "PreviousTxnID": "EB843063BD289BBFBD376602780A83F5CBA07AAADF65392683B9DE90E43B59C7",
+                    "PreviousTxnLgrSeq": 22420570,
+                    "Sequence": 15817525,
+                    "TakerGets": {
+                      "currency": "BTC",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "4.7"
+                    },
+                    "TakerPays": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "2955.46645977528"
+                    }
+                  },
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "3E26BB816F8D8FE43F01D10284AAC2A2E340AF8B20AD37B125C098A8BCAEF601"
+                }
+              },
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC9857165611D6A8983F",
+                  "NewFields": {
+                    "ExchangeRate": "57165611D6A8983F",
+                    "RootIndex": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC9857165611D6A8983F",
+                    "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                    "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                    "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                  }
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "ExchangeRate": "5716571BD367C12A",
+                    "Flags": 0,
+                    "RootIndex": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985716571BD367C12A",
+                    "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                    "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                    "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC985716571BD367C12A"
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Flags": 0,
+                    "IndexPrevious": "00000000000022F7",
+                    "Owner": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
+                    "RootIndex": "F435FBBEC9654204D7151A01E686BAA8CB325A472D7B61C7916EA58B59355767"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "88048321517F5E225D2963BC749F9F9853D348679406839659056E67D2D374C9"
+                }
+              }
+            ],
+            "TransactionIndex": 2,
+            "TransactionResult": "tesSUCCESS"
+          }
+        },
+        {
+          "Account": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX",
+          "Amount": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "10"
+          },
+          "Destination": "rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4",
+          "Fee": "10000",
+          "Flags": 131072,
+          "Sequence": 23295,
+          "SigningPubKey": "02B205F4B92351AC0EEB04254B636F4C49EF922CFA3CAAD03C6477DA1E04E94B53",
+          "TransactionType": "Payment",
+          "TxnSignature": "3045022100FAF247A836D601DE74A515B2AADE31186D8B0DA9C23DE489E09753F5CF4BB81F0220477C5B5BC3AC89F2347744F9E00CCA62267E198489D747578162C4C7D156211D",
+          "hash": "A0A074D10355223CBE2520A42F93A52E3CC8B4D692570EB4841084F9BBB39F7A",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX",
+                    "Balance": "1930599790",
+                    "Flags": 0,
+                    "OwnerCount": 2,
+                    "Sequence": 23296
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "267C16D24EC42EEF8B03D5BE4E94266B1675FA54AFCE42DE795E02AB61031CBD",
+                  "PreviousFields": {
+                    "Balance": "1930609790",
+                    "Sequence": 23295
+                  },
+                  "PreviousTxnID": "0F5396388E91D37BB26C8E24073A57E7C5D51E79AEE4CD855653B8499AE4E3DD",
+                  "PreviousTxnLgrSeq": 22419806
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Balance": {
+                      "currency": "USD",
+                      "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                      "value": "-9.980959751659681"
+                    },
+                    "Flags": 2228224,
+                    "HighLimit": {
+                      "currency": "USD",
+                      "issuer": "rNNuQMuExCiEjeZ4h9JJnj5PSWypdMXDj4",
+                      "value": "1000000"
+                    },
+                    "HighNode": "0000000000000000",
+                    "LowLimit": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "0"
+                    },
+                    "LowNode": "0000000000000423"
+                  },
+                  "LedgerEntryType": "RippleState",
+                  "LedgerIndex": "C66957AF25229357F9C2D2BA17CE47D88169788EDA7610AD0F29AD5BCB225EE5",
+                  "PreviousFields": {
+                    "Balance": {
+                      "currency": "USD",
+                      "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                      "value": "-0.0009198315"
+                    }
+                  },
+                  "PreviousTxnID": "2A01E994D7000000B43DD63825A081B4440A44AB2F6FA0D506158AC9CA6B2869",
+                  "PreviousTxnLgrSeq": 22420532
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Balance": {
+                      "currency": "USD",
+                      "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                      "value": "-276666.975959"
+                    },
+                    "Flags": 131072,
+                    "HighLimit": {
+                      "currency": "USD",
+                      "issuer": "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX",
+                      "value": "1000000"
+                    },
+                    "HighNode": "0000000000000000",
+                    "LowLimit": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "0"
+                    },
+                    "LowNode": "00000000000002D7"
+                  },
+                  "LedgerEntryType": "RippleState",
+                  "LedgerIndex": "FFD710AE2074A98D920D00CC352F25744899F069A6C1B9E31DD32D2C6606E615",
+                  "PreviousFields": {
+                    "Balance": {
+                      "currency": "USD",
+                      "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                      "value": "-276676.975959"
+                    }
+                  },
+                  "PreviousTxnID": "BB9DFC87E9D4ED09CA2726DDFE83A4A396ED0D6545536322DE17CDACF45C0D5B",
+                  "PreviousTxnLgrSeq": 22419307
+                }
+              }
+            ],
+            "DeliveredAmount": {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "9.980039920159681"
+            },
+            "TransactionIndex": 5,
+            "TransactionResult": "tesSUCCESS"
+          }
+        },
+        {
+          "Account": "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp",
+          "Fee": "10000",
+          "LastLedgerSequence": 22420577,
+          "Memos": [
+            {
+              "Memo": {
+                "MemoData": "535F72665F6A70795F7573645F746F6B796F5F6269745F6D6178696D23715F726970706C65",
+                "MemoType": "6F666665725F636F6D6D656E74"
+              }
+            }
+          ],
+          "OfferSequence": 1294409,
+          "Sequence": 1294410,
+          "SigningPubKey": "020D9B49DBB6583827CC36E86BF13EDFA600367BE26DB09759AD08890A13CD92F9",
+          "TakerGets": {
+            "currency": "JPY",
+            "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+            "value": "254121.4048342"
+          },
+          "TakerPays": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "2500"
+          },
+          "TransactionType": "OfferCreate",
+          "TxnSignature": "304402202EB6221AFBD704EF9E79C8DC69ED1B1B1219DB2239779A1B759CC9C42C759742022024C97FE2E4242C3B687416C1C518CDE1A06956347315B8AAFC45DE0CAC918FA6",
+          "hash": "B1B959CA2B3B46F07B2F1373C84E927C46B124E9728C79A2736F32AA3F2DB7FB",
+          "metaData": {
+            "AffectedNodes": [
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "Account": "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp",
+                    "BookDirectory": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222C6B99158DA5E",
+                    "BookNode": "0000000000000000",
+                    "Flags": 0,
+                    "OwnerNode": "0000000000000000",
+                    "PreviousTxnID": "050C1BD88A98FD6F5771EF04D76B1070FA9C3359FB3DB0F0E2518E0CB9BEE1FE",
+                    "PreviousTxnLgrSeq": 22420573,
+                    "Sequence": 1294409,
+                    "TakerGets": {
+                      "currency": "JPY",
+                      "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                      "value": "255397.84578255"
+                    },
+                    "TakerPays": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "2500"
+                    }
+                  },
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "1343E6606ABEBB1F9A67C509F0D6AD6BC8E5BB6233A52E1477C8B3EE9B56F22D"
+                }
+              },
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "Offer",
+                  "LedgerIndex": "1AE025735533090254CF26482318847923FF38E72606182926B36482D9D51C68",
+                  "NewFields": {
+                    "Account": "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp",
+                    "BookDirectory": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222F371609B8F32",
+                    "Sequence": 1294410,
+                    "TakerGets": {
+                      "currency": "JPY",
+                      "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN",
+                      "value": "254121.4048342"
+                    },
+                    "TakerPays": {
+                      "currency": "USD",
+                      "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                      "value": "2500"
+                    }
+                  }
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Account": "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp",
+                    "Balance": "2298060996",
+                    "Flags": 0,
+                    "OwnerCount": 24,
+                    "Sequence": 1294411
+                  },
+                  "LedgerEntryType": "AccountRoot",
+                  "LedgerIndex": "6F30F56C9326728173DD7A6FD9D3D84E5E4F95FE552D8F67C2C2BC154C596D53",
+                  "PreviousFields": {
+                    "Balance": "2298070996",
+                    "Sequence": 1294410
+                  },
+                  "PreviousTxnID": "050C1BD88A98FD6F5771EF04D76B1070FA9C3359FB3DB0F0E2518E0CB9BEE1FE",
+                  "PreviousTxnLgrSeq": 22420573
+                }
+              },
+              {
+                "DeletedNode": {
+                  "FinalFields": {
+                    "ExchangeRate": "5222C6B99158DA5E",
+                    "Flags": 0,
+                    "RootIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222C6B99158DA5E",
+                    "TakerGetsCurrency": "0000000000000000000000004A50590000000000",
+                    "TakerGetsIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
+                    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                    "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222C6B99158DA5E"
+                }
+              },
+              {
+                "CreatedNode": {
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222F371609B8F32",
+                  "NewFields": {
+                    "ExchangeRate": "5222F371609B8F32",
+                    "RootIndex": "95576C3354EA28D72B3A0D084DD6A45C45C2F47A64735CF45222F371609B8F32",
+                    "TakerGetsCurrency": "0000000000000000000000004A50590000000000",
+                    "TakerGetsIssuer": "5BBC0F22F61D9224A110650CFE21CC0C4BE13098",
+                    "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                    "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                  }
+                }
+              },
+              {
+                "ModifiedNode": {
+                  "FinalFields": {
+                    "Flags": 0,
+                    "Owner": "rMPJDVaiP1eY7QTy3qFKLyBJxry2vuD5Sp",
+                    "RootIndex": "987A5375A496B811965A54979A1E1A29F474CBA2D133F0587347B9B58E599666"
+                  },
+                  "LedgerEntryType": "DirectoryNode",
+                  "LedgerIndex": "987A5375A496B811965A54979A1E1A29F474CBA2D133F0587347B9B58E599666"
+                }
+              }
+            ],
+            "TransactionIndex": 3,
+            "TransactionResult": "tesSUCCESS"
+          }
+        }
+      ]
+    },
+    "ledger_hash": "4F6C0495378FF68A15749C0D51D097EB638DA70319FDAC7A97A27CE63E0BFFED",
+    "ledger_index": 100000,
+    "validated": true
+  }
+}

--- a/test/mock-rippled.js
+++ b/test/mock-rippled.js
@@ -205,6 +205,9 @@ module.exports = function createMockRippled(port) {
         createLedgerResponse(request, fixtures.ledger.withoutCloseTime));
     } else if (request.ledger_index === 4181996) {
       conn.send(createLedgerResponse(request, fixtures.ledger.withSettingsTx));
+    } else if (request.ledger_index === 100000) {
+      conn.send(
+        createLedgerResponse(request, fixtures.ledger.withPartialPayment));
     } else if (request.ledger_index === 38129) {
       const response = _.assign({}, fixtures.ledger.normal,
         {result: {ledger: fullLedger}});


### PR DESCRIPTION
ledger data from rippled includes meta.DeliveredAmount but not meta.delivered_amount, so it was not processed correctly on transactions coming from the 'getLedger' function vs. 'getTransaction'