### PR TITLE
Add "browser" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "clean": "rm -rf dist/npm",
     "compile": "mkdir -p dist/npm/common && cp -r src/common/schemas dist/npm/common/ && tsc",
     "watch": "tsc -w",
-    "prepublish": "npm run clean && npm run compile",
+    "prepublish": "npm run clean && npm run compile && npm run build",
     "test": "nyc mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p ./",
@@ -79,6 +79,6 @@
   },
   "readmeFilename": "README.md",
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=6.12.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "clean": "rm -rf dist/npm",
     "compile": "mkdir -p dist/npm/common && cp -r src/common/schemas dist/npm/common/ && tsc",
     "watch": "tsc -w",
-    "prepublish": "npm run clean && npm run compile && npm run build",
+    "prepublish": "npm run clean && npm run compile",
     "test": "nyc mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p ./",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "Gulpfile.js"
   ],
   "main": "dist/npm/",
-  "browser": "./build/ripple-latest.js",
+  "browser": {
+    "ws": "./dist/npm/common/wswrapper.js"
+  },
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "Gulpfile.js"
   ],
   "main": "dist/npm/",
+  "browser": "./build/ripple-latest.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This should be an alternative to https://github.com/ripple/ripple-lib/pull/840

~~We need to run the `build` script for this file to exist, so how should we handle that?~~

~~Perhaps we can just make sure "./build/ripple-latest.js" is prebuilt and published to npm?~~

See also: https://github.com/ripple/ripple-lib/pull/844#issuecomment-363514078