### PR TITLE
maxAmount must be excluded for XRP-to-XRP payments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+##Next Version to be released
+**Changes**
++ [Raise error when source.maxAmount is included for XRP to XRP transfer](<link here>)
+
 ##0.16.5
 **Changes**
 + [Filter insufficient source funds paths from pathfind results](https://github.com/ripple/ripple-lib/pull/688)

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,7 +339,7 @@ source | object | The source of the funds to be sent.
 *source.* address | [address](#ripple-address) | The address to send from.
 *source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
+*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount). Must be excluded for XRP-to-XRP payments.
 destination | object | The destination of the funds to be sent.
 *destination.* address | [address](#ripple-address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).
@@ -1674,7 +1674,7 @@ source | object | Properties of the source of the payment.
 *source.* address | [address](#ripple-address) | The address to send from.
 *source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
+*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount) Must be excluded for XRP-to-XRP payments.
 destination | object | Properties of the destination of the payment.
 *destination.* address | [address](#ripple-address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).

--- a/src/common/schemas/objects/max-adjustment.json
+++ b/src/common/schemas/objects/max-adjustment.json
@@ -9,7 +9,7 @@
     },
     "maxAmount": {
       "$ref": "laxAmount",
-      "description": "The maximum amount to send. (This field is exclusive with source.amount)"
+      "description": "The maximum amount to send. (This field is exclusive with source.amount).  Must be excluded for XRP-to-XRP payments."
     },
     "tag": {"$ref": "tag"}
   },

--- a/src/transaction/payment.js
+++ b/src/transaction/payment.js
@@ -72,6 +72,10 @@ function createPaymentTransaction(address: string, paymentArgument: Payment
   const payment = _.cloneDeep(paymentArgument)
   applyAnyCounterpartyEncoding(payment)
 
+  if (isXRPToXRPPayment(payment) && payment.source.maxAmount) {
+    throw new ValidationError('maxAmount should not be included for XRP to XRP payment');
+  }
+
   if (address !== payment.source.address) {
     throw new ValidationError('address must match payment.source.address')
   }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -79,6 +79,12 @@ describe('RippleAPI', function() {
           responses.preparePayment.minAmountXRPXRP, 'prepare'));
     });
 
+    it('preparePayment - xrp2xrp does not allow maxAmount', function() {
+      assert.throws(() => {
+        this.api.preparePayment(address, requests.preparePayment.xrp2xrpMaxAmount, instructions);
+      }, /maxAmount should not be included for XRP to XRP payment/);
+    });
+
     it('preparePayment - XRP to XRP no partial', function() {
       assert.throws(() => {
         this.api.preparePayment(address, requests.preparePayment.wrongPartial);

--- a/test/fixtures/requests/index.js
+++ b/test/fixtures/requests/index.js
@@ -18,7 +18,8 @@ module.exports = {
     wrongAmount: require('./prepare-payment-wrong-amount'),
     wrongPartial: require('./prepare-payment-wrong-partial'),
     allOptions: require('./prepare-payment-all-options'),
-    noCounterparty: require('./prepare-payment-no-counterparty')
+    noCounterparty: require('./prepare-payment-no-counterparty'),
+    xrp2xrpMaxAmount: require('./prepare-payment-xrp2xrp-max-amount')
   },
   prepareSettings: {
     domain: require('./prepare-settings'),

--- a/test/fixtures/requests/prepare-payment-all-options.json
+++ b/test/fixtures/requests/prepare-payment-all-options.json
@@ -1,7 +1,7 @@
 {
   "source": {
     "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "maxAmount": {
+    "amount": {
       "value": "0.01",
       "currency": "XRP"
     },
@@ -9,7 +9,7 @@
   },
   "destination": {
     "address": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-    "amount": {
+    "minAmount": {
       "value": "0.01",
       "currency": "XRP"
     },

--- a/test/fixtures/requests/prepare-payment-xrp2xrp-max-amount.json
+++ b/test/fixtures/requests/prepare-payment-xrp2xrp-max-amount.json
@@ -1,0 +1,29 @@
+{
+  "source": {
+    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+    "maxAmount": {
+      "value": "0.01",
+      "currency": "XRP"
+    },
+    "tag": 14
+  },
+  "destination": {
+    "address": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+    "amount": {
+      "value": "0.01",
+      "currency": "XRP"
+    },
+    "tag": 58
+  },
+  "memos": [
+    {
+      "type": "test",
+      "format": "plain/text",
+      "data": "texted data"
+    }
+  ],
+  "invoiceID": "A98FD36C17BE2B8511AD36DC335478E7E89F06262949F36EB88E2D683BBCC50A",
+  "noDirectRipple": true,
+  "limitQuality": true,
+  "paths": "[[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":49,\"type_hex\":\"0000000000000031\"},{\"currency\":\"LTC\",\"issuer\":\"rfYv1TXnwgDDK4WQNbFALykYuEBnrR4pDX\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rfYv1TXnwgDDK4WQNbFALykYuEBnrR4pDX\",\"currency\":\"LTC\",\"issuer\":\"rfYv1TXnwgDDK4WQNbFALykYuEBnrR4pDX\",\"type\":49,\"type_hex\":\"0000000000000031\"}]]"
+}


### PR DESCRIPTION
## Status
**READY**


## Description

[Payment](https://ripple.com/build/transactions/#payment) transactions can have an optional SendMax field, which "Must be omitted for XRP-to-XRP payments."

The payment object in ripple-lib's `preparePayment` method can have an optional `source.maxAmount`, which is intended to serve the same purpose as `SendMax`

https://github.com/ripple/ripple-lib/blob/develop/docs/index.md#payment
https://github.com/ripple/ripple-lib/blob/develop/docs/index.md#preparepayment

If `maxAmount` is provided for XRP to XRP payment, error will be thrown

## Steps to Test or Reproduce

```sh
git pull --prune
git checkout xrp_maxAmount_fix
```

1. npm test

![image](https://user-images.githubusercontent.com/1644883/29505409-024627d0-85fb-11e7-9da3-60a0c897fd92.png)


## Impacted Areas in Application

* XRP to XRP payment

## References
n/a
