### PR TITLE
[Docs] Improve escrow creation example to have ExecuteAfter date

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -540,7 +540,8 @@ sourceTag | integer | *Optional* Source tag.
 {
   "destination": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
   "amount": "0.01",
-  "allowCancelAfter": "2014-09-24T21:21:50.000Z"
+  "allowExecuteAfter": "2014-09-24T21:21:50.000Z",
+  "allowCancelAfter":  "2017-01-01T00:00:00.000Z"
 }
 ```
 
@@ -3291,7 +3292,8 @@ const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
 const escrowCreation = {
   "destination": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
   "amount": "0.01",
-  "allowCancelAfter": "2014-09-24T21:21:50.000Z"
+  "allowExecuteAfter": "2014-09-24T21:21:50.000Z",
+  "allowCancelAfter":  "2017-01-01T00:00:00.000Z"
 };
 return api.prepareEscrowCreation(address, escrowCreation).then(prepared =>
   {/* ... */});

--- a/test/fixtures/requests/prepare-escrow-creation.json
+++ b/test/fixtures/requests/prepare-escrow-creation.json
@@ -1,5 +1,6 @@
 {
   "destination": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
   "amount": "0.01",
-  "allowCancelAfter": "2014-09-24T21:21:50.000Z"
+  "allowExecuteAfter": "2014-09-24T21:21:50.000Z",
+  "allowCancelAfter":  "2017-01-01T00:00:00.000Z"
 }


### PR DESCRIPTION
The existing example of an escrowCreation transaction in the docs includes `allowCancelAfter` but not an `allowExecuteAfter` field (and also no condition field)—this is the exact arrangement that can cause "false escrows" like the ones Ripple mistakenly made with the first set of the 55B escrows—they can be finished by anyone at any time before the cancellation.

This PR edits the example test fixture to add an `allowExecuteAfter` field. This provides a better example, but _should_ be functionally identical as a test fixture because the stated `allowCancelAfter` date is still in the past.