### PR TITLE
convert common.js modules to new standard ESM module syntax

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,56 +1,50 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
 
-const _ = require('lodash')
-const EventEmitter = require('events').EventEmitter
-const common = require('./common')
-const server = require('./server/server')
+import * as _ from 'lodash'
+import events from 'events'
+import {Connection, errors, validate} from './common'
+import * as server from './server/server'
 const connect = server.connect
 const disconnect = server.disconnect
 const getServerInfo = server.getServerInfo
 const getFee = server.getFee
 const isConnected = server.isConnected
 const getLedgerVersion = server.getLedgerVersion
-const getTransaction = require('./ledger/transaction')
-const getTransactions = require('./ledger/transactions')
-const getTrustlines = require('./ledger/trustlines')
-const getBalances = require('./ledger/balances')
-const getBalanceSheet = require('./ledger/balance-sheet')
-const getPaths = require('./ledger/pathfind')
-const getOrders = require('./ledger/orders')
-const getOrderbook = require('./ledger/orderbook')
-const getSettings = require('./ledger/settings')
-const getAccountInfo = require('./ledger/accountinfo')
-const getPaymentChannel = require('./ledger/payment-channel')
-const preparePayment = require('./transaction/payment')
-const prepareTrustline = require('./transaction/trustline')
-const prepareOrder = require('./transaction/order')
-const prepareOrderCancellation = require('./transaction/ordercancellation')
-const prepareEscrowCreation =
-  require('./transaction/escrow-creation')
-const prepareEscrowExecution =
-  require('./transaction/escrow-execution')
-const prepareEscrowCancellation =
-  require('./transaction/escrow-cancellation')
-const preparePaymentChannelCreate =
-  require('./transaction/payment-channel-create')
-const preparePaymentChannelFund =
-  require('./transaction/payment-channel-fund')
-const preparePaymentChannelClaim =
-  require('./transaction/payment-channel-claim')
-const prepareSettings = require('./transaction/settings')
-const sign = require('./transaction/sign')
-const combine = require('./transaction/combine')
-const submit = require('./transaction/submit')
-const errors = require('./common').errors
-const generateAddress =
-  require('./offline/generate-address').generateAddressAPI
-const computeLedgerHash = require('./offline/ledgerhash')
-const signPaymentChannelClaim =
-  require('./offline/sign-payment-channel-claim')
-const verifyPaymentChannelClaim =
-  require('./offline/verify-payment-channel-claim')
-const getLedger = require('./ledger/ledger')
+import getTransaction from './ledger/transaction'
+import getTransactions from './ledger/transactions'
+import getTrustlines from './ledger/trustlines'
+import getBalances from './ledger/balances'
+import getBalanceSheet from './ledger/balance-sheet'
+import getPaths from './ledger/pathfind'
+import getOrders from './ledger/orders'
+import getOrderbook from './ledger/orderbook'
+import getSettings from './ledger/settings'
+import getAccountInfo from './ledger/accountinfo'
+import getPaymentChannel from './ledger/payment-channel'
+import preparePayment from './transaction/payment'
+import prepareTrustline from './transaction/trustline'
+import prepareOrder from './transaction/order'
+import prepareOrderCancellation from './transaction/ordercancellation'
+import prepareEscrowCreation from './transaction/escrow-creation'
+import prepareEscrowExecution from './transaction/escrow-execution'
+import prepareEscrowCancellation from './transaction/escrow-cancellation'
+import preparePaymentChannelCreate from './transaction/payment-channel-create'
+import preparePaymentChannelFund from './transaction/payment-channel-fund'
+import preparePaymentChannelClaim from './transaction/payment-channel-claim'
+import prepareSettings from './transaction/settings'
+import sign from './transaction/sign'
+import combine from './transaction/combine'
+import submit from './transaction/submit'
+import {generateAddressAPI} from './offline/generate-address'
+import computeLedgerHash from './offline/ledgerhash'
+import signPaymentChannelClaim from './offline/sign-payment-channel-claim'
+import verifyPaymentChannelClaim from './offline/verify-payment-channel-claim'
+import getLedger from './ledger/ledger'
+
+
+import RangeSet from './common/rangeset'
+import * as ledgerUtils from './ledger/utils'
+import * as schemaValidator from './common/schema-validator'
 
 type APIOptions = {
   server?: string,
@@ -61,7 +55,7 @@ type APIOptions = {
 }
 
 // prevent access to non-validated ledger versions
-class RestrictedConnection extends common.Connection {
+class RestrictedConnection extends Connection {
   request(request, timeout) {
     const ledger_index = request.ledger_index
     if (ledger_index !== undefined && ledger_index !== 'validated') {
@@ -75,21 +69,21 @@ class RestrictedConnection extends common.Connection {
   }
 }
 
-class RippleAPI extends EventEmitter {
+class RippleAPI extends events.EventEmitter {
 
-  _feeCushion: number;
-  connection: RestrictedConnection;
+  _feeCushion: number
+  connection: RestrictedConnection
 
   // these are exposed only for use by unit tests; they are not part of the API.
   static _PRIVATE = {
-    validate: common.validate,
-    RangeSet: require('./common/rangeset').RangeSet,
-    ledgerUtils: require('./ledger/utils'),
-    schemaValidator: require('./common/schema-validator')
+    validate: validate,
+    RangeSet,
+    ledgerUtils,
+    schemaValidator
   };
 
   constructor(options: APIOptions = {}) {
-    common.validate.apiOptions(options)
+    validate.apiOptions(options)
     super()
     this._feeCushion = options.feeCushion || 1.2
     const serverURL = options.server
@@ -151,13 +145,13 @@ _.assign(RippleAPI.prototype, {
   combine,
   submit,
 
-  generateAddress,
+  generateAddress: generateAddressAPI,
   computeLedgerHash,
   signPaymentChannelClaim,
   verifyPaymentChannelClaim,
   errors
 })
 
-module.exports = {
+export {
   RippleAPI
 }

--- a/src/broadcast.js
+++ b/src/broadcast.js
@@ -1,6 +1,6 @@
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const RippleAPI = require('./api').RippleAPI
+
+import * as _ from 'lodash'
+import {RippleAPI} from './api'
 
 class RippleAPIBroadcast extends RippleAPI {
   constructor(servers, options) {
@@ -65,6 +65,6 @@ class RippleAPIBroadcast extends RippleAPI {
   }
 }
 
-module.exports = {
+export {
   RippleAPIBroadcast
 }

--- a/src/common/browser-hacks.js
+++ b/src/common/browser-hacks.js
@@ -1,10 +1,10 @@
-'use strict' // eslint-disable-line strict
+
 
 function setPrototypeOf(object, prototype) {
   // Object.setPrototypeOf not supported on Internet Explorer 9
   /* eslint-disable */
   Object.setPrototypeOf ? Object.setPrototypeOf(object, prototype) :
-    object.__proto__ = prototype;
+    object.__proto__ = prototype
   /* eslint-enable */
 }
 
@@ -15,7 +15,7 @@ function getConstructorName(object) {
     object.constructor.name
 }
 
-module.exports = {
+export {
   getConstructorName,
   setPrototypeOf
 }

--- a/src/common/connection.js
+++ b/src/common/connection.js
@@ -1,13 +1,13 @@
-'use strict' // eslint-disable-line strict
 
-const _ = require('lodash')
-const {EventEmitter} = require('events')
-const WebSocket = require('ws')
-const parseURL = require('url').parse
-const RangeSet = require('./rangeset').RangeSet
-const {RippledError, DisconnectedError, NotConnectedError,
+
+import * as _ from 'lodash'
+import events from 'events'
+import WebSocket from 'ws'
+import urlLib from 'url'
+import RangeSet from './rangeset'
+import {RippledError, DisconnectedError, NotConnectedError,
   TimeoutError, ResponseFormatError, ConnectionError,
-  RippledNotInitializedError} = require('./errors')
+  RippledNotInitializedError} from './errors'
 
 function isStreamMessageType(type) {
   return type === 'ledgerClosed' ||
@@ -15,7 +15,7 @@ function isStreamMessageType(type) {
          type === 'path_find'
 }
 
-class Connection extends EventEmitter {
+class Connection extends events.EventEmitter {
   constructor(url, options = {}) {
     super()
     this.setMaxListeners(Infinity)
@@ -226,8 +226,8 @@ class Connection extends EventEmitter {
   _createWebSocket() {
     const options = {}
     if (this._proxyURL !== undefined) {
-      const parsedURL = parseURL(this._url)
-      const parsedProxyURL = parseURL(this._proxyURL)
+      const parsedURL = urlLib.parse(this._url)
+      const parsedProxyURL = urlLib.parse(this._proxyURL)
       const proxyOverrides = _.omitBy({
         secureEndpoint: (parsedURL.protocol === 'wss:'),
         secureProxy: (parsedProxyURL.protocol === 'https:'),
@@ -446,4 +446,4 @@ class Connection extends EventEmitter {
   }
 }
 
-module.exports = Connection
+export default Connection

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,5 +1,5 @@
-'use strict' // eslint-disable-line strict
-const flagIndices = require('./txflags').txFlagIndices.AccountSet
+
+import {txFlagIndices} from './txflags'
 
 const accountRootFlags = {
   PasswordSpent: 0x00010000, // password set fee is spent
@@ -24,14 +24,14 @@ const AccountFlags = {
 }
 
 const AccountFlagIndices = {
-  requireDestinationTag: flagIndices.asfRequireDest,
-  requireAuthorization: flagIndices.asfRequireAuth,
-  disallowIncomingXRP: flagIndices.asfDisallowXRP,
-  disableMasterKey: flagIndices.asfDisableMaster,
-  enableTransactionIDTracking: flagIndices.asfAccountTxnID,
-  noFreeze: flagIndices.asfNoFreeze,
-  globalFreeze: flagIndices.asfGlobalFreeze,
-  defaultRipple: flagIndices.asfDefaultRipple
+  requireDestinationTag: txFlagIndices.AccountSet.asfRequireDest,
+  requireAuthorization: txFlagIndices.AccountSet.asfRequireAuth,
+  disallowIncomingXRP: txFlagIndices.AccountSet.asfDisallowXRP,
+  disableMasterKey: txFlagIndices.AccountSet.asfDisableMaster,
+  enableTransactionIDTracking: txFlagIndices.AccountSet.asfAccountTxnID,
+  noFreeze: txFlagIndices.AccountSet.asfNoFreeze,
+  globalFreeze: txFlagIndices.AccountSet.asfGlobalFreeze,
+  defaultRipple: txFlagIndices.AccountSet.asfDefaultRipple
 }
 
 const AccountFields = {
@@ -42,7 +42,7 @@ const AccountFields = {
   TransferRate: {name: 'transferRate', defaults: 0, shift: 9}
 }
 
-module.exports = {
+export {
   AccountFields,
   AccountFlagIndices,
   AccountFlags

--- a/src/common/errors.js
+++ b/src/common/errors.js
@@ -1,6 +1,6 @@
-'use strict' // eslint-disable-line strict
-const util = require('util')
-const browserHacks = require('./browser-hacks')
+
+import util from 'util'
+import * as browserHacks from './browser-hacks'
 
 // this is needed because extending builtins doesn't work in babel 6.x
 function extendableBuiltin(cls) {
@@ -80,7 +80,7 @@ class PendingLedgerVersionError extends RippleError {
   }
 }
 
-module.exports = {
+export {
   RippleError,
   UnexpectedError,
   ConnectionError,

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,22 +1,23 @@
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-
-module.exports = {
-  Connection: require('./connection'),
-  constants: require('./constants'),
-  errors: require('./errors'),
-  validate: require('./validate'),
-  txFlags: require('./txflags').txFlags,
-  serverInfo: require('./serverinfo'),
-  dropsToXrp: utils.dropsToXrp,
-  xrpToDrops: utils.xrpToDrops,
-  toRippledAmount: utils.toRippledAmount,
-  generateAddress: utils.generateAddress,
-  generateAddressAPI: utils.generateAddressAPI,
-  removeUndefined: utils.removeUndefined,
-  convertKeysFromSnakeCaseToCamelCase:
-    utils.convertKeysFromSnakeCaseToCamelCase,
-  iso8601ToRippleTime: utils.iso8601ToRippleTime,
-  rippleTimeToISO8601: utils.rippleTimeToISO8601,
-  isValidSecret: utils.isValidSecret
+import * as constants from './constants'
+import * as errors from './errors'
+import * as validate from './validate'
+import * as serverInfo from './serverinfo'
+export {
+  constants,
+  errors,
+  validate,
+  serverInfo
 }
+
+export {
+  dropsToXrp,
+  xrpToDrops,
+  toRippledAmount,
+  removeUndefined,
+  convertKeysFromSnakeCaseToCamelCase,
+  iso8601ToRippleTime,
+  rippleTimeToISO8601
+} from './utils'
+export {default as Connection} from './connection'
+export {txFlags} from './txflags'
+

--- a/src/common/rangeset.js
+++ b/src/common/rangeset.js
@@ -1,7 +1,7 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const assert = require('assert')
+
+import * as _ from 'lodash'
+import assert from 'assert'
 
 function mergeIntervals(intervals: Array<[number, number]>) {
   const stack = [[-Infinity, -Infinity]]
@@ -19,7 +19,7 @@ function mergeIntervals(intervals: Array<[number, number]>) {
 
 class RangeSet {
 
-  ranges: Array<[number, number]>;
+  ranges: Array<[number, number]>
 
   constructor() {
     this.reset()
@@ -60,4 +60,4 @@ class RangeSet {
   }
 }
 
-module.exports.RangeSet = RangeSet
+export default RangeSet

--- a/src/common/schema-validator.js
+++ b/src/common/schema-validator.js
@@ -1,12 +1,12 @@
 // flow is disabled for this file until support for requiring json is added:
 // https://github.com/facebook/flow/issues/167
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const assert = require('assert')
-const Validator = require('jsonschema').Validator
-const ValidationError = require('./errors').ValidationError
-const {isValidAddress} = require('ripple-address-codec')
-const {isValidSecret} = require('./utils')
+
+import * as _ from 'lodash'
+import assert from 'assert'
+import {Validator} from 'jsonschema'
+import {ValidationError} from './errors'
+import {isValidAddress} from 'ripple-address-codec'
+import {isValidSecret} from './utils'
 
 function loadSchemas() {
   // listed explicitly for webpack (instead of scanning schemas directory)
@@ -150,7 +150,7 @@ function schemaValidate(schemaName: string, object: any): void {
   }
 }
 
-module.exports = {
+export {
   schemaValidate,
   isValidSecret
 }

--- a/src/common/serverinfo.js
+++ b/src/common/serverinfo.js
@@ -1,7 +1,6 @@
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const {convertKeysFromSnakeCaseToCamelCase} = require('./utils')
-import type {Connection} from './connection'
+import * as _ from 'lodash'
+import {convertKeysFromSnakeCaseToCamelCase} from './utils'
+import type Connection from './connection'
 
 export type GetServerInfoResponse = {
   buildVersion: string,
@@ -73,7 +72,7 @@ function getFee(connection: Connection, cushion: number) {
     _.partial(computeFeeFromServerInfo, cushion))
 }
 
-module.exports = {
+export {
   getServerInfo,
   getFee
 }

--- a/src/common/txflags.js
+++ b/src/common/txflags.js
@@ -1,4 +1,4 @@
-'use strict' // eslint-disable-line strict
+
 
 const txFlags = {
   // Universal flags can apply to any transaction type
@@ -59,7 +59,7 @@ const txFlagIndices = {
   }
 }
 
-module.exports = {
+export {
   txFlags,
   txFlagIndices
 }

--- a/src/common/types.js
+++ b/src/common/types.js
@@ -1,5 +1,5 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
+
 
 export type RippledAmountIOU = {
   currency: string,

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,10 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const BigNumber = require('bignumber.js')
-const {deriveKeypair} = require('ripple-keypairs')
 
-import type {Amount, RippledAmount} from './types.js'
+import * as _ from 'lodash'
+import BigNumber from 'bignumber.js'
+import {deriveKeypair} from 'ripple-keypairs'
+
+import type {Amount, RippledAmount} from './types'
 
 function isValidSecret(secret: string): boolean {
   try {
@@ -82,7 +82,7 @@ function iso8601ToRippleTime(iso8601: string): number {
   return unixToRippleTimestamp(Date.parse(iso8601))
 }
 
-module.exports = {
+export {
   dropsToXrp,
   xrpToDrops,
   toRippledAmount,
@@ -92,3 +92,4 @@ module.exports = {
   iso8601ToRippleTime,
   isValidSecret
 }
+

--- a/src/common/validate.js
+++ b/src/common/validate.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const ValidationError = require('./errors').ValidationError
-const schemaValidate = require('./schema-validator').schemaValidate
+
+import * as _ from 'lodash'
+import {ValidationError} from './errors'
+import {schemaValidate} from './schema-validator'
 
 function error(text) {
   return new ValidationError(text)
@@ -22,46 +22,98 @@ function validateOptions(schema, instance) {
   validateLedgerRange(instance.options)
 }
 
-module.exports = {
-  getPaths: _.partial(schemaValidate, 'getPathsParameters'),
-  getTransactions: _.partial(validateOptions, 'getTransactionsParameters'),
-  getSettings: _.partial(validateOptions, 'getSettingsParameters'),
-  getAccountInfo: _.partial(validateOptions, 'getAccountInfoParameters'),
-  getTrustlines: _.partial(validateOptions, 'getTrustlinesParameters'),
-  getBalances: _.partial(validateOptions, 'getBalancesParameters'),
-  getBalanceSheet: _.partial(validateOptions, 'getBalanceSheetParameters'),
-  getOrders: _.partial(validateOptions, 'getOrdersParameters'),
-  getOrderbook: _.partial(validateOptions, 'getOrderbookParameters'),
-  getTransaction: _.partial(validateOptions, 'getTransactionParameters'),
-  getPaymentChannel: _.partial(validateOptions, 'getPaymentChannelParameters'),
-  getLedger: _.partial(validateOptions, 'getLedgerParameters'),
-  preparePayment: _.partial(schemaValidate, 'preparePaymentParameters'),
-  prepareOrder: _.partial(schemaValidate, 'prepareOrderParameters'),
-  prepareOrderCancellation:
-    _.partial(schemaValidate, 'prepareOrderCancellationParameters'),
-  prepareTrustline: _.partial(schemaValidate, 'prepareTrustlineParameters'),
-  prepareSettings: _.partial(schemaValidate, 'prepareSettingsParameters'),
-  prepareEscrowCreation: _.partial(schemaValidate,
-    'prepareEscrowCreationParameters'),
-  prepareEscrowCancellation: _.partial(schemaValidate,
-    'prepareEscrowCancellationParameters'),
-  prepareEscrowExecution: _.partial(schemaValidate,
-    'prepareEscrowExecutionParameters'),
-  preparePaymentChannelCreate: _.partial(schemaValidate,
-    'preparePaymentChannelCreateParameters'),
-  preparePaymentChannelFund: _.partial(schemaValidate,
-    'preparePaymentChannelFundParameters'),
-  preparePaymentChannelClaim: _.partial(schemaValidate,
-    'preparePaymentChannelClaimParameters'),
-  sign: _.partial(schemaValidate, 'signParameters'),
-  combine: _.partial(schemaValidate, 'combineParameters'),
-  submit: _.partial(schemaValidate, 'submitParameters'),
-  computeLedgerHash: _.partial(schemaValidate, 'computeLedgerHashParameters'),
-  generateAddress: _.partial(schemaValidate, 'generateAddressParameters'),
-  signPaymentChannelClaim: _.partial(schemaValidate,
-    'signPaymentChannelClaimParameters'),
-  verifyPaymentChannelClaim: _.partial(schemaValidate,
-    'verifyPaymentChannelClaimParameters'),
-  apiOptions: _.partial(schemaValidate, 'api-options'),
-  instructions: _.partial(schemaValidate, 'instructions')
-}
+export const getPaths =
+  _.partial(schemaValidate, 'getPathsParameters')
+
+export const getTransactions =
+_.partial(validateOptions, 'getTransactionsParameters')
+
+export const getSettings =
+_.partial(validateOptions, 'getSettingsParameters')
+
+export const getAccountInfo =
+_.partial(validateOptions, 'getAccountInfoParameters')
+
+export const getTrustlines =
+_.partial(validateOptions, 'getTrustlinesParameters')
+
+export const getBalances =
+_.partial(validateOptions, 'getBalancesParameters')
+
+export const getBalanceSheet =
+_.partial(validateOptions, 'getBalanceSheetParameters')
+
+export const getOrders =
+_.partial(validateOptions, 'getOrdersParameters')
+
+export const getOrderbook =
+_.partial(validateOptions, 'getOrderbookParameters')
+
+export const getTransaction =
+_.partial(validateOptions, 'getTransactionParameters')
+
+export const getPaymentChannel =
+_.partial(validateOptions, 'getPaymentChannelParameters')
+
+export const getLedger =
+_.partial(validateOptions, 'getLedgerParameters')
+
+export const preparePayment =
+_.partial(schemaValidate, 'preparePaymentParameters')
+
+export const prepareOrder =
+_.partial(schemaValidate, 'prepareOrderParameters')
+
+export const prepareOrderCancellation =
+_.partial(schemaValidate, 'prepareOrderCancellationParameters')
+
+export const prepareTrustline =
+_.partial(schemaValidate, 'prepareTrustlineParameters')
+
+export const prepareSettings =
+_.partial(schemaValidate, 'prepareSettingsParameters')
+
+export const prepareEscrowCreation =
+_.partial(schemaValidate, 'prepareEscrowCreationParameters')
+
+export const prepareEscrowCancellation =
+_.partial(schemaValidate, 'prepareEscrowCancellationParameters')
+
+export const prepareEscrowExecution =
+_.partial(schemaValidate, 'prepareEscrowExecutionParameters')
+
+export const preparePaymentChannelCreate =
+_.partial(schemaValidate, 'preparePaymentChannelCreateParameters')
+
+export const preparePaymentChannelFund =
+_.partial(schemaValidate, 'preparePaymentChannelFundParameters')
+
+export const preparePaymentChannelClaim =
+_.partial(schemaValidate, 'preparePaymentChannelClaimParameters')
+
+export const sign =
+_.partial(schemaValidate, 'signParameters')
+
+export const combine =
+_.partial(schemaValidate, 'combineParameters')
+
+export const submit =
+_.partial(schemaValidate, 'submitParameters')
+
+export const computeLedgerHash =
+_.partial(schemaValidate, 'computeLedgerHashParameters')
+
+export const generateAddress =
+_.partial(schemaValidate, 'generateAddressParameters')
+
+export const signPaymentChannelClaim =
+_.partial(schemaValidate, 'signPaymentChannelClaimParameters')
+
+export const verifyPaymentChannelClaim =
+_.partial(schemaValidate, 'verifyPaymentChannelClaimParameters')
+
+export const apiOptions =
+_.partial(schemaValidate, 'api-options')
+
+export const instructions =
+_.partial(schemaValidate, 'instructions')

--- a/src/common/wswrapper.js
+++ b/src/common/wswrapper.js
@@ -1,6 +1,6 @@
-'use strict' // eslint-disable-line strict
 
-const {EventEmitter} = require('events')
+
+import events from 'events'
 
 function unsused() {}
 
@@ -8,7 +8,7 @@ function unsused() {}
  * Provides `EventEmitter` interface for native browser `WebSocket`,
  * same, as `ws` package provides.
  */
-class WSWrapper extends EventEmitter {
+class WSWrapper extends events.EventEmitter {
   constructor(url, protocols = null, websocketOptions = {}) {
     super()
     unsused(protocols)
@@ -55,5 +55,5 @@ WSWrapper.OPEN = 1
 WSWrapper.CLOSING = 2
 WSWrapper.CLOSED = 3
 
-module.exports = WSWrapper
+export default WSWrapper
 

--- a/src/http.js
+++ b/src/http.js
@@ -1,11 +1,9 @@
 /* eslint-disable new-cap */
-'use strict' // eslint-disable-line strict
 
-const assert = require('assert')
-const _ = require('lodash')
-const jayson = require('jayson')
-
-const RippleAPI = require('./api').RippleAPI
+import assert from 'assert'
+import * as _ from 'lodash'
+import jayson from 'jayson'
+import {RippleAPI} from './api'
 
 
 /* istanbul ignore next */
@@ -81,6 +79,6 @@ function createHTTPServer(options, httpPort) {
   }
 }
 
-module.exports = {
+export {
   createHTTPServer
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
-'use strict' // eslint-disable-line strict
 
-module.exports = {
-  RippleAPI: require('./api').RippleAPI,
-  // Broadcast api is experimental
-  RippleAPIBroadcast: require('./broadcast').RippleAPIBroadcast
-}
+
+export {RippleAPI} from './api'
+// Broadcast api is experimental
+export {RippleAPIBroadcast} from './broadcast'

--- a/src/ledger/accountinfo.js
+++ b/src/ledger/accountinfo.js
@@ -1,8 +1,6 @@
 /* @flow */
 
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const {validate, removeUndefined} = utils.common
+import {validate, removeUndefined, dropsToXrp} from '../common'
 
 type AccountData = {
   Sequence: number,
@@ -42,7 +40,7 @@ function formatAccountInfo(response: AccountDataResponse) {
   const data = response.account_data
   return removeUndefined({
     sequence: data.Sequence,
-    xrpBalance: utils.common.dropsToXrp(data.Balance),
+    xrpBalance: dropsToXrp(data.Balance),
     ownerCount: data.OwnerCount,
     previousInitiatedTransactionID: data.AccountTxnID,
     previousAffectingTransactionID: data.PreviousTxnID,
@@ -63,4 +61,4 @@ function getAccountInfo(address: string, options: AccountInfoOptions = {}
   return this.connection.request(request).then(formatAccountInfo)
 }
 
-module.exports = getAccountInfo
+export default getAccountInfo

--- a/src/ledger/balance-sheet.js
+++ b/src/ledger/balance-sheet.js
@@ -1,10 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
 
-const _ = require('lodash')
-const utils = require('./utils')
-const {validate} = utils.common
-import type {Amount} from '../common/types.js'
+import * as _ from 'lodash'
+import * as utils from './utils'
+import {validate} from '../common'
+import type {Amount} from '../common/types'
 
 type BalanceSheetOptions = {
   excludeAddresses?: Array<string>,
@@ -64,4 +63,4 @@ function getBalanceSheet(address: string, options: BalanceSheetOptions = {}
   })
 }
 
-module.exports = getBalanceSheet
+export default getBalanceSheet

--- a/src/ledger/balances.js
+++ b/src/ledger/balances.js
@@ -1,9 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const {validate} = utils.common
-import type {Connection} from '../common/connection.js'
-import type {TrustlinesOptions, Trustline} from './trustlines-types.js'
+
+import * as utils from './utils'
+import {validate} from '../common'
+import type {Connection} from '../common'
+import type {TrustlinesOptions, Trustline} from './trustlines-types'
 
 
 type Balance = {
@@ -61,4 +61,4 @@ function getBalances(address: string, options: TrustlinesOptions = {}
     formatBalances(options, {xrp: results[0], trustlines: results[1]}))
 }
 
-module.exports = getBalances
+export default getBalances

--- a/src/ledger/ledger.js
+++ b/src/ledger/ledger.js
@@ -1,9 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const {validate} = utils.common
-const parseLedger = require('./parse/ledger')
-import type {GetLedger} from './types.js'
+
+import {validate} from '../common'
+import parseLedger from './parse/ledger'
+import type {GetLedger} from './types'
 
 type LedgerOptions = {
   ledgerVersion?: number,
@@ -28,4 +27,4 @@ function getLedger(options: LedgerOptions = {}): Promise<GetLedger> {
     parseLedger(response.ledger))
 }
 
-module.exports = getLedger
+export default getLedger

--- a/src/ledger/orderbook.js
+++ b/src/ledger/orderbook.js
@@ -1,12 +1,12 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const {validate} = utils.common
-const parseOrderbookOrder = require('./parse/orderbook-order')
-import type {Connection} from '../common/connection.js'
-import type {OrdersOptions, OrderSpecification} from './types.js'
-import type {Amount, Issue} from '../common/types.js'
+
+import * as _ from 'lodash'
+import * as utils from './utils'
+import parseOrderbookOrder from './parse/orderbook-order'
+import {validate} from '../common'
+import type {Connection} from '../common'
+import type {OrdersOptions, OrderSpecification} from './types'
+import type {Amount, Issue} from '../common/types'
 
 type Orderbook = {
   base: Issue,
@@ -104,4 +104,4 @@ function getOrderbook(address: string, orderbook: Orderbook,
     formatBidsAndAsks(orderbook, _.flatten(data)))
 }
 
-module.exports = getOrderbook
+export default getOrderbook

--- a/src/ledger/orders.js
+++ b/src/ledger/orders.js
@@ -1,11 +1,11 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const {validate} = utils.common
-const parseAccountOrder = require('./parse/account-order')
-import type {Connection} from '../common/connection.js'
-import type {OrdersOptions, Order} from './types.js'
+
+import * as _ from 'lodash'
+import * as utils from './utils'
+import {validate} from '../common'
+import type {Connection} from '../common'
+import parseAccountOrder from './parse/account-order'
+import type {OrdersOptions, Order} from './types'
 
 type GetOrders = Array<Order>
 
@@ -38,4 +38,4 @@ function getOrders(address: string, options: OrdersOptions = {}
   })
 }
 
-module.exports = getOrders
+export default getOrders

--- a/src/ledger/parse/account-trustline.js
+++ b/src/ledger/parse/account-trustline.js
@@ -1,6 +1,7 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
+
+import {parseQuality} from './utils'
+import {removeUndefined} from '../../common'
 
 type Trustline = {
   account: string, limit: number, currency: string, quality_in: ?number,
@@ -20,18 +21,18 @@ type AccountTrustline = {
 // rippled 'account_lines' returns a different format for
 // trustlines than 'tx'
 function parseAccountTrustline(trustline: Trustline): AccountTrustline {
-  const specification = utils.removeUndefined({
+  const specification = removeUndefined({
     limit: trustline.limit,
     currency: trustline.currency,
     counterparty: trustline.account,
-    qualityIn: utils.parseQuality(trustline.quality_in) || undefined,
-    qualityOut: utils.parseQuality(trustline.quality_out) || undefined,
+    qualityIn: parseQuality(trustline.quality_in) || undefined,
+    qualityOut: parseQuality(trustline.quality_out) || undefined,
     ripplingDisabled: trustline.no_ripple || undefined,
     frozen: trustline.freeze || undefined,
     authorized: trustline.authorized || undefined
   })
   // rippled doesn't provide the counterparty's qualities
-  const counterparty = utils.removeUndefined({
+  const counterparty = removeUndefined({
     limit: trustline.limit_peer,
     ripplingDisabled: trustline.no_ripple_peer || undefined,
     frozen: trustline.freeze_peer || undefined,
@@ -43,4 +44,4 @@ function parseAccountTrustline(trustline: Trustline): AccountTrustline {
   return {specification, counterparty, state}
 }
 
-module.exports = parseAccountTrustline
+export default parseAccountTrustline

--- a/src/ledger/parse/amendment.js
+++ b/src/ledger/parse/amendment.js
@@ -1,4 +1,4 @@
-'use strict' // eslint-disable-line strict
+
 
 function parseAmendment(tx: Object) {
   return {
@@ -6,4 +6,4 @@ function parseAmendment(tx: Object) {
   }
 }
 
-module.exports = parseAmendment
+export default parseAmendment

--- a/src/ledger/parse/amount.js
+++ b/src/ledger/parse/amount.js
@@ -1,14 +1,14 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('../utils')
-import type {Amount, RippledAmount} from '../../common/types.js'
+
+import * as common from '../../common'
+import type {Amount, RippledAmount} from '../../common/types'
 
 
 function parseAmount(amount: RippledAmount): Amount {
   if (typeof amount === 'string') {
     return {
       currency: 'XRP',
-      value: utils.common.dropsToXrp(amount)
+      value: common.dropsToXrp(amount)
     }
   }
   return {
@@ -18,4 +18,4 @@ function parseAmount(amount: RippledAmount): Amount {
   }
 }
 
-module.exports = parseAmount
+export default parseAmount

--- a/src/ledger/parse/cancellation.js
+++ b/src/ledger/parse/cancellation.js
@@ -1,6 +1,6 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
+
+import assert from 'assert'
 
 function parseOrderCancellation(tx: Object): Object {
   assert(tx.TransactionType === 'OfferCancel')
@@ -9,4 +9,4 @@ function parseOrderCancellation(tx: Object): Object {
   }
 }
 
-module.exports = parseOrderCancellation
+export default parseOrderCancellation

--- a/src/ledger/parse/escrow-cancellation.js
+++ b/src/ledger/parse/escrow-cancellation.js
@@ -1,16 +1,17 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
+
+import assert from 'assert'
+import {parseMemos} from './utils'
+import {removeUndefined} from '../../common'
 
 function parseEscrowCancellation(tx: Object): Object {
   assert(tx.TransactionType === 'EscrowCancel')
 
-  return utils.removeUndefined({
-    memos: utils.parseMemos(tx),
+  return removeUndefined({
+    memos: parseMemos(tx),
     owner: tx.Owner,
     escrowSequence: tx.OfferSequence
   })
 }
 
-module.exports = parseEscrowCancellation
+export default parseEscrowCancellation

--- a/src/ledger/parse/escrow-creation.js
+++ b/src/ledger/parse/escrow-creation.js
@@ -1,22 +1,23 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const parseAmount = require('./amount')
+
+import assert from 'assert'
+import parseAmount from './amount'
+import {parseTimestamp, parseMemos} from './utils'
+import {removeUndefined} from '../../common'
 
 function parseEscrowCreation(tx: Object): Object {
   assert(tx.TransactionType === 'EscrowCreate')
 
-  return utils.removeUndefined({
+  return removeUndefined({
     amount: parseAmount(tx.Amount).value,
     destination: tx.Destination,
-    memos: utils.parseMemos(tx),
+    memos: parseMemos(tx),
     condition: tx.Condition,
-    allowCancelAfter: utils.parseTimestamp(tx.CancelAfter),
-    allowExecuteAfter: utils.parseTimestamp(tx.FinishAfter),
+    allowCancelAfter: parseTimestamp(tx.CancelAfter),
+    allowExecuteAfter: parseTimestamp(tx.FinishAfter),
     sourceTag: tx.SourceTag,
     destinationTag: tx.DestinationTag
   })
 }
 
-module.exports = parseEscrowCreation
+export default parseEscrowCreation

--- a/src/ledger/parse/escrow-execution.js
+++ b/src/ledger/parse/escrow-execution.js
@@ -1,13 +1,14 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
+
+import assert from 'assert'
+import {parseMemos} from './utils'
+import {removeUndefined} from '../../common'
 
 function parseEscrowExecution(tx: Object): Object {
   assert(tx.TransactionType === 'EscrowFinish')
 
-  return utils.removeUndefined({
-    memos: utils.parseMemos(tx),
+  return removeUndefined({
+    memos: parseMemos(tx),
     owner: tx.Owner,
     escrowSequence: tx.OfferSequence,
     condition: tx.Condition,
@@ -15,4 +16,4 @@ function parseEscrowExecution(tx: Object): Object {
   })
 }
 
-module.exports = parseEscrowExecution
+export default parseEscrowExecution

--- a/src/ledger/parse/fee-update.js
+++ b/src/ledger/parse/fee-update.js
@@ -1,6 +1,6 @@
-'use strict' // eslint-disable-line strict
-const BigNumber = require('bignumber.js')
-const {dropsToXrp} = require('./utils')
+
+import BigNumber from 'bignumber.js'
+import {dropsToXrp} from '../../common'
 
 function parseFeeUpdate(tx: Object) {
   const baseFeeDrops = (new BigNumber(tx.BaseFee, 16)).toString()
@@ -12,4 +12,4 @@ function parseFeeUpdate(tx: Object) {
   }
 }
 
-module.exports = parseFeeUpdate
+export default parseFeeUpdate

--- a/src/ledger/parse/fields.js
+++ b/src/ledger/parse/fields.js
@@ -1,8 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const BigNumber = require('bignumber.js')
-const AccountFields = require('./utils').constants.AccountFields
+
+import * as _ from 'lodash'
+import BigNumber from 'bignumber.js'
+import {constants} from '../../common'
+const AccountFields = constants.AccountFields
 
 function parseField(info, value) {
   if (info.encoding === 'hex' && !info.length) { // e.g. "domain"
@@ -49,4 +50,4 @@ function parseFields(data: Object): Object {
   return settings
 }
 
-module.exports = parseFields
+export default parseFields

--- a/src/ledger/parse/flags.js
+++ b/src/ledger/parse/flags.js
@@ -1,4 +1,4 @@
-'use strict' // eslint-disable-line strict
+
 
 const orderFlags = {
   Passive: 0x00010000,
@@ -16,7 +16,7 @@ const trustlineFlags = {
   HighFreeze: 0x00800000
 }
 
-module.exports = {
+export {
   orderFlags,
   trustlineFlags
 }

--- a/src/ledger/parse/ledger.js
+++ b/src/ledger/parse/ledger.js
@@ -1,9 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const {removeUndefined, rippleTimeToISO8601} = require('./utils')
-const parseTransaction = require('./transaction')
-import type {GetLedger} from '../types.js'
+
+import * as _ from 'lodash'
+import {removeUndefined, rippleTimeToISO8601} from '../../common'
+import parseTransaction from './transaction'
+import type {GetLedger} from '../types'
 
 function parseTransactionWrapper(ledgerVersion, tx) {
   const transaction = _.assign({}, _.omit(tx, 'metaData'), {
@@ -60,4 +60,4 @@ function parseLedger(ledger: Object): GetLedger {
   ))
 }
 
-module.exports = parseLedger
+export default parseLedger

--- a/src/ledger/parse/order.js
+++ b/src/ledger/parse/order.js
@@ -1,9 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const parseAmount = require('./amount')
-const flags = utils.txFlags.OfferCreate
+
+import assert from 'assert'
+import {parseTimestamp} from './utils'
+import parseAmount from './amount'
+import {removeUndefined, txFlags} from '../../common'
+const flags = txFlags.OfferCreate
 
 function parseOrder(tx: Object): Object {
   assert(tx.TransactionType === 'OfferCreate')
@@ -14,7 +15,7 @@ function parseOrder(tx: Object): Object {
   const quantity = (direction === 'buy') ? takerPaysAmount : takerGetsAmount
   const totalPrice = (direction === 'buy') ? takerGetsAmount : takerPaysAmount
 
-  return utils.removeUndefined({
+  return removeUndefined({
     direction: direction,
     quantity: quantity,
     totalPrice: totalPrice,
@@ -22,8 +23,8 @@ function parseOrder(tx: Object): Object {
     immediateOrCancel: ((tx.Flags & flags.ImmediateOrCancel) !== 0)
       || undefined,
     fillOrKill: ((tx.Flags & flags.FillOrKill) !== 0) || undefined,
-    expirationTime: utils.parseTimestamp(tx.Expiration)
+    expirationTime: parseTimestamp(tx.Expiration)
   })
 }
 
-module.exports = parseOrder
+export default parseOrder

--- a/src/ledger/parse/orderbook-order.js
+++ b/src/ledger/parse/orderbook-order.js
@@ -1,12 +1,14 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const flags = require('./flags').orderFlags
-const parseAmount = require('./amount')
+
+import * as _ from 'lodash'
+import {parseTimestamp, adjustQualityForXRP} from './utils'
+import {removeUndefined} from '../../common'
+
+import {orderFlags} from './flags'
+import parseAmount from './amount'
 
 function parseOrderbookOrder(order: Object): Object {
-  const direction = (order.Flags & flags.Sell) === 0 ? 'buy' : 'sell'
+  const direction = (order.Flags & orderFlags.Sell) === 0 ? 'buy' : 'sell'
   const takerGetsAmount = parseAmount(order.TakerGets)
   const takerPaysAmount = parseAmount(order.TakerPays)
   const quantity = (direction === 'buy') ? takerPaysAmount : takerGetsAmount
@@ -14,18 +16,18 @@ function parseOrderbookOrder(order: Object): Object {
 
   // note: immediateOrCancel and fillOrKill orders cannot enter the order book
   // so we can omit those flags here
-  const specification = utils.removeUndefined({
+  const specification = removeUndefined({
     direction: direction,
     quantity: quantity,
     totalPrice: totalPrice,
-    passive: ((order.Flags & flags.Passive) !== 0) || undefined,
-    expirationTime: utils.parseTimestamp(order.Expiration)
+    passive: ((order.Flags & orderFlags.Passive) !== 0) || undefined,
+    expirationTime: parseTimestamp(order.Expiration)
   })
 
   const properties = {
     maker: order.Account,
     sequence: order.Sequence,
-    makerExchangeRate: utils.adjustQualityForXRP(order.quality,
+    makerExchangeRate: adjustQualityForXRP(order.quality,
       takerGetsAmount.currency, takerPaysAmount.currency)
   }
 
@@ -33,12 +35,12 @@ function parseOrderbookOrder(order: Object): Object {
     parseAmount(order.taker_gets_funded) : undefined
   const takerPaysFunded = order.taker_pays_funded ?
     parseAmount(order.taker_pays_funded) : undefined
-  const available = utils.removeUndefined({
+  const available = removeUndefined({
     fundedAmount: takerGetsFunded,
     priceOfFundedAmount: takerPaysFunded
   })
   const state = _.isEmpty(available) ? undefined : available
-  return utils.removeUndefined({specification, properties, state})
+  return removeUndefined({specification, properties, state})
 }
 
-module.exports = parseOrderbookOrder
+export default parseOrderbookOrder

--- a/src/ledger/parse/pathfind.js
+++ b/src/ledger/parse/pathfind.js
@@ -1,9 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const parseAmount = require('./amount')
-import type {Amount, RippledAmount} from '../../common/types.js'
-import type {GetPaths, RippledPathsResponse} from '../pathfind-types.js'
+
+import * as _ from 'lodash'
+import parseAmount from './amount'
+import type {Amount, RippledAmount} from '../../common/types'
+import type {GetPaths, RippledPathsResponse} from '../pathfind-types'
 
 function parsePaths(paths) {
   return paths.map(steps => steps.map(step =>
@@ -48,4 +48,4 @@ function parsePathfind(pathfindResult: RippledPathsResponse): GetPaths {
     sourceAddress, destinationAddress, destinationAmount))
 }
 
-module.exports = parsePathfind
+export default parsePathfind

--- a/src/ledger/parse/payment-channel-claim.js
+++ b/src/ledger/parse/payment-channel-claim.js
@@ -1,14 +1,14 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const parseAmount = require('./amount')
-const claimFlags = utils.txFlags.PaymentChannelClaim
+
+import assert from 'assert'
+import {removeUndefined, txFlags} from '../../common'
+import parseAmount from './amount'
+const claimFlags = txFlags.PaymentChannelClaim
 
 function parsePaymentChannelClaim(tx: Object): Object {
   assert(tx.TransactionType === 'PaymentChannelClaim')
 
-  return utils.removeUndefined({
+  return removeUndefined({
     channel: tx.Channel,
     balance: tx.Balance && parseAmount(tx.Balance).value,
     amount: tx.Amount && parseAmount(tx.Amount).value,
@@ -19,4 +19,4 @@ function parsePaymentChannelClaim(tx: Object): Object {
   })
 }
 
-module.exports = parsePaymentChannelClaim
+export default parsePaymentChannelClaim

--- a/src/ledger/parse/payment-channel-create.js
+++ b/src/ledger/parse/payment-channel-create.js
@@ -1,21 +1,22 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const parseAmount = require('./amount')
+
+import assert from 'assert'
+import {parseTimestamp} from './utils'
+import {removeUndefined} from '../../common'
+import parseAmount from './amount'
 
 function parsePaymentChannelCreate(tx: Object): Object {
   assert(tx.TransactionType === 'PaymentChannelCreate')
 
-  return utils.removeUndefined({
+  return removeUndefined({
     amount: parseAmount(tx.Amount).value,
     destination: tx.Destination,
     settleDelay: tx.SettleDelay,
     publicKey: tx.PublicKey,
-    cancelAfter: tx.CancelAfter && utils.parseTimestamp(tx.CancelAfter),
+    cancelAfter: tx.CancelAfter && parseTimestamp(tx.CancelAfter),
     sourceTag: tx.SourceTag,
     destinationTag: tx.DestinationTag
   })
 }
 
-module.exports = parsePaymentChannelCreate
+export default parsePaymentChannelCreate

--- a/src/ledger/parse/payment-channel-fund.js
+++ b/src/ledger/parse/payment-channel-fund.js
@@ -1,17 +1,18 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const parseAmount = require('./amount')
+
+import assert from 'assert'
+import {parseTimestamp} from './utils'
+import {removeUndefined} from '../../common'
+import parseAmount from './amount'
 
 function parsePaymentChannelFund(tx: Object): Object {
   assert(tx.TransactionType === 'PaymentChannelFund')
 
-  return utils.removeUndefined({
+  return removeUndefined({
     channel: tx.Channel,
     amount: parseAmount(tx.Amount).value,
-    expiration: tx.Expiration && utils.parseTimestamp(tx.Expiration)
+    expiration: tx.Expiration && parseTimestamp(tx.Expiration)
   })
 }
 
-module.exports = parsePaymentChannelFund
+export default parsePaymentChannelFund

--- a/src/ledger/parse/payment-channel.js
+++ b/src/ledger/parse/payment-channel.js
@@ -1,6 +1,7 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
+
+import {parseTimestamp} from './utils'
+import {removeUndefined, dropsToXrp} from '../../common'
 
 type PaymentChannelResponse = {
   account: string,
@@ -17,15 +18,15 @@ type PaymentChannelResponse = {
 }
 
 function parsePaymentChannel(data: Object): PaymentChannelResponse {
-  return utils.removeUndefined({
+  return removeUndefined({
     account: data.Account,
-    amount: utils.dropsToXrp(data.Amount),
-    balance: utils.dropsToXrp(data.Balance),
+    amount: dropsToXrp(data.Amount),
+    balance: dropsToXrp(data.Balance),
     destination: data.Destination,
     publicKey: data.PublicKey,
     settleDelay: data.SettleDelay,
-    expiration: utils.parseTimestamp(data.Expiration),
-    cancelAfter: utils.parseTimestamp(data.CancelAfter),
+    expiration: parseTimestamp(data.Expiration),
+    cancelAfter: parseTimestamp(data.CancelAfter),
     sourceTag: data.SourceTag,
     destinationTag: data.DestinationTag,
     previousAffectingTransactionID: data.PreviousTxnID,
@@ -33,4 +34,4 @@ function parsePaymentChannel(data: Object): PaymentChannelResponse {
   })
 }
 
-module.exports = parsePaymentChannel
+export default parsePaymentChannel

--- a/src/ledger/parse/payment.js
+++ b/src/ledger/parse/payment.js
@@ -1,10 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const assert = require('assert')
-const utils = require('./utils')
-const parseAmount = require('./amount')
-const txFlags = utils.txFlags
+
+import * as _ from 'lodash'
+import assert from 'assert'
+import * as utils from './utils'
+import {txFlags, removeUndefined} from '../../common'
+import parseAmount from './amount'
 
 function isNoDirectRipple(tx) {
   return (tx.Flags & txFlags.Payment.NoRippleDirect) !== 0
@@ -35,9 +35,9 @@ function parsePayment(tx: Object): Object {
     tag: tx.DestinationTag
   }
 
-  return utils.removeUndefined({
-    source: utils.removeUndefined(source),
-    destination: utils.removeUndefined(destination),
+  return removeUndefined({
+    source: removeUndefined(source),
+    destination: removeUndefined(destination),
     memos: utils.parseMemos(tx),
     invoiceID: tx.InvoiceID,
     paths: tx.Paths ? JSON.stringify(tx.Paths) : undefined,
@@ -47,4 +47,4 @@ function parsePayment(tx: Object): Object {
   })
 }
 
-module.exports = parsePayment
+export default parsePayment

--- a/src/ledger/parse/settings.js
+++ b/src/ledger/parse/settings.js
@@ -1,9 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const assert = require('assert')
-const AccountFlags = require('./utils').constants.AccountFlags
-const parseFields = require('./fields')
+
+import * as _ from 'lodash'
+import assert from 'assert'
+import {constants} from '../../common'
+const AccountFlags = constants.AccountFlags
+import parseFields from './fields'
 
 function getAccountRootModifiedNode(tx: Object) {
   const modifiedNodes = tx.meta.AffectedNodes.filter(node =>
@@ -58,4 +59,4 @@ function parseSettings(tx: Object) {
   return _.assign({}, parseFlags(tx), parseFields(tx))
 }
 
-module.exports = parseSettings
+export default parseSettings

--- a/src/ledger/parse/transaction.js
+++ b/src/ledger/parse/transaction.js
@@ -1,20 +1,21 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const parsePayment = require('./payment')
-const parseTrustline = require('./trustline')
-const parseOrder = require('./order')
-const parseOrderCancellation = require('./cancellation')
-const parseSettings = require('./settings')
-const parseEscrowCreation = require('./escrow-creation')
-const parseEscrowExecution = require('./escrow-execution')
-const parseEscrowCancellation = require('./escrow-cancellation')
-const parsePaymentChannelCreate = require('./payment-channel-create')
-const parsePaymentChannelFund = require('./payment-channel-fund')
-const parsePaymentChannelClaim = require('./payment-channel-claim')
-const parseFeeUpdate = require('./fee-update')
-const parseAmendment = require('./amendment')
+
+import assert from 'assert'
+import {parseOutcome} from './utils'
+import {removeUndefined} from '../../common'
+import parsePayment from './payment'
+import parseTrustline from './trustline'
+import parseOrder from './order'
+import parseOrderCancellation from './cancellation'
+import parseSettings from './settings'
+import parseEscrowCreation from './escrow-creation'
+import parseEscrowExecution from './escrow-execution'
+import parseEscrowCancellation from './escrow-cancellation'
+import parsePaymentChannelCreate from './payment-channel-create'
+import parsePaymentChannelFund from './payment-channel-fund'
+import parsePaymentChannelClaim from './payment-channel-claim'
+import parseFeeUpdate from './fee-update'
+import parseAmendment from './amendment'
 
 function parseTransactionType(type) {
   const mapping = {
@@ -57,15 +58,15 @@ function parseTransaction(tx: Object): Object {
   const parser: Function = (mapping: Object)[type]
   assert(parser !== undefined, 'Unrecognized transaction type')
   const specification = parser(tx)
-  const outcome = utils.parseOutcome(tx)
-  return utils.removeUndefined({
+  const outcome = parseOutcome(tx)
+  return removeUndefined({
     type: type,
     address: tx.Account,
     sequence: tx.Sequence,
     id: tx.hash,
-    specification: utils.removeUndefined(specification),
-    outcome: outcome ? utils.removeUndefined(outcome) : undefined
+    specification: removeUndefined(specification),
+    outcome: outcome ? removeUndefined(outcome) : undefined
   })
 }
 
-module.exports = parseTransaction
+export default parseTransaction

--- a/src/ledger/parse/trustline.js
+++ b/src/ledger/parse/trustline.js
@@ -1,8 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const assert = require('assert')
-const utils = require('./utils')
-const flags = utils.txFlags.TrustSet
+
+import assert from 'assert'
+import {parseQuality} from './utils'
+import {txFlags, removeUndefined} from '../../common'
+const flags = txFlags.TrustSet
 
 function parseFlag(flagsValue, trueValue, falseValue) {
   if (flagsValue & trueValue) {
@@ -17,12 +18,12 @@ function parseFlag(flagsValue, trueValue, falseValue) {
 function parseTrustline(tx: Object): Object {
   assert(tx.TransactionType === 'TrustSet')
 
-  return utils.removeUndefined({
+  return removeUndefined({
     limit: tx.LimitAmount.value,
     currency: tx.LimitAmount.currency,
     counterparty: tx.LimitAmount.issuer,
-    qualityIn: utils.parseQuality(tx.QualityIn),
-    qualityOut: utils.parseQuality(tx.QualityOut),
+    qualityIn: parseQuality(tx.QualityIn),
+    qualityOut: parseQuality(tx.QualityOut),
     ripplingDisabled: parseFlag(
       tx.Flags, flags.SetNoRipple, flags.ClearNoRipple),
     frozen: parseFlag(tx.Flags, flags.SetFreeze, flags.ClearFreeze),
@@ -30,4 +31,4 @@ function parseTrustline(tx: Object): Object {
   })
 }
 
-module.exports = parseTrustline
+export default parseTrustline

--- a/src/ledger/parse/utils.js
+++ b/src/ledger/parse/utils.js
@@ -1,12 +1,12 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const transactionParser = require('ripple-lib-transactionparser')
-const utils = require('../utils')
-const BigNumber = require('bignumber.js')
-const parseAmount = require('./amount')
 
-import type {Amount} from '../../common/types.js'
+import * as _ from 'lodash'
+import transactionParser from 'ripple-lib-transactionparser'
+import BigNumber from 'bignumber.js'
+import * as common from '../../common'
+import parseAmount from './amount'
+
+import type {Amount} from '../../common/types'
 
 function adjustQualityForXRP(
   quality: string, takerGetsCurrency: string, takerPaysCurrency: string
@@ -28,7 +28,7 @@ function parseQuality(quality: ?number) {
 }
 
 function parseTimestamp(rippleTime: number): string | void {
-  return rippleTime ? utils.common.rippleTimeToISO8601(rippleTime) : undefined
+  return rippleTime ? common.rippleTimeToISO8601(rippleTime) : undefined
 }
 
 function removeEmptyCounterparty(amount) {
@@ -52,7 +52,7 @@ function removeEmptyCounterpartyInOrderbookChanges(orderbookChanges) {
 }
 
 function isPartialPayment(tx: Object) {
-  return (tx.Flags & utils.common.txFlags.Payment.PartialPayment) !== 0
+  return (tx.Flags & common.txFlags.Payment.PartialPayment) !== 0
 }
 
 function parseDeliveredAmount(tx: Object): Amount | void {
@@ -105,10 +105,10 @@ function parseOutcome(tx: Object): ?Object {
   removeEmptyCounterpartyInBalanceChanges(balanceChanges)
   removeEmptyCounterpartyInOrderbookChanges(orderbookChanges)
 
-  return utils.common.removeUndefined({
+  return common.removeUndefined({
     result: tx.meta.TransactionResult,
     timestamp: parseTimestamp(tx.date),
-    fee: utils.common.dropsToXrp(tx.Fee),
+    fee: common.dropsToXrp(tx.Fee),
     balanceChanges: balanceChanges,
     orderbookChanges: orderbookChanges,
     ledgerVersion: tx.ledger_index,
@@ -126,7 +126,7 @@ function parseMemos(tx: Object): ?Array<Object> {
     return undefined
   }
   return tx.Memos.map(m => {
-    return utils.common.removeUndefined({
+    return common.removeUndefined({
       type: m.Memo.parsed_memo_type || hexToString(m.Memo.MemoType),
       format: m.Memo.parsed_memo_format || hexToString(m.Memo.MemoFormat),
       data: m.Memo.parsed_memo_data || hexToString(m.Memo.MemoData)
@@ -134,17 +134,12 @@ function parseMemos(tx: Object): ?Array<Object> {
   })
 }
 
-module.exports = {
+export {
   parseQuality,
   parseOutcome,
   parseMemos,
   hexToString,
   parseTimestamp,
   adjustQualityForXRP,
-  isPartialPayment,
-  dropsToXrp: utils.common.dropsToXrp,
-  constants: utils.common.constants,
-  txFlags: utils.common.txFlags,
-  removeUndefined: utils.common.removeUndefined,
-  rippleTimeToISO8601: utils.common.rippleTimeToISO8601
+  isPartialPayment
 }

--- a/src/ledger/pathfind-types.js
+++ b/src/ledger/pathfind-types.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
+
 
 import type {Amount, LaxLaxAmount, RippledAmount, Adjustment, MaxAdjustment,
-  MinAdjustment} from '../common/types.js'
+  MinAdjustment} from '../common/types'
 
 
 type Path = {

--- a/src/ledger/pathfind.js
+++ b/src/ledger/pathfind.js
@@ -1,16 +1,17 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const BigNumber = require('bignumber.js')
-const utils = require('./utils')
-const parsePathfind = require('./parse/pathfind')
-const {validate, toRippledAmount} = utils.common
-const NotFoundError = utils.common.errors.NotFoundError
-const ValidationError = utils.common.errors.ValidationError
-import type {Connection} from '../common/connection'
-import type {RippledAmount} from '../common/types.js'
-import type {GetPaths, PathFind, RippledPathsResponse, PathFindRequest}
-  from './pathfind-types.js'
+
+import * as _ from 'lodash'
+import BigNumber from 'bignumber.js'
+import {getXRPBalance} from './utils'
+import {validate, toRippledAmount, errors} from '../common'
+import type {Connection} from '../common'
+import parsePathfind from './parse/pathfind'
+import type {RippledAmount} from '../common/types'
+import type {
+  GetPaths, PathFind, RippledPathsResponse, PathFindRequest
+} from './pathfind-types'
+const NotFoundError = errors.NotFoundError
+const ValidationError = errors.ValidationError
 
 
 function addParams(request: PathFindRequest, result: RippledPathsResponse
@@ -83,7 +84,7 @@ function conditionallyAddDirectXRPPath(connection: Connection, address: string,
       || !_.includes(paths.destination_currencies, 'XRP')) {
     return Promise.resolve(paths)
   }
-  return utils.getXRPBalance(connection, address, undefined).then(
+  return getXRPBalance(connection, address, undefined).then(
     xrpBalance => addDirectXrpPath(paths, xrpBalance))
 }
 
@@ -137,4 +138,4 @@ function getPaths(pathfind: PathFind): Promise<GetPaths> {
     .then(paths => formatResponse(pathfind, paths))
 }
 
-module.exports = getPaths
+export default getPaths

--- a/src/ledger/payment-channel.js
+++ b/src/ledger/payment-channel.js
@@ -1,9 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const parsePaymentChannel = require('./parse/payment-channel')
-const {validate} = utils.common
-const NotFoundError = utils.common.errors.NotFoundError
+
+import parsePaymentChannel from './parse/payment-channel'
+import {validate, errors} from '../common'
+const NotFoundError = errors.NotFoundError
 
 type PaymentChannel = {
   Sequence: number,
@@ -53,4 +52,4 @@ function getPaymentChannel(id: string): Promise<PaymentChannel> {
   return this.connection.request(request).then(formatResponse)
 }
 
-module.exports = getPaymentChannel
+export default getPaymentChannel

--- a/src/ledger/settings.js
+++ b/src/ledger/settings.js
@@ -1,10 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const parseFields = require('./parse/fields')
-const {validate} = utils.common
-const AccountFlags = utils.common.constants.AccountFlags
+
+import * as _ from 'lodash'
+import parseFields from './parse/fields'
+import {validate, constants} from '../common'
+const AccountFlags = constants.AccountFlags
 
 type SettingsOptions = {
   ledgerVersion?: number
@@ -59,4 +58,4 @@ function getSettings(address: string, options: SettingsOptions = {}
   return this.connection.request(request).then(formatSettings)
 }
 
-module.exports = getSettings
+export default getSettings

--- a/src/ledger/transaction-types.js
+++ b/src/ledger/transaction-types.js
@@ -1,7 +1,7 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
 
-import type {Amount, Memo} from '../common/types.js'
+
+import type {Amount, Memo} from '../common/types'
 
 type Outcome = {
   result: string,

--- a/src/ledger/transaction.js
+++ b/src/ledger/transaction.js
@@ -1,10 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const parseTransaction = require('./parse/transaction')
-const {validate, errors} = utils.common
-import type {Connection} from '../common/connection.js'
+
+import * as _ from 'lodash'
+import * as utils from './utils'
+import parseTransaction from './parse/transaction'
+import {validate, errors} from '../common'
+import type {Connection} from '../common'
 import type {TransactionType, TransactionOptions} from './transaction-types'
 
 function attachTransactionDate(connection: Connection, tx: Object
@@ -100,4 +100,4 @@ function getTransaction(id: string, options: TransactionOptions = {}
   })
 }
 
-module.exports = getTransaction
+export default getTransaction

--- a/src/ledger/transactions.js
+++ b/src/ledger/transactions.js
@@ -1,14 +1,13 @@
 /* @flow */
-/* eslint-disable max-params */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const binary = require('ripple-binary-codec')
-const {computeTransactionHash} = require('ripple-hashes')
-const utils = require('./utils')
-const parseTransaction = require('./parse/transaction')
-const getTransaction = require('./transaction')
-const {validate} = utils.common
-import type {Connection} from '../common/connection.js'
+
+import * as _ from 'lodash'
+import binary from 'ripple-binary-codec'
+import {computeTransactionHash} from 'ripple-hashes'
+import * as utils from './utils'
+import parseTransaction from './parse/transaction'
+import getTransaction from './transaction'
+import {validate, errors} from '../common'
+import type {Connection} from '../common'
 import type {TransactionType} from './transaction-types'
 
 
@@ -137,7 +136,7 @@ function checkForLedgerGaps(connection: Connection,
   return utils.hasCompleteLedgerRange(connection, minLedgerVersion,
     maxLedgerVersion).then(hasCompleteLedgerRange => {
     if (!hasCompleteLedgerRange) {
-      throw new utils.common.errors.MissingLedgerHistoryError()
+      throw new errors.MissingLedgerHistoryError()
     }
   })
 }
@@ -178,4 +177,4 @@ function getTransactions(address: string, options: TransactionsOptions = {}
   return getTransactionsInternal(this.connection, address, newOptions)
 }
 
-module.exports = getTransactions
+export default getTransactions

--- a/src/ledger/trustlines-types.js
+++ b/src/ledger/trustlines-types.js
@@ -1,5 +1,5 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
+
 
 export type TrustLineSpecification = {
   currency: string,

--- a/src/ledger/trustlines.js
+++ b/src/ledger/trustlines.js
@@ -1,11 +1,11 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const {validate} = utils.common
-const parseAccountTrustline = require('./parse/account-trustline')
-import type {Connection} from '../common/connection.js'
-import type {TrustlinesOptions, Trustline} from './trustlines-types.js'
+
+import * as _ from 'lodash'
+import * as utils from './utils'
+import {validate} from '../common'
+import type {Connection} from '../common'
+import parseAccountTrustline from './parse/account-trustline'
+import type {TrustlinesOptions, Trustline} from './trustlines-types'
 
 
 type GetTrustlinesResponse = Array<Trustline>
@@ -49,4 +49,4 @@ function getTrustlines(address: string, options: TrustlinesOptions = {}
   })
 }
 
-module.exports = getTrustlines
+export default getTrustlines

--- a/src/ledger/types.js
+++ b/src/ledger/types.js
@@ -1,7 +1,7 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
 
-import type {Amount} from '../common/types.js'
+
+import type {Amount} from '../common/types'
 
 export type OrdersOptions = {
   limit?: number,

--- a/src/ledger/utils.js
+++ b/src/ledger/utils.js
@@ -1,12 +1,11 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const assert = require('assert')
-const common = require('../common')
-const dropsToXrp = common.dropsToXrp
+
+import * as _ from 'lodash'
+import assert from 'assert'
+import * as common from '../common'
+import type {Connection} from '../common'
 import type {TransactionType} from './transaction-types'
-import type {Issue} from '../common/types.js'
-import type {Connection} from '../common/connection'
+import type {Issue} from '../common/types'
 
 type RecursiveData = {
   marker: string,
@@ -29,7 +28,7 @@ function getXRPBalance(connection: Connection, address: string,
     ledger_index: ledgerVersion
   }
   return connection.request(request).then(data =>
-    dropsToXrp(data.account_data.Balance))
+    common.dropsToXrp(data.account_data.Balance))
 }
 
 // If the marker is omitted from a response, you have reached the end
@@ -122,7 +121,7 @@ function ensureLedgerVersion(options: Object
     _.assign({}, options, {ledgerVersion}))
 }
 
-module.exports = {
+export {
   getXRPBalance,
   ensureLedgerVersion,
   compareTransactions,
@@ -130,6 +129,6 @@ module.exports = {
   getRecursive,
   hasCompleteLedgerRange,
   isPendingLedgerVersion,
-  clamp: clamp,
-  common: common
+  clamp,
+  common
 }

--- a/src/offline/generate-address.js
+++ b/src/offline/generate-address.js
@@ -1,6 +1,7 @@
-'use strict' // eslint-disable-line strict
-const keypairs = require('ripple-keypairs')
-const common = require('../common')
+/* @flow */
+
+import keypairs from 'ripple-keypairs'
+import * as common from '../common'
 const {errors, validate} = common
 
 function generateAddress(options?: Object): Object {
@@ -19,6 +20,6 @@ function generateAddressAPI(options?: Object): Object {
   }
 }
 
-module.exports = {
+export {
   generateAddressAPI
 }

--- a/src/offline/ledgerhash.js
+++ b/src/offline/ledgerhash.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const common = require('../common')
-const hashes = require('ripple-hashes')
+
+import * as _ from 'lodash'
+import * as common from '../common'
+import hashes from 'ripple-hashes'
 
 function convertLedgerHeader(header) {
   return {
@@ -71,4 +71,4 @@ function computeLedgerHash(ledger: Object): string {
   return hashLedgerHeader(_.assign({}, ledger, subhashes))
 }
 
-module.exports = computeLedgerHash
+export default computeLedgerHash

--- a/src/offline/sign-payment-channel-claim.js
+++ b/src/offline/sign-payment-channel-claim.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const common = require('../common')
-const keypairs = require('ripple-keypairs')
-const binary = require('ripple-binary-codec')
+
+import * as common from '../common'
+import keypairs from 'ripple-keypairs'
+import binary from 'ripple-binary-codec'
 const {validate, xrpToDrops} = common
 
 function signPaymentChannelClaim(channel: string, amount: string,
@@ -17,4 +17,4 @@ function signPaymentChannelClaim(channel: string, amount: string,
   return keypairs.sign(signingData, privateKey)
 }
 
-module.exports = signPaymentChannelClaim
+export default signPaymentChannelClaim

--- a/src/offline/verify-payment-channel-claim.js
+++ b/src/offline/verify-payment-channel-claim.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const common = require('../common')
-const keypairs = require('ripple-keypairs')
-const binary = require('ripple-binary-codec')
+
+import * as common from '../common'
+import keypairs from 'ripple-keypairs'
+import binary from 'ripple-binary-codec'
 const {validate, xrpToDrops} = common
 
 function verifyPaymentChannelClaim(channel: string, amount: string,
@@ -17,4 +17,4 @@ function verifyPaymentChannelClaim(channel: string, amount: string,
   return keypairs.verify(signingData, signature, publicKey)
 }
 
-module.exports = verifyPaymentChannelClaim
+export default verifyPaymentChannelClaim

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,6 +1,6 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const common = require('../common')
+
+import * as common from '../common'
 import type {GetServerInfoResponse} from '../common/serverinfo'
 
 function isConnected(): boolean {
@@ -41,7 +41,7 @@ function formatLedgerClose(ledgerClose: Object): Object {
   }
 }
 
-module.exports = {
+export {
   connect,
   disconnect,
   isConnected,

--- a/src/transaction/combine.js
+++ b/src/transaction/combine.js
@@ -1,12 +1,12 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const binary = require('ripple-binary-codec')
-const utils = require('./utils')
-const BigNumber = require('bignumber.js')
-const {decodeAddress} = require('ripple-address-codec')
-const {validate} = utils.common
-const {computeBinaryTransactionHash} = require('ripple-hashes')
+
+import * as _ from 'lodash'
+import binary from 'ripple-binary-codec'
+import * as utils from './utils'
+import BigNumber from 'bignumber.js'
+import {decodeAddress} from 'ripple-address-codec'
+import {validate} from '../common'
+import {computeBinaryTransactionHash} from 'ripple-hashes'
 
 function addressToBigNumber(address) {
   const hex = (new Buffer(decodeAddress(address))).toString('hex')
@@ -36,4 +36,4 @@ function combine(signedTransactions: Array<string>): Object {
   return {signedTransaction, id}
 }
 
-module.exports = combine
+export default combine

--- a/src/transaction/escrow-cancellation.js
+++ b/src/transaction/escrow-cancellation.js
@@ -1,10 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import * as utils from './utils'
 const validate = utils.common.validate
-import type {Instructions, Prepare} from './types.js'
-import type {Memo} from '../common/types.js'
+import type {Instructions, Prepare} from './types'
+import type {Memo} from '../common/types'
 
 type EscrowCancellation = {
   owner: string,
@@ -38,4 +38,4 @@ function prepareEscrowCancellation(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareEscrowCancellation
+export default prepareEscrowCancellation

--- a/src/transaction/escrow-creation.js
+++ b/src/transaction/escrow-creation.js
@@ -1,11 +1,11 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const {validate, iso8601ToRippleTime, xrpToDrops} = utils.common
+
+import * as _ from 'lodash'
+import * as utils from './utils'
+import {validate, iso8601ToRippleTime, xrpToDrops} from '../common'
 const ValidationError = utils.common.errors.ValidationError
-import type {Instructions, Prepare} from './types.js'
-import type {Memo} from '../common/types.js'
+import type {Instructions, Prepare} from './types'
+import type {Memo} from '../common/types'
 
 type EscrowCreation = {
   amount: string,
@@ -65,4 +65,4 @@ function prepareEscrowCreation(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareEscrowCreation
+export default prepareEscrowCreation

--- a/src/transaction/escrow-execution.js
+++ b/src/transaction/escrow-execution.js
@@ -1,11 +1,11 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import * as utils from './utils'
 const validate = utils.common.validate
 const ValidationError = utils.common.errors.ValidationError
-import type {Instructions, Prepare} from './types.js'
-import type {Memo} from '../common/types.js'
+import type {Instructions, Prepare} from './types'
+import type {Memo} from '../common/types'
 
 type EscrowExecution = {
   owner: string,
@@ -53,4 +53,4 @@ function prepareEscrowExecution(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareEscrowExecution
+export default prepareEscrowExecution

--- a/src/transaction/order.js
+++ b/src/transaction/order.js
@@ -1,11 +1,11 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import * as utils from './utils'
 const offerFlags = utils.common.txFlags.OfferCreate
-const {validate, iso8601ToRippleTime} = utils.common
-import type {Instructions, Prepare} from './types.js'
-import type {Order} from '../ledger/transaction-types.js'
+import {validate, iso8601ToRippleTime} from '../common'
+import type {Instructions, Prepare} from './types'
+import type {Order} from '../ledger/transaction-types'
 
 function createOrderTransaction(account: string, order: Order): Object {
   const takerPays = utils.common.toRippledAmount(order.direction === 'buy' ?
@@ -52,4 +52,4 @@ function prepareOrder(address: string, order: Order,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareOrder
+export default prepareOrder

--- a/src/transaction/ordercancellation.js
+++ b/src/transaction/ordercancellation.js
@@ -1,9 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import * as utils from './utils'
 const validate = utils.common.validate
-import type {Instructions, Prepare} from './types.js'
+import type {Instructions, Prepare} from './types'
 
 function createOrderCancellationTransaction(account: string,
   orderCancellation: Object
@@ -27,4 +27,4 @@ function prepareOrderCancellation(address: string, orderCancellation: Object,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareOrderCancellation
+export default prepareOrderCancellation

--- a/src/transaction/payment-channel-claim.js
+++ b/src/transaction/payment-channel-claim.js
@@ -1,10 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
+
+import * as utils from './utils'
 const ValidationError = utils.common.errors.ValidationError
 const claimFlags = utils.common.txFlags.PaymentChannelClaim
-const {validate, xrpToDrops} = utils.common
-import type {Instructions, Prepare} from './types.js'
+import {validate, xrpToDrops} from '../common'
+import type {Instructions, Prepare} from './types'
 
 type PaymentChannelClaim = {
   channel: string,
@@ -71,4 +71,4 @@ function preparePaymentChannelClaim(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = preparePaymentChannelClaim
+export default preparePaymentChannelClaim

--- a/src/transaction/payment-channel-create.js
+++ b/src/transaction/payment-channel-create.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const {validate, iso8601ToRippleTime, xrpToDrops} = utils.common
-import type {Instructions, Prepare} from './types.js'
+
+import * as utils from './utils'
+import {validate, iso8601ToRippleTime, xrpToDrops} from '../common'
+import type {Instructions, Prepare} from './types'
 
 type PaymentChannelCreate = {
   amount: string,
@@ -50,4 +50,4 @@ function preparePaymentChannelCreate(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = preparePaymentChannelCreate
+export default preparePaymentChannelCreate

--- a/src/transaction/payment-channel-fund.js
+++ b/src/transaction/payment-channel-fund.js
@@ -1,8 +1,8 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const {validate, iso8601ToRippleTime, xrpToDrops} = utils.common
-import type {Instructions, Prepare} from './types.js'
+
+import * as utils from './utils'
+import {validate, iso8601ToRippleTime, xrpToDrops} from '../common'
+import type {Instructions, Prepare} from './types'
 
 type PaymentChannelFund = {
   channel: string,
@@ -38,4 +38,4 @@ function preparePaymentChannelFund(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = preparePaymentChannelFund
+export default preparePaymentChannelFund

--- a/src/transaction/payment.js
+++ b/src/transaction/payment.js
@@ -1,14 +1,14 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import * as utils from './utils'
 const validate = utils.common.validate
 const toRippledAmount = utils.common.toRippledAmount
 const paymentFlags = utils.common.txFlags.Payment
 const ValidationError = utils.common.errors.ValidationError
-import type {Instructions, Prepare} from './types.js'
+import type {Instructions, Prepare} from './types'
 import type {Amount, Adjustment, MaxAdjustment,
-  MinAdjustment, Memo} from '../common/types.js'
+  MinAdjustment, Memo} from '../common/types'
 
 
 type Payment = {
@@ -153,4 +153,4 @@ function preparePayment(address: string, payment: Payment,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = preparePayment
+export default preparePayment

--- a/src/transaction/settings.js
+++ b/src/transaction/settings.js
@@ -1,13 +1,13 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const assert = require('assert')
-const BigNumber = require('bignumber.js')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import assert from 'assert'
+import BigNumber from 'bignumber.js'
+import * as utils from './utils'
 const validate = utils.common.validate
 const AccountFlagIndices = utils.common.constants.AccountFlagIndices
 const AccountFields = utils.common.constants.AccountFields
-import type {Instructions, Prepare} from './types.js'
+import type {Instructions, Prepare} from './types'
 
 type Settings = {
   passwordSpent?: boolean,
@@ -152,4 +152,4 @@ function prepareSettings(address: string, settings: Settings,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareSettings
+export default prepareSettings

--- a/src/transaction/sign.js
+++ b/src/transaction/sign.js
@@ -1,9 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const utils = require('./utils')
-const keypairs = require('ripple-keypairs')
-const binary = require('ripple-binary-codec')
-const {computeBinaryTransactionHash} = require('ripple-hashes')
+
+import * as utils from './utils'
+import keypairs from 'ripple-keypairs'
+import binary from 'ripple-binary-codec'
+import {computeBinaryTransactionHash} from 'ripple-hashes'
 const validate = utils.common.validate
 
 function computeSignature(tx: Object, privateKey: string, signAs: ?string) {
@@ -45,4 +45,4 @@ function sign(txJSON: string, secret: string, options: Object = {}
   }
 }
 
-module.exports = sign
+export default sign

--- a/src/transaction/submit.js
+++ b/src/transaction/submit.js
@@ -1,9 +1,9 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
-const {validate} = utils.common
-import type {Submit} from './types.js'
+
+import * as _ from 'lodash'
+import * as utils from './utils'
+import {validate} from '../common'
+import type {Submit} from './types'
 
 function isImmediateRejection(engineResult: string): boolean {
   // note: "tel" errors mean the local server refused to process the
@@ -36,4 +36,4 @@ function submit(signedTransaction: string): Promise<Submit> {
   return this.connection.request(request).then(formatSubmitResponse)
 }
 
-module.exports = submit
+export default submit

--- a/src/transaction/trustline.js
+++ b/src/transaction/trustline.js
@@ -1,12 +1,12 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const utils = require('./utils')
+
+import * as _ from 'lodash'
+import BigNumber from 'bignumber.js'
+import * as utils from './utils'
 const validate = utils.common.validate
 const trustlineFlags = utils.common.txFlags.TrustSet
-const BigNumber = require('bignumber.js')
-import type {Instructions, Prepare} from './types.js'
-import type {TrustLineSpecification} from '../ledger/trustlines-types.js'
+import type {Instructions, Prepare} from './types'
+import type {TrustLineSpecification} from '../ledger/trustlines-types'
 
 function convertQuality(quality) {
   return (new BigNumber(quality)).shift(9).truncated().toNumber()
@@ -58,4 +58,4 @@ function prepareTrustline(address: string,
   return utils.prepareTransaction(txJSON, this, instructions)
 }
 
-module.exports = prepareTrustline
+export default prepareTrustline

--- a/src/transaction/types.js
+++ b/src/transaction/types.js
@@ -1,5 +1,5 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
+
 
 export type Instructions = {
   sequence?: number,

--- a/src/transaction/utils.js
+++ b/src/transaction/utils.js
@@ -1,10 +1,10 @@
 /* @flow */
-'use strict' // eslint-disable-line strict
-const _ = require('lodash')
-const BigNumber = require('bignumber.js')
-const common = require('../common')
+
+import * as _ from 'lodash'
+import BigNumber from 'bignumber.js'
+import * as common from '../common'
 const txFlags = common.txFlags
-import type {Instructions, Prepare} from './types.js'
+import type {Instructions, Prepare} from './types'
 
 function formatPrepareResponse(txJSON: Object): Object {
   const instructions = {
@@ -119,7 +119,7 @@ function convertMemo(memo: Object): Object {
   }
 }
 
-module.exports = {
+export {
   convertStringToHex,
   convertMemo,
   prepareTransaction,


### PR DESCRIPTION
Node.js, Browser Vendors, and the rest of the JS ecosystem are moving towards a standard module syntax for JavaScript. It's "strict" by default, standard across environments, and easier for compilers to optimize for.

Why now? This work is driven by our switch from Flow to TypeScript, so that we can add powerful typing support to our new API request interface. TypeScript uses ESM exclusively, so this is the first step. See https://github.com/ripple/ripple-lib/issues/812 for more info. 

No changes to Babel were needed, it successfully compiles down to Node-style common.js modules for distribution. Tests continue to pass.

/cc @intelliot 
