### PR TITLE
Throw error when XRP-to-XRP payment has maxAmount (RLJS-591)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 + [Update ws dependency to 3.3.1](https://github.com/ripple/ripple-lib/pull/804)
++ Throw error when XRP-to-XRP payment has maxAmount. source.maxAmount must be omitted for XRP-to-XRP payments
 
 ## 0.17.8 (2017-11-06)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,7 +339,7 @@ source | object | The source of the funds to be sent.
 *source.* address | [address](#address) | The address to send from.
 *source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
+*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. This field is exclusive with source.amount. Must be omitted for XRP-to-XRP payments.
 destination | object | The destination of the funds to be sent.
 *destination.* address | [address](#address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).
@@ -1674,7 +1674,7 @@ source | object | Properties of the source of the payment.
 *source.* address | [address](#address) | The address to send from.
 *source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
+*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. This field is exclusive with source.amount. Must be omitted for XRP-to-XRP payments.
 destination | object | Properties of the destination of the payment.
 *destination.* address | [address](#address) | The address to receive at.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with destination.minAmount).

--- a/src/common/schemas/objects/max-adjustment.json
+++ b/src/common/schemas/objects/max-adjustment.json
@@ -9,7 +9,7 @@
     },
     "maxAmount": {
       "$ref": "laxAmount",
-      "description": "The maximum amount to send. (This field is exclusive with source.amount)"
+      "description": "The maximum amount to send. This field is exclusive with source.amount. Must be omitted for XRP-to-XRP payments."
     },
     "tag": {"$ref": "tag"}
   },

--- a/src/transaction/payment.js
+++ b/src/transaction/payment.js
@@ -82,6 +82,10 @@ function createPaymentTransaction(address: string, paymentArgument: Payment
       + 'and destination.amount) or (source.amount and destination.minAmount)')
   }
 
+  if (isXRPToXRPPayment(payment) && payment.source.maxAmount) {
+    throw new ValidationError('maxAmount must be omitted for XRP to XRP payments')
+  }
+
   // when using destination.minAmount, rippled still requires that we set
   // a destination amount in addition to DeliverMin. the destination amount
   // is interpreted as the maximum amount to send. we want to be sure to

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -54,11 +54,8 @@ describe('RippleAPI', function() {
   describe('preparePayment', function() {
 
     it('normal', function() {
-      const localInstructions = _.defaults({
-        maxFee: '0.000012'
-      }, instructions);
       return this.api.preparePayment(
-        address, requests.preparePayment.normal, localInstructions).then(
+        address, requests.preparePayment.normal, instructions).then(
         _.partial(checkResult, responses.preparePayment.normal, 'prepare'));
     });
 
@@ -83,6 +80,12 @@ describe('RippleAPI', function() {
       assert.throws(() => {
         this.api.preparePayment(address, requests.preparePayment.wrongPartial);
       }, /XRP to XRP payments cannot be partial payments/);
+    });
+
+    it('throws when maxAmount is specified for xrp2xrp payment', function() {
+      assert.throws(() => {
+        this.api.preparePayment(address, requests.preparePayment.xrp2xrpWithMaxAmount, instructions);
+      }, /maxAmount must be omitted for XRP to XRP payments/);
     });
 
     it('preparePayment - address must match payment.source.address', function(

--- a/test/fixtures/requests/index.js
+++ b/test/fixtures/requests/index.js
@@ -18,7 +18,8 @@ module.exports = {
     wrongAmount: require('./prepare-payment-wrong-amount'),
     wrongPartial: require('./prepare-payment-wrong-partial'),
     allOptions: require('./prepare-payment-all-options'),
-    noCounterparty: require('./prepare-payment-no-counterparty')
+    noCounterparty: require('./prepare-payment-no-counterparty'),
+    xrp2xrpWithMaxAmount: require('./prepare-payment-xrp2xrp-with-max-amount.json')
   },
   prepareSettings: {
     domain: require('./prepare-settings'),

--- a/test/fixtures/requests/prepare-payment-xrp2xrp-with-max-amount.json
+++ b/test/fixtures/requests/prepare-payment-xrp2xrp-with-max-amount.json
@@ -1,7 +1,7 @@
 {
   "source": {
     "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "amount": {
+    "maxAmount": {
       "value": "0.01",
       "currency": "XRP"
     },
@@ -9,7 +9,7 @@
   },
   "destination": {
     "address": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-    "minAmount": {
+    "amount": {
       "value": "0.01",
       "currency": "XRP"
     },


### PR DESCRIPTION
`maxAmount` ([SendMax](https://ripple.com/build/transactions/#payment)) must be omitted for XRP-to-XRP payments.