### PR TITLE
Ledger object - accountState supersedes accounts

### DIFF
--- a/src/common/types/objects/ledger.ts
+++ b/src/common/types/objects/ledger.ts
@@ -1,6 +1,5 @@
 export interface Ledger {
   account_hash: string,
-  accounts?: any[],
   close_time: number,
   close_time_human: string,
   close_time_resolution: number,
@@ -22,5 +21,5 @@ export interface Ledger {
   // TODO: undocumented
   parent_close_time?: number,
   // TODO: undocumented
-  accountState?: any
+  accountState?: any[]
 }

--- a/src/common/types/objects/ledger.ts
+++ b/src/common/types/objects/ledger.ts
@@ -16,10 +16,7 @@ export interface Ledger {
   totalCoins?: string,
   // @deprecated
   hash?: string,
-  // TODO: undocumented
   close_flags?: number,
-  // TODO: undocumented
   parent_close_time?: number,
-  // TODO: undocumented
   accountState?: any[]
 }


### PR DESCRIPTION
This appears to originate from a mistake in the docs.
The actual name of the field is `accountState`.

- In rippled, [here is where `accountState` gets added to the response](https://github.com/ripple/rippled/blame/9af994ceb45a82861205bb9d0b8d845cec950524/src/ripple/app/ledger/impl/LedgerToJson.cpp#L167)
- [PR to update the docs](https://github.com/ripple/ripple-dev-portal/pull/324)