### PR TITLE
Bump versions to build on nodejs 4.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "https-proxy-agent": "^1.0.0",
     "jayson": "^1.2.2",
     "lodash": "^3.1.0",
-    "ripple-address-codec": "^2.0.1",
+    "ripple-address-codec": "^2.0.2",
     "ripple-binary-codec": "^0.1.5",
     "ripple-hashes": "^0.2.0",
     "ripple-keypairs": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ripple-hashes": "^0.2.0",
     "ripple-keypairs": "^0.10.0",
     "ripple-lib-transactionparser": "^0.6.0",
-    "ws": "^1.0.1"
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",


### PR DESCRIPTION
Couldn't get other ripple components to build on 4.2.6 without bumping up the version of 'ws'.  Bumped the version of ripple-address-codec while I was at it.

Specifically bufferutil 1.1.0 doesn't build on anything newer than the 0.12 series, per:
https://github.com/websockets/bufferutil/issues/22