### PR TITLE
Add linting to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
   - yarn compile
   - yarn test
   - yarn build
+  - yarn lint


### PR DESCRIPTION
It's currently possible to merge code that fails linting without Travis noticing. We should enforce linting for code being reviewed/merged.