### PR TITLE
Add build to prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "clean": "rm -rf dist/npm",
     "compile": "mkdir -p dist/npm/common && cp -r src/common/schemas dist/npm/common/ && tsc",
     "watch": "tsc -w",
-    "prepublish": "npm run clean && npm run compile",
+    "prepublish": "npm run clean && npm run compile && npm run build",
     "test": "nyc mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "tslint -p ./",


### PR DESCRIPTION
/cc @intelliot 
Follow up from #847:

We should continue to publish `build/` directory so that our users can grab it from CDN's like [unpkg.com](https://unpkg.com/ripple-lib@0.18.1/build/ripple-latest.js). When publishing, we should make sure our `build/` directory matches the latest compiled `dist/` directory by also building right before publishing.