### PR TITLE
webpack config - include src instead of excluding node_modules

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -51,7 +51,9 @@ function getWebpackConfig(extension, overrides) {
       }, {
         test: /\.ts$/,
         use: 'ts-loader',
-        exclude: /node_modules/,
+        include: [
+          path.resolve(__dirname, 'src')
+        ]
       }, {
         test: /\.json/,
         use: 'json-loader',


### PR DESCRIPTION
In the process of working on https://github.com/ripple/ripple-lib/pull/840, I found that our webpack config prevents the `build` script (i.e. `yarn build`) from working when `node_modules` exists anywhere in the path.

For example, if ripple-lib is cloned to:
```
/Users/elliotlee/github/ripple-lib-browser-client/node_modules/ripple-lib
```

Then webpack will output a file containing this monstrosity:
```
/* 1 */
...
/***/ (function(module, exports) {

throw new Error("Module parse failed: Unexpected token (47:5)\nYou may need an appropriate loader to handle this file type.\n| import * as schemaValidator from './common/schema-validator'\n| \n| type APIOptions = {\n|   server?: string,\n|   feeCushion?: number,");

/***/ }),
...
```

The solution to this was found here: https://github.com/webpack/webpack/issues/2031

An alternate fix would be `exclude: path.resolve(__dirname, 'node_modules'),`. This also works, but I opted to use `include` instead because it's more explicit (all source files should be under `src`).