### PR TITLE
Add ability to derive address from secret

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,7 @@
   - [combine](#combine)
   - [submit](#submit)
   - [generateAddress](#generateaddress)
+  - [deriveAddress](#deriveaddress)
   - [signPaymentChannelClaim](#signpaymentchannelclaim)
   - [verifyPaymentChannelClaim](#verifypaymentchannelclaim)
   - [computeLedgerHash](#computeledgerhash)
@@ -199,6 +200,7 @@ Methods that depend on the state of the XRP Ledger are unavailable in offline mo
 * [prepareEscrowExecution](#prepareescrowexecution)
 * [sign](#sign)
 * [generateAddress](#generateaddress)
+* [deriveAddress](#deriveaddress)
 * [computeLedgerHash](#computeledgerhash)
 
 # Basic Types
@@ -5092,6 +5094,42 @@ return api.generateAddress();
 {
   "address": "rGCkuB7PBr5tNy68tPEABEtcdno4hE6Y7f",
   "secret": "sp6JS7f14BuwFY8Mw6bTtLKWauoUs"
+}
+```
+
+
+## deriveAddress
+
+`deriveAddress(secret: string): {address: string, secret: string}`
+
+Derive the corresponding address for the provided secret.
+
+### Parameters
+
+Name | Type | Description
+---- | ---- | -----------
+secret | secret string | The secret of the account to derive the address for.
+
+### Return Value
+
+This method returns an object with the following structure:
+
+Name | Type | Description
+---- | ---- | -----------
+address | [address](#address) | A Ripple account address corresponding to the secret.
+secret | secret string | The provided secret.
+
+### Example
+
+```javascript
+return api.deriveAddress("snUneA3NnRJDULZRaJBJdUtducjWK");
+```
+
+
+```json
+{
+  "address": "r4B7t5BqmHp3oPVHAnsMpPnw1QkuuJq7Z3",
+  "secret": "snUneA3NnRJDULZRaJBJdUtducjWK"
 }
 ```
 

--- a/docs/src/deriveAddress.md.ejs
+++ b/docs/src/deriveAddress.md.ejs
@@ -1,0 +1,23 @@
+## deriveAddress
+
+`deriveAddress(secret: string): {address: string, secret: string}`
+
+Derive the corresponding address for the provided secret.
+
+### Parameters
+
+<%- renderSchema('input/derive-address.json') %>
+
+### Return Value
+
+This method returns an object with the following structure:
+
+<%- renderSchema('output/derive-address.json') %>
+
+### Example
+
+```javascript
+return api.deriveAddress("snUneA3NnRJDULZRaJBJdUtducjWK");
+```
+
+<%- renderFixture('responses/derive-address.json') %>

--- a/docs/src/index.md.ejs
+++ b/docs/src/index.md.ejs
@@ -46,6 +46,7 @@
 <% include combine.md.ejs %>
 <% include submit.md.ejs %>
 <% include generateAddress.md.ejs %>
+<% include deriveAddress.md.ejs %>
 <% include signPaymentChannelClaim.md.ejs %>
 <% include verifyPaymentChannelClaim.md.ejs %>
 <% include computeLedgerHash.md.ejs %>

--- a/docs/src/offline.md.ejs
+++ b/docs/src/offline.md.ejs
@@ -23,4 +23,5 @@ Methods that depend on the state of the XRP Ledger are unavailable in offline mo
 * [prepareEscrowExecution](#prepareescrowexecution)
 * [sign](#sign)
 * [generateAddress](#generateaddress)
+* [deriveAddress](#deriveaddress)
 * [computeLedgerHash](#computeledgerhash)

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,6 +45,7 @@ import sign from './transaction/sign'
 import combine from './transaction/combine'
 import submit from './transaction/submit'
 import {generateAddressAPI} from './offline/generate-address'
+import {deriveAddressAPI} from './offline/derive-address'
 import computeLedgerHash from './offline/ledgerhash'
 import signPaymentChannelClaim from './offline/sign-payment-channel-claim'
 import verifyPaymentChannelClaim from './offline/verify-payment-channel-claim'
@@ -321,6 +322,7 @@ class RippleAPI extends EventEmitter {
   submit = submit
 
   generateAddress = generateAddressAPI
+  deriveAddress = deriveAddressAPI
   computeLedgerHash = computeLedgerHash
   signPaymentChannelClaim = signPaymentChannelClaim
   verifyPaymentChannelClaim = verifyPaymentChannelClaim

--- a/src/broadcast.ts
+++ b/src/broadcast.ts
@@ -36,7 +36,8 @@ class RippleAPIBroadcast extends RippleAPI {
 
     // synchronous methods are all passed directly to the first api instance
     const defaultAPI = apis[0]
-    const syncMethods = ['sign', 'generateAddress', 'computeLedgerHash']
+    const syncMethods = ['sign', 'generateAddress', 'deriveAddress',
+      'computeLedgerHash']
     syncMethods.forEach(name => {
       this[name] = defaultAPI[name].bind(defaultAPI)
     })

--- a/src/common/schema-validator.ts
+++ b/src/common/schema-validator.ts
@@ -115,6 +115,7 @@ function loadSchemas() {
     require('./schemas/input/sign.json'),
     require('./schemas/input/submit.json'),
     require('./schemas/input/generate-address.json'),
+    require('./schemas/input/derive-address.json'),
     require('./schemas/input/sign-payment-channel-claim.json'),
     require('./schemas/input/verify-payment-channel-claim.json'),
     require('./schemas/input/combine.json')

--- a/src/common/schemas/input/derive-address.json
+++ b/src/common/schemas/input/derive-address.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "deriveAddressParameters",
+  "type": "object",
+  "properties": {
+    "secret": {
+      "type": "string",
+      "format": "secret",
+      "description": "The secret of the account to derive the address for."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["secret"]
+}

--- a/src/common/schemas/output/derive-address.json
+++ b/src/common/schemas/output/derive-address.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "deriveAddress",
+  "type": "object",
+  "properties": {
+    "address": {
+      "$ref": "address",
+      "description": "A Ripple account address corresponding to the secret."
+    },
+    "secret": {
+      "type": "string",
+      "format": "secret",
+      "description": "The provided secret."
+    }
+  },
+  "required": ["address", "secret"],
+  "additionalProperties": false
+}

--- a/src/common/validate.ts
+++ b/src/common/validate.ts
@@ -113,6 +113,9 @@ _.partial(schemaValidate, 'computeLedgerHashParameters')
 export const generateAddress =
 _.partial(schemaValidate, 'generateAddressParameters')
 
+export const deriveAddress =
+_.partial(schemaValidate, 'deriveAddressParameters')
+
 export const signPaymentChannelClaim =
 _.partial(schemaValidate, 'signPaymentChannelClaimParameters')
 

--- a/src/offline/derive-address.ts
+++ b/src/offline/derive-address.ts
@@ -1,0 +1,22 @@
+import keypairs = require('ripple-keypairs')
+import * as common from '../common'
+const {errors, validate} = common
+
+function deriveAddress(secret: string): Object {
+  const keypair = keypairs.deriveKeypair(secret)
+  const address = keypairs.deriveAddress(keypair.publicKey)
+  return {secret, address}
+}
+
+function deriveAddressAPI(secret): Object {
+  validate.deriveAddress({secret})
+  try {
+    return deriveAddress(secret)
+  } catch (error) {
+    throw new errors.UnexpectedError(error.message)
+  }
+}
+
+export {
+  deriveAddressAPI
+}

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1965,6 +1965,17 @@ describe('RippleAPI', function () {
     }, this.api.errors.UnexpectedError);
   });
 
+  it('deriveAddress', function() {
+    assert.deepEqual(this.api.deriveAddress('snUneA3NnRJDULZRaJBJdUtducjWK'),
+                     responses.deriveAddress);
+  });
+
+  it('deriveAddress invalid', function() {
+    assert.throws(() => {
+      this.api.deriveAddress('invalidsecret');
+    }, this.api.errors.ValidationError);
+  });
+
   it('getSettings', function () {
     return this.api.getSettings(address).then(
       _.partial(checkResult, responses.getSettings, 'getSettings'));

--- a/test/fixtures/responses/derive-address.json
+++ b/test/fixtures/responses/derive-address.json
@@ -1,0 +1,4 @@
+{
+  "address": "r4B7t5BqmHp3oPVHAnsMpPnw1QkuuJq7Z3",
+  "secret": "snUneA3NnRJDULZRaJBJdUtducjWK"
+}

--- a/test/fixtures/responses/index.js
+++ b/test/fixtures/responses/index.js
@@ -6,6 +6,7 @@ function buildList(options) {
 
 module.exports = {
   generateAddress: require('./generate-address.json'),
+  deriveAddress: require('./derive-address.json'),
   getAccountInfo: require('./get-account-info.json'),
   getAccountObjects: require('./get-account-objects.json'),
   getBalances: require('./get-balances.json'),

--- a/test/integration/http-integration-test.js
+++ b/test/integration/http-integration-test.js
@@ -183,6 +183,12 @@ describe('http server integration tests', function() {
   );
 
   createTest(
+    'deriveAddress',
+    [{secret: 'snUneA3NnRJDULZRaJBJdUtducjWK'}],
+    result => assert.deepEqual(result.result, apiResponses.deriveAddress)
+  );
+
+  createTest(
     'computeLedgerHash',
     [{ledger: _.assign({}, apiResponses.getLedger.full,
       {parentCloseTime: apiResponses.getLedger.full.closeTime})

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -439,6 +439,15 @@ describe('integration tests', function() {
     assert(isValidSecret(newWallet.secret));
   });
 
+  it('deriveWallet', function() {
+    const secret = 'snUneA3NnRJDULZRaJBJdUtducjWK';
+    const address = 'r4B7t5BqmHp3oPVHAnsMpPnw1QkuuJq7Z3';
+    const wallet = this.api.deriveAddress(secret);
+    assert(wallet && wallet.address && wallet.secret);
+    assert(address == wallet.address);
+    assert(secret == wallet.secret);
+  });
+
 });
 
 describe('integration tests - standalone rippled', function() {


### PR DESCRIPTION
Storing both the secret and the address of an account is redundant, as the address can be derived from the secret. The ripple-lib API does not offer any possibility to derive an address from a secret, thereby forcing clients to store redundant information. The deriveKeypair function from ripple-keypairs is used internally by ripple-lib, but is not exposed through the API. Since ripple-lib is "the official client library to the XRP Ledger", it would be natural for the API to offer this functionality.

This pull request contains a suggested addition of the function deriveAddress, to the API, that exposes the deriveKeypair functionality.