### PR TITLE
Change yarn install to yarn add

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can use `npm`, but we recommend using `yarn` for the added assurance provide
 
 Install `ripple-lib`:
 ```
-$ yarn install ripple-lib
+$ yarn add ripple-lib
 ```
 
 Then see the [documentation](https://github.com/ripple/ripple-lib/blob/develop/docs/index.md) and [code samples](https://github.com/ripple/ripple-lib/tree/develop/docs/samples)


### PR DESCRIPTION
```
> yarn install ripple-lib
yarn install v1.3.2
error `install` has been replaced with `add` to add new dependencies. Run "yarn add ripple-lib" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```