### PR TITLE
Point to types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build/*"
   ],
   "main": "dist/npm/",
+  "types": "dist/npm/index.d.ts",
   "browser": {
     "ws": "./dist/npm/common/wswrapper.js"
   },


### PR DESCRIPTION
The `types` property in `package.json` should point to main types declaration file.

via https://github.com/ripple/ripple-lib/pull/851#issuecomment-370236308