### PR TITLE
Export types used by exported variables

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -53,7 +53,7 @@ import * as ledgerUtils from './ledger/utils'
 import * as schemaValidator from './common/schema-validator'
 import {clamp} from './ledger/utils'
 
-type APIOptions = {
+export type APIOptions = {
   server?: string,
   feeCushion?: number,
   trace?: boolean,
@@ -79,7 +79,7 @@ function getCollectKeyFromCommand(command: string): string|undefined {
 }
 
 // prevent access to non-validated ledger versions
-class RestrictedConnection extends Connection {
+export class RestrictedConnection extends Connection {
   request(request: any, timeout?: number) {
     const ledger_index = request.ledger_index
     if (ledger_index !== undefined && ledger_index !== 'validated') {

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -13,7 +13,7 @@ function isStreamMessageType(type) {
          type === 'path_find'
 }
 
-interface ConnectionOptions {
+export interface ConnectionOptions {
   trace?: boolean,
   proxy?: string
   proxyAuthorization?: string

--- a/src/common/types/commands/account_info.ts
+++ b/src/common/types/commands/account_info.ts
@@ -18,7 +18,7 @@ export interface AccountInfoResponse {
   validated?: boolean
 }
 
-interface QueueData {
+export interface QueueData {
   txn_count: number,
   auth_change_queued?: boolean,
   lowest_sequence?: number,
@@ -27,7 +27,7 @@ interface QueueData {
   transactions?: TransactionData[]
 }
 
-interface TransactionData {
+export interface TransactionData {
   auth_change?: boolean,
   fee?: string,
   fee_level?: string,

--- a/src/common/types/commands/book_offers.ts
+++ b/src/common/types/commands/book_offers.ts
@@ -22,7 +22,7 @@ export interface BookOffersResponse {
   marker?: any
 }
 
-interface OrderBookOffer extends OfferCreateTransaction {
+export interface OrderBookOffer extends OfferCreateTransaction {
   quality?: number
   owner_funds?: string,
   taker_gets_funded?: RippledAmount,

--- a/src/ledger/accountinfo.ts
+++ b/src/ledger/accountinfo.ts
@@ -2,11 +2,11 @@ import {validate, removeUndefined, dropsToXrp} from '../common'
 import {RippleAPI} from '../api'
 import {AccountInfoResponse} from '../common/types/commands/account_info'
 
-type GetAccountInfoOptions = {
+export type GetAccountInfoOptions = {
   ledgerVersion?: number
 }
 
-type FormattedGetAccountInfoResponse = {
+export type FormattedGetAccountInfoResponse = {
   sequence: number,
   xrpBalance: string,
   ownerCount: number,

--- a/src/ledger/balance-sheet.ts
+++ b/src/ledger/balance-sheet.ts
@@ -4,12 +4,12 @@ import {Amount} from '../common/types/objects'
 import {ensureLedgerVersion} from './utils'
 import {RippleAPI} from '../api'
 
-type BalanceSheetOptions = {
+export type BalanceSheetOptions = {
   excludeAddresses?: Array<string>,
   ledgerVersion?: number
 }
 
-type GetBalanceSheet = {
+export type GetBalanceSheet = {
   balances?: Array<Amount>,
   assets?: Array<Amount>,
   obligations?: Array<{

--- a/src/ledger/balances.ts
+++ b/src/ledger/balances.ts
@@ -5,13 +5,13 @@ import {GetTrustlinesOptions} from './trustlines'
 import {FormattedTrustline} from '../common/types/objects/trustlines'
 
 
-type Balance = {
+export type Balance = {
   value: string,
   currency: string,
   counterparty?: string
 }
 
-type GetBalances = Array<Balance>
+export type GetBalances = Array<Balance>
 
 function getTrustlineBalanceAmount(trustline: FormattedTrustline) {
   return {

--- a/src/ledger/ledger.ts
+++ b/src/ledger/ledger.ts
@@ -2,7 +2,7 @@ import {validate} from '../common'
 import parseLedger from './parse/ledger'
 import {GetLedger} from './types'
 
-type LedgerOptions = {
+export type LedgerOptions = {
   ledgerVersion?: number,
   includeAllData?: boolean,
   includeTransactions?: boolean,

--- a/src/ledger/orderbook.ts
+++ b/src/ledger/orderbook.ts
@@ -12,11 +12,12 @@ export type OrdersOptions = {
   ledgerVersion?: number
 }
 
-type Orderbook = {
+export type Orderbook = {
   base: Issue,
   counter: Issue
 }
-type OrderbookItem = {
+
+export type OrderbookItem = {
    specification: OrderSpecification,
    properties: {
     maker: string,
@@ -29,9 +30,9 @@ type OrderbookItem = {
   }
 }
 
-type OrderbookOrders = Array<OrderbookItem>
+export type OrderbookOrders = Array<OrderbookItem>
 
-type GetOrderbook = {
+export type GetOrderbook = {
   bids: OrderbookOrders,
   asks: OrderbookOrders
 }

--- a/src/ledger/parse/payment-channel.ts
+++ b/src/ledger/parse/payment-channel.ts
@@ -29,7 +29,7 @@ export type LedgerEntryResponse = {
   validated: boolean
 }
 
-type PaymentChannelResponse = {
+export type PaymentChannelResponse = {
   account: string,
   balance: string,
   publicKey: string,

--- a/src/ledger/settings.ts
+++ b/src/ledger/settings.ts
@@ -3,11 +3,11 @@ import parseFields from './parse/fields'
 import {validate, constants} from '../common'
 const AccountFlags = constants.AccountFlags
 
-type SettingsOptions = {
+export type SettingsOptions = {
   ledgerVersion?: number
 }
 
-type GetSettings = {
+export type GetSettings = {
   passwordSpent?: boolean,
   requireDestinationTag?: boolean,
   requireAuthorization?: boolean,

--- a/src/ledger/transaction-types.ts
+++ b/src/ledger/transaction-types.ts
@@ -1,7 +1,7 @@
 
 import {Amount, Memo} from '../common/types/objects'
 
-type Outcome = {
+export type Outcome = {
   result: string,
   ledgerVersion: number,
   indexInLedger: number,
@@ -17,7 +17,7 @@ type Outcome = {
   timestamp?: string
 }
 
-type Adjustment = {
+export type Adjustment = {
   address: string,
   amount: {
    currency: string,
@@ -27,7 +27,7 @@ type Adjustment = {
   tag?: number
 }
 
-type Trustline = {
+export type Trustline = {
   currency: string,
   counterparty: string,
   limit: string,
@@ -38,7 +38,7 @@ type Trustline = {
   frozen?: boolean
 }
 
-type Settings = {
+export type Settings = {
   passwordSpent?: boolean,
   requireDestinationTag?: boolean,
   requireAuthorization?: boolean,
@@ -56,11 +56,11 @@ type Settings = {
   regularKey?: string
 }
 
-type OrderCancellation = {
+export type OrderCancellation = {
   orderSequence: number
 }
 
-type Payment = {
+export type Payment = {
   source: Adjustment,
   destination: Adjustment,
   paths?: string,
@@ -71,7 +71,7 @@ type Payment = {
   limitQuality?: boolean
 }
 
-type PaymentTransaction = {
+export type PaymentTransaction = {
   type: string,
   specification: Payment,
   outcome: Outcome,
@@ -92,7 +92,7 @@ export type Order = {
   memos?: Memo[]
 }
 
-type OrderTransaction = {
+export type OrderTransaction = {
   type: string,
   specification: Order,
   outcome: Outcome,
@@ -101,7 +101,7 @@ type OrderTransaction = {
   sequence: number
 }
 
-type OrderCancellationTransaction = {
+export type OrderCancellationTransaction = {
   type: string,
   specification: OrderCancellation,
   outcome: Outcome,
@@ -110,7 +110,7 @@ type OrderCancellationTransaction = {
   sequence: number
 }
 
-type TrustlineTransaction = {
+export type TrustlineTransaction = {
   type: string,
   specification: Trustline,
   outcome: Outcome,
@@ -119,7 +119,7 @@ type TrustlineTransaction = {
   sequence: number
 }
 
-type SettingsTransaction = {
+export type SettingsTransaction = {
   type: string,
   specification: Settings,
   outcome: Outcome,

--- a/src/ledger/transactions.ts
+++ b/src/ledger/transactions.ts
@@ -9,7 +9,7 @@ import {Connection} from '../common'
 import {TransactionType} from './transaction-types'
 
 
-type TransactionsOptions = {
+export type TransactionsOptions = {
   start?: string,
   limit?: number,
   minLedgerVersion?: number,
@@ -23,7 +23,7 @@ type TransactionsOptions = {
   startTx?: TransactionType
 }
 
-type GetTransactionsResponse = Array<TransactionType>
+export type GetTransactionsResponse = Array<TransactionType>
 
 function parseBinaryTransaction(transaction) {
   const tx = binary.decode(transaction.tx_blob)

--- a/src/ledger/utils.ts
+++ b/src/ledger/utils.ts
@@ -5,12 +5,12 @@ import {Connection} from '../common'
 import {TransactionType} from './transaction-types'
 import {Issue} from '../common/types/objects'
 
-type RecursiveData = {
+export type RecursiveData = {
   marker: string,
   results: Array<any>
 }
 
-type Getter = (marker?: string, limit?: number) => Promise<RecursiveData>
+export type Getter = (marker?: string, limit?: number) => Promise<RecursiveData>
 
 function clamp(value: number, min: number, max: number): number {
   assert(min <= max, 'Illegal clamp bounds')
@@ -59,7 +59,7 @@ function renameCounterpartyToIssuer<T>(
   return withIssuer
 }
 
-type RequestBookOffersArgs = {taker_gets: Issue, taker_pays: Issue}
+export type RequestBookOffersArgs = {taker_gets: Issue, taker_pays: Issue}
 
 function renameCounterpartyToIssuerInOrder(order: RequestBookOffersArgs) {
   const taker_gets = renameCounterpartyToIssuer(order.taker_gets)

--- a/src/transaction/escrow-cancellation.ts
+++ b/src/transaction/escrow-cancellation.ts
@@ -4,7 +4,7 @@ const validate = utils.common.validate
 import {Instructions, Prepare} from './types'
 import {Memo} from '../common/types/objects'
 
-type EscrowCancellation = {
+export type EscrowCancellation = {
   owner: string,
   escrowSequence: number,
   memos?: Array<Memo>

--- a/src/transaction/escrow-creation.ts
+++ b/src/transaction/escrow-creation.ts
@@ -5,7 +5,7 @@ const ValidationError = utils.common.errors.ValidationError
 import {Instructions, Prepare} from './types'
 import {Memo} from '../common/types/objects'
 
-type EscrowCreation = {
+export type EscrowCreation = {
   amount: string,
   destination: string,
   memos?: Array<Memo>,

--- a/src/transaction/escrow-execution.ts
+++ b/src/transaction/escrow-execution.ts
@@ -5,7 +5,7 @@ const ValidationError = utils.common.errors.ValidationError
 import {Instructions, Prepare} from './types'
 import {Memo} from '../common/types/objects'
 
-type EscrowExecution = {
+export type EscrowExecution = {
   owner: string,
   escrowSequence: number,
   memos?: Array<Memo>,

--- a/src/transaction/payment-channel-claim.ts
+++ b/src/transaction/payment-channel-claim.ts
@@ -4,7 +4,7 @@ const claimFlags = utils.common.txFlags.PaymentChannelClaim
 import {validate, xrpToDrops} from '../common'
 import {Instructions, Prepare} from './types'
 
-type PaymentChannelClaim = {
+export type PaymentChannelClaim = {
   channel: string,
   balance?: string,
   amount?: string,

--- a/src/transaction/payment-channel-create.ts
+++ b/src/transaction/payment-channel-create.ts
@@ -2,7 +2,7 @@ import * as utils from './utils'
 import {validate, iso8601ToRippleTime, xrpToDrops} from '../common'
 import {Instructions, Prepare} from './types'
 
-type PaymentChannelCreate = {
+export type PaymentChannelCreate = {
   amount: string,
   destination: string,
   settleDelay: number,

--- a/src/transaction/payment-channel-fund.ts
+++ b/src/transaction/payment-channel-fund.ts
@@ -2,7 +2,7 @@ import * as utils from './utils'
 import {validate, iso8601ToRippleTime, xrpToDrops} from '../common'
 import {Instructions, Prepare} from './types'
 
-type PaymentChannelFund = {
+export type PaymentChannelFund = {
   channel: string,
   amount: string,
   expiration?: string

--- a/src/transaction/payment.ts
+++ b/src/transaction/payment.ts
@@ -9,7 +9,7 @@ import {Amount, Adjustment, MaxAdjustment,
   MinAdjustment, Memo} from '../common/types/objects'
 
 
-type Payment = {
+  export type Payment = {
   source: Adjustment & MaxAdjustment,
   destination: Adjustment & MinAdjustment,
   paths?: string,

--- a/src/transaction/settings.ts
+++ b/src/transaction/settings.ts
@@ -8,12 +8,12 @@ const AccountFields = utils.common.constants.AccountFields
 import {Instructions, Prepare} from './types'
 import {Memo} from '../common/types/objects'
 
-type WeightedSigner = {address: string, weight: number}
-type SettingsSigners = {
+export type WeightedSigner = {address: string, weight: number}
+export type SettingsSigners = {
   threshold?: number,
   weights: WeightedSigner[]
 }
-type Settings = {
+export type Settings = {
   passwordSpent?: boolean,
   requireDestinationTag?: boolean,
   requireAuthorization?: boolean,


### PR DESCRIPTION
I found that `tsc` was giving me these errors:
```
src/api.ts(99,15): error TS4031: Public property 'connection' of exported class has or is using private name 'RestrictedConnection'.
src/api.ts(109,24): error TS4063: Parameter 'options' of constructor from exported class has or is using private name 'APIOptions'.
src/api.ts(221,3): error TS4029: Public property 'connect' of exported class has or is using name 'connect' from external module "/Users/user/ripple/ripple-lib/src/server/server" but cannot be named.
src/api.ts(222,3): error TS4029: Public property 'disconnect' of exported class has or is using name 'disconnect' from external module "/Users/user/ripple/ripple-lib/src/server/server" but cannot be named.
src/api.ts(223,3): error TS4029: Public property 'isConnected' of exported class has or is using name 'isConnected' from external module "/Users/user/ripple/ripple-lib/src/server/server" but cannot be named.
src/api.ts(224,3): error TS4029: Public property 'getServerInfo' of exported class has or is using name 'getServerInfo' from external module "/Users/user/ripple/ripple-lib/src/server/server" but cannot be named.
src/api.ts(225,3): error TS4029: Public property 'getFee' of exported class has or is using name 'getFee' from external module "/Users/user/ripple/ripple-lib/src/server/server" but cannot be named.
src/api.ts(226,3): error TS4029: Public property 'getLedgerVersion' of exported class has or is using name 'getLedgerVersion' from external module "/Users/user/ripple/ripple-lib/src/server/server" but cannot be named.
src/common/connection.ts(53,29): error TS4063: Parameter 'options' of constructor from exported class has or is using private name 'ConnectionOptions'.
src/common/types/commands/account_info.ts(17,16): error TS4033: Property 'queue_data' of exported interface has or is using private name 'QueueData'.
src/common/types/commands/book_offers.ts(18,11): error TS4033: Property 'offers' of exported interface has or is using private name 'OrderBookOffer'.
src/ledger/accountinfo.ts(33,46): error TS4078: Parameter 'options' of exported function has or is using private name 'GetAccountInfoOptions'.
src/ledger/accountinfo.ts(34,12): error TS4060: Return type of exported function has or is using private name 'FormattedGetAccountInfoResponse'.
src/ledger/balance-sheet.ts(51,46): error TS4078: Parameter 'options' of exported function has or is using private name 'BalanceSheetOptions'.
src/ledger/balance-sheet.ts(52,12): error TS4060: Return type of exported function has or is using private name 'GetBalanceSheet'.
src/ledger/balances.ts(51,12): error TS4060: Return type of exported function has or is using private name 'GetBalances'.
src/ledger/ledger.ts(13,29): error TS4078: Parameter 'options' of exported function has or is using private name 'LedgerOptions'.
src/ledger/orderbook.ts(104,14): error TS4078: Parameter 'orderbook' of exported function has or is using private name 'Orderbook'.
src/ledger/orderbook.ts(106,12): error TS4060: Return type of exported function has or is using private name 'GetOrderbook'.
src/ledger/parse/payment-channel.ts(46,53): error TS4060: Return type of exported function has or is using private name 'PaymentChannelResponse'.
src/ledger/settings.ts(46,48): error TS4078: Parameter 'options' of exported function has or is using private name 'SettingsOptions'.
src/ledger/settings.ts(47,12): error TS4060: Return type of exported function has or is using private name 'GetSettings'.
src/ledger/transaction-types.ts(136,31): error TS4081: Exported type alias 'TransactionType' has or is using private name 'PaymentTransaction'.
src/ledger/transaction-types.ts(136,52): error TS4081: Exported type alias 'TransactionType' has or is using private name 'OrderTransaction'.
src/ledger/transaction-types.ts(137,3): error TS4081: Exported type alias 'TransactionType' has or is using private name 'OrderCancellationTransaction'.
src/ledger/transaction-types.ts(137,34): error TS4081: Exported type alias 'TransactionType' has or is using private name 'TrustlineTransaction'.
src/ledger/transaction-types.ts(137,57): error TS4081: Exported type alias 'TransactionType' has or is using private name 'SettingsTransaction'.
src/ledger/transactions.ts(161,52): error TS4078: Parameter 'options' of exported function has or is using private name 'TransactionsOptions'.
src/ledger/transactions.ts(162,12): error TS4060: Return type of exported function has or is using private name 'GetTransactionsResponse'.
src/ledger/utils.ts(47,31): error TS4078: Parameter 'getter' of exported function has or is using private name 'Getter'.
src/ledger/utils.ts(64,51): error TS4078: Parameter 'order' of exported function has or is using private name 'RequestBookOffersArgs'.
src/transaction/escrow-cancellation.ts(29,23): error TS4078: Parameter 'escrowCancellation' of exported function has or is using private name 'EscrowCancellation'.
src/transaction/escrow-creation.ts(56,19): error TS4078: Parameter 'escrowCreation' of exported function has or is using private name 'EscrowCreation'.
src/transaction/escrow-execution.ts(44,20): error TS4078: Parameter 'escrowExecution' of exported function has or is using private name 'EscrowExecution'.
src/transaction/payment-channel-claim.ts(62,24): error TS4078: Parameter 'paymentChannelClaim' of exported function has or is using private name 'PaymentChannelClaim'.
src/transaction/payment-channel-create.ts(41,25): error TS4078: Parameter 'paymentChannelCreate' of exported function has or is using private name 'PaymentChannelCreate'.
src/transaction/payment-channel-fund.ts(29,23): error TS4078: Parameter 'paymentChannelFund' of exported function has or is using private name 'PaymentChannelFund'.
src/transaction/payment.ts(146,51): error TS4078: Parameter 'payment' of exported function has or is using private name 'Payment'.
src/transaction/settings.ts(149,53): error TS4078: Parameter 'settings' of exported function has or is using private name 'Settings'.
```

These occur due to generating TS declaration files (see #851).

This PR fixes the errors by exporting the types.

/cc @FredKSchott 