### PR TITLE
remove unneccessary double-polyfills from runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "test": "test"
   },
   "dependencies": {
-    "babel-polyfill": "^6.3.14",
-    "babel-runtime": "^6.3.19",
     "bignumber.js": "^4.1.0",
     "https-proxy-agent": "^1.0.0",
     "jsonschema": "^1.1.1",

--- a/src/api.js
+++ b/src/api.js
@@ -1,17 +1,6 @@
 /* @flow */
 'use strict' // eslint-disable-line strict
 
-/* eslint-disable max-len */
-// Enable core-js polyfills. This allows use of ES6/7 extensions listed here:
-// https://github.com/zloirock/core-js/blob/fb0890f32dabe8d4d88a4350d1b268446127132e/shim.js#L1-L103
-/* eslint-enable max-len */
-
-// In node.js env, polyfill might be already loaded (from any npm package),
-// that's why we do this check.
-if (!global._babelPolyfill) {
-  require('babel-polyfill')
-}
-
 const _ = require('lodash')
 const EventEmitter = require('events').EventEmitter
 const common = require('./common')

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,7 +786,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.26.0, babel-polyfill@^6.3.14:
+babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -868,7 +868,7 @@ babel-runtime@^5.8.20:
   dependencies:
     core-js "^1.0.0"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.3.19, babel-runtime@^6.6.1:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:


### PR DESCRIPTION
From the [babel-polyfill](https://babeljs.io/docs/usage/polyfill/) docs:

>Babel includes a polyfill that includes a custom regenerator runtime and core-js.
>
>This will emulate a full ES2015+ environment and is intended to be used in an application rather than a library/tool. This polyfill is automatically loaded when using babel-node.

ripple-lib is already using babel to transpile all advanced features and add necessary polyfills, so loading "babel-polyfill" additionally is unnecessary.  Worse, it means that all polyfills are being double-loaded and potentially double-executed.

Removing this line results in a much smaller build (`ripple-latest.js` 1.4MB vs 1.7MB) and a much faster load time (`require("./ripple-latest.js")` 267ms vs 337ms).

*Also removed "babel-runtime" dependency (no longer used) & some outdated comments.*