### PR TITLE
fix lint errors and configure eslintrc to automatically work /w tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,4 @@ out/
 # Ignore perf test cache
 scripts/cache
 
-eslintrc
+.eslintrc

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prepublish": "npm run clean && npm run compile",
     "test": "babel-node ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "lint": "if ! [ -f eslintrc ]; then curl -o eslintrc 'https://raw.githubusercontent.com/ripple/javascript-style-guide/es6/eslintrc'; echo 'parser: babel-eslint' >> eslintrc; fi; eslint -c eslintrc src/",
+    "lint": "if ! [ -f .eslintrc ]; then curl -o .eslintrc 'https://raw.githubusercontent.com/ripple/javascript-style-guide/es6/eslintrc'; echo 'parser: babel-eslint' >> .eslintrc; fi; eslint -c .eslintrc src/",
     "perf": "./scripts/perf_test.sh",
     "start": "babel-node scripts/http.js",
     "sauce": "babel-node scripts/sauce-runner.js"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -17,9 +17,9 @@ lint() {
   echo "eslint $(node_modules/.bin/eslint --version)"
   yarn list babel-eslint
   REPO_URL="https://raw.githubusercontent.com/ripple/javascript-style-guide"
-  curl "$REPO_URL/es6/eslintrc" > ./eslintrc
-  echo "parser: babel-eslint" >> ./eslintrc
-  node_modules/.bin/eslint -c ./eslintrc $(git --no-pager diff --name-only -M100% --diff-filter=AM --relative $(git merge-base FETCH_HEAD origin/HEAD) FETCH_HEAD | grep "\.js$")
+  curl "$REPO_URL/es6/eslintrc" > .eslintrc
+  echo "parser: babel-eslint" >> .eslintrc
+  node_modules/.bin/eslint -c .eslintrc $(git --no-pager diff --name-only -M100% --diff-filter=AM --relative $(git merge-base FETCH_HEAD origin/HEAD) FETCH_HEAD | grep "\.js$")
 }
 
 unittest() {

--- a/src/ledger/parse/escrow-creation.js
+++ b/src/ledger/parse/escrow-creation.js
@@ -1,6 +1,5 @@
 /* @flow */
 'use strict' // eslint-disable-line strict
-const _ = require('lodash')
 const assert = require('assert')
 const utils = require('./utils')
 const parseAmount = require('./amount')

--- a/src/ledger/parse/fields.js
+++ b/src/ledger/parse/fields.js
@@ -36,12 +36,14 @@ function parseFields(data: Object): Object {
       settings.signers.threshold = data.signer_lists[0].SignerQuorum
     }
     if (data.signer_lists[0].SignerEntries) {
-      settings.signers.weights = _.map(data.signer_lists[0].SignerEntries, entry => {
-        return {
-          address: entry.SignerEntry.Account,
-          weight: entry.SignerEntry.SignerWeight
-        }
-      })
+      settings.signers.weights = _.map(
+        data.signer_lists[0].SignerEntries,
+        entry => {
+          return {
+            address: entry.SignerEntry.Account,
+            weight: entry.SignerEntry.SignerWeight
+          }
+        })
     }
   }
   return settings

--- a/src/ledger/parse/payment-channel.js
+++ b/src/ledger/parse/payment-channel.js
@@ -1,6 +1,5 @@
 /* @flow */
 'use strict' // eslint-disable-line strict
-const _ = require('lodash')
 const utils = require('./utils')
 
 type PaymentChannelResponse = {

--- a/src/ledger/payment-channel.js
+++ b/src/ledger/payment-channel.js
@@ -1,9 +1,8 @@
 /* @flow */
 'use strict' // eslint-disable-line strict
-const _ = require('lodash')
 const utils = require('./utils')
 const parsePaymentChannel = require('./parse/payment-channel')
-const {validate, removeUndefined} = utils.common
+const {validate} = utils.common
 const NotFoundError = utils.common.errors.NotFoundError
 
 type PaymentChannel = {
@@ -34,15 +33,14 @@ type LedgerEntryResponse = {
 
 function formatResponse(response: LedgerEntryResponse) {
   if (response.node !== undefined &&
-      response.node.LedgerEntryType === 'PayChannel')
-  {
+    response.node.LedgerEntryType === 'PayChannel') {
     return parsePaymentChannel(response.node)
   } else {
     throw new NotFoundError('Payment channel ledger entry not found')
   }
 }
 
-function getPaymentChannel(id: string): Promise<PaymentChannelResponse> {
+function getPaymentChannel(id: string): Promise<PaymentChannel> {
   validate.getPaymentChannel({id})
 
   const request = {
@@ -52,7 +50,7 @@ function getPaymentChannel(id: string): Promise<PaymentChannelResponse> {
     ledger_index: 'validated'
   }
 
-  return this.connection.request(request).then(_.partial(formatResponse))
+  return this.connection.request(request).then(formatResponse)
 }
 
 module.exports = getPaymentChannel

--- a/src/offline/sign-payment-channel-claim.js
+++ b/src/offline/sign-payment-channel-claim.js
@@ -12,7 +12,7 @@ function signPaymentChannelClaim(channel: string, amount: string,
 
   const signingData = binary.encodeForSigningClaim({
     channel: channel,
-    amount: xrpToDrops(amount),
+    amount: xrpToDrops(amount)
   })
   return keypairs.sign(signingData, privateKey)
 }

--- a/src/offline/verify-payment-channel-claim.js
+++ b/src/offline/verify-payment-channel-claim.js
@@ -12,7 +12,7 @@ function verifyPaymentChannelClaim(channel: string, amount: string,
 
   const signingData = binary.encodeForSigningClaim({
     channel: channel,
-    amount: xrpToDrops(amount),
+    amount: xrpToDrops(amount)
   })
   return keypairs.verify(signingData, signature, publicKey)
 }

--- a/src/transaction/escrow-creation.js
+++ b/src/transaction/escrow-creation.js
@@ -5,7 +5,7 @@ const utils = require('./utils')
 const {validate, iso8601ToRippleTime, xrpToDrops} = utils.common
 const ValidationError = utils.common.errors.ValidationError
 import type {Instructions, Prepare} from './types.js'
-import type {Adjustment, MaxAdjustment, Memo} from '../common/types.js'
+import type {Memo} from '../common/types.js'
 
 type EscrowCreation = {
   amount: string,
@@ -25,7 +25,7 @@ function createEscrowCreationTransaction(account: string,
     TransactionType: 'EscrowCreate',
     Account: account,
     Destination: payment.destination,
-    Amount: xrpToDrops(payment.amount),
+    Amount: xrpToDrops(payment.amount)
   }
 
   if (payment.condition !== undefined) {


### PR DESCRIPTION
I was seeing some errors when I ran `lint`, this PR fixes them.

I love the automatic fetch of team linting config, I've never seen that before. But by writing it to `eslintrc` instead of the expected `.eslintrc`, automatic tooling (like Sublime and VSCode editor plugins) can't pick up the config. Your [style guide](https://github.com/ripple/javascript-style-guide) mentions the correct file location, so I'm assuming this was just a mistake and fixed it in this PR as well.