### PR TITLE
getOrderbook - return raw order data

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2272,6 +2272,7 @@ bids[] | object | An order in the order book.
 *bids[].properties.* maker | [address](#address) | The address of the account that submitted the order.
 *bids[].properties.* sequence | [sequence](#account-sequence-number) | The account sequence number of the transaction that created this order.
 *bids[].properties.* makerExchangeRate | [value](#value) | The exchange rate from the point of view of the account that submitted the order (also known as "quality").
+*bids[].data.* \* | object | 
 *bids[].* state | object | *Optional* The state of the order.
 *bids[].state.* fundedAmount | [amount](#amount) | How much of the amount the maker would have to pay that the maker currently holds.
 *bids[].state.* priceOfFundedAmount | [amount](#amount) | How much the `fundedAmount` would convert to through the exchange rate of this order.
@@ -2282,9 +2283,16 @@ asks[] | object | An order in the order book.
 *asks[].properties.* maker | [address](#address) | The address of the account that submitted the order.
 *asks[].properties.* sequence | [sequence](#account-sequence-number) | The account sequence number of the transaction that created this order.
 *asks[].properties.* makerExchangeRate | [value](#value) | The exchange rate from the point of view of the account that submitted the order (also known as "quality").
+*asks[].data.* \* | object | 
 *asks[].* state | object | *Optional* The state of the order.
 *asks[].state.* fundedAmount | [amount](#amount) | How much of the amount the maker would have to pay that the maker currently holds.
 *asks[].state.* priceOfFundedAmount | [amount](#amount) | How much the `fundedAmount` would convert to through the exchange rate of this order.
+
+### New in ripple-lib 0.22.0 and higher
+
+The response includes a `data` property containing the raw order data. This may include `owner_funds`, `Flags`, and other fields.
+
+For details, see the rippled method [book_offers](https://ripple.com/build/rippled-apis/#book-offers).
 
 ### Example
 
@@ -2326,6 +2334,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
         "sequence": 386940,
         "makerExchangeRate": "326.5003614141928"
+      },
+      "data": {
+        "Account": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570B9980E49C7DE8",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000008",
+        "PreviousTxnID": "92DBA0BE18B331AC61FB277211477A255D3B5EA9C5FE689171DE689FB45FE18A",
+        "PreviousTxnLgrSeq": 10714030,
+        "Sequence": 386940,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.2849323720855092"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "93.030522464522"
+        },
+        "index": "8092033091034D94219BC1131AF7A6B469D790D81831CB479AB6F67A32BE4E13",
+        "owner_funds": "31.77682120227525",
+        "quality": "326.5003614141928"
       }
     },
     {
@@ -2346,6 +2378,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
         "sequence": 207855,
         "makerExchangeRate": "330.6364334177034"
+      },
+      "data": {
+        "Account": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570BBF1EEFA2FB0A",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "C6BDA152363E3CFE18688A6830B49F3DB2B05976110B5908EA4EB66D93DEEB1F",
+        "PreviousTxnLgrSeq": 10714031,
+        "Sequence": 207855,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.00302447007930511"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1"
+        },
+        "index": "8DB3520FF9CB16A0EA955056C49115F8CFB03A587D0A4AFC844F1D220EFCE0B9",
+        "owner_funds": "0.0670537912615556",
+        "quality": "330.6364334177034"
       }
     },
     {
@@ -2367,6 +2423,31 @@ return api.getOrderbook(address, orderbook)
         "maker": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
         "sequence": 110103,
         "makerExchangeRate": "331.1338298016111"
+      },
+      "data": {
+        "Account": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570BC3A506FC016F",
+        "BookNode": "0000000000000000",
+        "Expiration": 472785283,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000008F0",
+        "PreviousTxnID": "77E763F1D02F58965CD1AD94F557B37A582FAC7760B71F391B856959836C2F7B",
+        "PreviousTxnLgrSeq": 10713576,
+        "Sequence": 110103,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.3"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "99.34014894048333"
+        },
+        "index": "9ECDFD31B28643FD3A54658398C5715D6DAD574F83F04529CB24765770F9084D",
+        "owner_funds": "4.021116654525635",
+        "quality": "331.1338298016111"
       }
     },
     {
@@ -2399,6 +2480,40 @@ return api.getOrderbook(address, orderbook)
           "value": "268.2219496064341",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rPyYxUGK8L4dgEvjPs3aRc1B1jEiLr3Hx5",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570BCB85BCA78000",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "D22993C68C94ACE3F2FCE4A334EBEA98CC46DCA92886C12B5E5B4780B5E17D4E",
+        "PreviousTxnLgrSeq": 10711938,
+        "Sequence": 392,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8095"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "268.754"
+        },
+        "index": "18B136E08EF50F0DEE8521EA22D16A950CD8B6DDF5F6E07C35F7FDDBBB09718D",
+        "owner_funds": "0.8095132334507441",
+        "quality": "332",
+        "taker_gets_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8078974385735969"
+        },
+        "taker_pays_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "268.2219496064341"
+        }
       }
     },
     {
@@ -2420,6 +2535,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
         "sequence": 110105,
         "makerExchangeRate": "337.7996295968016"
+      },
+      "data": {
+        "Account": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570C00450D461510",
+        "BookNode": "0000000000000000",
+        "Expiration": 472785284,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000008F0",
+        "PreviousTxnID": "1F4D9D859D9AABA888C0708A572B38919A3AEF2C8C1F5A13F58F44C92E5FF3FB",
+        "PreviousTxnLgrSeq": 10713576,
+        "Sequence": 110105,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.4499999999999999"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "152.0098333185607"
+        },
+        "index": "9F380E0B39E2AF8AA9608C3E39A5A8628E6D0F44385C6D12BE06F4FEC8D83351",
+        "quality": "337.7996295968016"
       }
     },
     {
@@ -2440,6 +2579,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
         "sequence": 110061,
         "makerExchangeRate": "347.2306949944844"
+      },
+      "data": {
+        "Account": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570C560B764D760C",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000001",
+        "PreviousTxnID": "9A0B6B76F0D86614F965A2FFCC8859D8607F4E424351D4CFE2FBE24510F93F25",
+        "PreviousTxnLgrSeq": 10708382,
+        "Sequence": 110061,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.003768001830745216"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.308365894430151"
+        },
+        "index": "B971769686CE1B9139502770158A4E7C011CFF8E865E5AAE5428E23AAA0E146D",
+        "owner_funds": "0.2229210189326514",
+        "quality": "347.2306949944844"
       }
     },
     {
@@ -2461,6 +2624,31 @@ return api.getOrderbook(address, orderbook)
         "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
         "sequence": 35788,
         "makerExchangeRate": "352.7092203179974"
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570C87DF25DC4FC6",
+        "BookNode": "0000000000000000",
+        "Expiration": 472783298,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003D2",
+        "PreviousTxnID": "E5F9A10F29A4BB3634D5A84FC96931E17267B58E0D2D5ADE24FFB751E52ADB9E",
+        "PreviousTxnLgrSeq": 10713533,
+        "Sequence": 35788,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.5"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "176.3546101589987"
+        },
+        "index": "D2CB71038AD0ECAF4B5FF0A953AD1257225D0071E6F3AF9ADE67F05590B45C6E",
+        "owner_funds": "6.617688680663627",
+        "quality": "352.7092203179974"
       }
     },
     {
@@ -2493,6 +2681,40 @@ return api.getOrderbook(address, orderbook)
           "value": "179.1217564870259",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rN6jbxx4H6NxcnmkzBxQnbCWLECNKrgSSf",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570CC0B8E0E2C000",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "2E16ACFEAC2306E3B3483D445787F3496FACF9504F7A5E909620C1A73E2EDE54",
+        "PreviousTxnLgrSeq": 10558020,
+        "Sequence": 491,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.5"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "179.48"
+        },
+        "index": "DA853913C8013C9471957349EDAEE4DF4846833B8CCB92008E2A8994E37BEF0D",
+        "owner_funds": "0.5",
+        "quality": "358.96",
+        "taker_gets_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.499001996007984"
+        },
+        "taker_pays_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "179.1217564870259"
+        }
       }
     },
     {
@@ -2514,6 +2736,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
         "sequence": 35789,
         "makerExchangeRate": "360.9637829743709"
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570CD2F24C9C145D",
+        "BookNode": "0000000000000000",
+        "Expiration": 472783299,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003D2",
+        "PreviousTxnID": "B1B12E47043B4260223A2C4240D19E93526B55B1DB38DEED335DACE7C04FEB23",
+        "PreviousTxnLgrSeq": 10713534,
+        "Sequence": 35789,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "288.7710263794967"
+        },
+        "index": "B89AD580E908F7337CCBB47A0BAAC6417EF13AC3465E34E8B7DD3BED016EA833",
+        "quality": "360.9637829743709"
       }
     },
     {
@@ -2546,6 +2792,40 @@ return api.getOrderbook(address, orderbook)
           "value": "82.50309772176658",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rUeCeioKJkbYhv4mRGuAbZpPcqkMCoYq6N",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570D0069F50EA028",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000012",
+        "PreviousTxnID": "F0E8ABF07F83DF0B5EF5B417E8E29A45A5503BA8F26FBC86447CC6B1FAD6A1C4",
+        "PreviousTxnLgrSeq": 10447672,
+        "Sequence": 5255,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.5"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "182.9814890090516"
+        },
+        "index": "D652DCE4B19C6CB43912651D3A975371D3B2A16A034EDF07BC11BF721AEF94A4",
+        "owner_funds": "0.225891986027944",
+        "quality": "365.9629780181032",
+        "taker_gets_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.2254411038203033"
+        },
+        "taker_pays_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "82.50309772176658"
+        }
       }
     }
   ],
@@ -2568,6 +2848,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
         "sequence": 434,
         "makerExchangeRate": "0.003120027456241615"
+      },
+      "data": {
+        "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B15A60037FFCF",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "544932DC56D72E845AF2B738821FE07865E32EC196270678AB0D947F54E9F49F",
+        "PreviousTxnLgrSeq": 10679000,
+        "Sequence": 434,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "3205.1"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "10"
+        },
+        "index": "CE457115A4ADCC8CB351B3E35A0851E48DE16605C23E305017A9B697B156DE5A",
+        "owner_funds": "41952.95917199965",
+        "quality": "0.003120027456241615"
       }
     },
     {
@@ -2588,6 +2892,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rDYCRhpahKEhCFV25xScg67Bwf4W9sTYAm",
         "sequence": 233,
         "makerExchangeRate": "0.003125"
+      },
+      "data": {
+        "Account": "rDYCRhpahKEhCFV25xScg67Bwf4W9sTYAm",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B1A2BC2EC5000",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "F68F9658AB3D462FEB027E6C380F054BC6D2514B43EC3C6AD46EE19C59BF1CC3",
+        "PreviousTxnLgrSeq": 10704238,
+        "Sequence": 233,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1599.063669386278"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "4.99707396683212"
+        },
+        "index": "BF14FBB305159DBCAEA91B7E848408F5B559A91B160EBCB6D244958A6A16EA6B",
+        "owner_funds": "3169.910902910102",
+        "quality": "0.003125"
       }
     },
     {
@@ -2620,6 +2948,41 @@ return api.getOrderbook(address, orderbook)
           "currency": "BTC",
           "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "data": {
+        "Account": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B2BF1C2F4D4C9",
+        "BookNode": "0000000000000000",
+        "Expiration": 472785284,
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000008F0",
+        "PreviousTxnID": "446410E1CD718AC01929DD16B558FCF6B3A7B8BF208C420E67A280C089C5C59B",
+        "PreviousTxnLgrSeq": 10713576,
+        "Sequence": 110104,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "143.1050962074379"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.4499999999999999"
+        },
+        "index": "67924B0EAA15784CC00CCD5FDD655EE2D6D2AE40341776B5F14E52341E7FC73E",
+        "owner_funds": "0",
+        "quality": "0.003144542101755081",
+        "taker_gets_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        },
+        "taker_pays_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
         }
       }
     },
@@ -2654,6 +3017,41 @@ return api.getOrderbook(address, orderbook)
           "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B2CD7A2BFBB75",
+        "BookNode": "0000000000000000",
+        "Expiration": 472772651,
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003CD",
+        "PreviousTxnID": "D49164AB68DDA3AEC9DFCC69A35685C4F532B5C231D3C1D25FEA7D5D0224FB84",
+        "PreviousTxnLgrSeq": 10711128,
+        "Sequence": 35625,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "254.329207354604"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8"
+        },
+        "index": "567BF2825173E3FB28FC94E436B6EB30D9A415FC2335E6D25CDE1BE47B25D120",
+        "owner_funds": "0",
+        "quality": "0.003145529403882357",
+        "taker_gets_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        },
+        "taker_pays_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        }
       }
     },
     {
@@ -2674,6 +3072,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
         "sequence": 387756,
         "makerExchangeRate": "0.003155743848271834"
+      },
+      "data": {
+        "Account": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B3621DF140FDA",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000008",
+        "PreviousTxnID": "2E371E2B287C8A9FBB3424E4204B17AD9FA1BAA9F3B33C7D2261E3B038AFF083",
+        "PreviousTxnLgrSeq": 10716291,
+        "Sequence": 387756,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "390.4979"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.23231134568807"
+        },
+        "index": "8CA23E55BF9F46AC7E803D3DB40FD03225EFCA66650D4CF0CBDD28A7CCDC8400",
+        "owner_funds": "5704.824764087842",
+        "quality": "0.003155743848271834"
       }
     },
     {
@@ -2694,6 +3116,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
         "sequence": 208927,
         "makerExchangeRate": "0.003160328237957649"
+      },
+      "data": {
+        "Account": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B3A4D41FF4211",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "91763FA7089C63CC4D5D14CBA6A5A5BF7ECE949B0D34F00FD35E733AF9F05AF1",
+        "PreviousTxnLgrSeq": 10716292,
+        "Sequence": 208927,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.003160328237957649"
+        },
+        "index": "7206866E39D9843623EE79E570242753DEE3C597F3856AEFB4631DD5AD8B0557",
+        "owner_funds": "45.55665106096075",
+        "quality": "0.003160328237957649"
       }
     },
     {
@@ -2714,6 +3160,29 @@ return api.getOrderbook(address, orderbook)
         "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
         "sequence": 429,
         "makerExchangeRate": "0.003174603174603175"
+      },
+      "data": {
+        "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B4748E68669A7",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "3B3CF6FF1A336335E78513CF77AFD3A784ACDD7B1B4D3F1F16E22957A060BFAE",
+        "PreviousTxnLgrSeq": 10639969,
+        "Sequence": 429,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "4725"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "15"
+        },
+        "index": "42894809370C7E6B23498EF8E22AD4B05F02B94F08E6983357A51EA96A95FF7F",
+        "quality": "0.003174603174603175"
       }
     },
     {
@@ -2734,6 +3203,30 @@ return api.getOrderbook(address, orderbook)
         "maker": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
         "sequence": 110099,
         "makerExchangeRate": "0.003193013959408667"
+      },
+      "data": {
+        "Account": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B58077ED03C1B",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000001",
+        "PreviousTxnID": "98F3F2D02D3BB0AEAC09EECCF2F24BBE5E1AB2C71C40D7BD0A5199E12541B6E2",
+        "PreviousTxnLgrSeq": 10715839,
+        "Sequence": 110099,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.24252537879871"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.003967400879423823"
+        },
+        "index": "F4404D6547149419D3607F81D7080979FBB3AFE2661F9A933E2F6C07AC1D1F6D",
+        "owner_funds": "73.52163803897041",
+        "quality": "0.003193013959408667"
       }
     },
     {
@@ -2767,6 +3260,40 @@ return api.getOrderbook(address, orderbook)
           "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B72A555B981A3",
+        "BookNode": "0000000000000000",
+        "Expiration": 472772652,
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003CD",
+        "PreviousTxnID": "146C8DBB047BAAFAE5B8C8DECCCDACD9DFCD7A464E5AB273230FF975E9B83CF7",
+        "PreviousTxnLgrSeq": 10711128,
+        "Sequence": 35627,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "496.5429474010489"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.6"
+        },
+        "index": "50CAA04E81D0009115B61C132FC9887FA9E5336E0CB8A2E7D3280ADBF6ABC043",
+        "quality": "0.003222279177208227",
+        "taker_gets_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        },
+        "taker_pays_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        }
       }
     },
     {
@@ -2787,6 +3314,29 @@ return api.getOrderbook(address, orderbook)
         "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
         "sequence": 431,
         "makerExchangeRate": "0.003222687721559781"
+      },
+      "data": {
+        "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B730474DD96E5",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "624F9ADA85EC3BE845EAC075B47E01E4F89288EAF27823C715777B3DFFB21F24",
+        "PreviousTxnLgrSeq": 10639989,
+        "Sequence": 431,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "3103"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "10"
+        },
+        "index": "8A319A496288228AD9CAD74375E32FA81805C56A9AD84798A26756A8B3F9EE23",
+        "quality": "0.003222687721559781"
       }
     }
   ]

--- a/docs/src/getOrderbook.md.ejs
+++ b/docs/src/getOrderbook.md.ejs
@@ -14,6 +14,12 @@ This method returns a promise that resolves with an object with the following st
 
 <%- renderSchema('output/get-orderbook.json') %>
 
+### New in ripple-lib 0.22.0 and higher
+
+The response includes a `data` property containing the raw order data. This may include `owner_funds`, `Flags`, and other fields.
+
+For details, see the rippled method [book_offers](https://ripple.com/build/rippled-apis/#book-offers).
+
 ### Example
 
 ```javascript

--- a/src/common/schemas/output/orderbook-orders.json
+++ b/src/common/schemas/output/orderbook-orders.json
@@ -47,7 +47,7 @@
         "additionalProperties": false
       },
       "data": {
-        "description": "The raw order data.",
+        "description": "The raw order data. This may include `owner_funds`, `Flags`, and other fields.",
         "type": "object",
         "additionalProperties": true
       }

--- a/src/common/schemas/output/orderbook-orders.json
+++ b/src/common/schemas/output/orderbook-orders.json
@@ -45,9 +45,14 @@
         },
         "required": ["fundedAmount", "priceOfFundedAmount"],
         "additionalProperties": false
+      },
+      "data": {
+        "description": "The raw order data.",
+        "type": "object",
+        "additionalProperties": true
       }
     },
-    "required": ["specification", "properties"],
+    "required": ["specification", "properties", "data"],
     "additionalProperties": false
   }
 }

--- a/src/ledger/orderbook.ts
+++ b/src/ledger/orderbook.ts
@@ -73,7 +73,7 @@ async function makeRequest(
     ledger_index: options.ledgerVersion || 'validated',
     limit: options.limit,
     taker
-})
+  })
 }
 
 

--- a/src/ledger/parse/orderbook-order.ts
+++ b/src/ledger/parse/orderbook-order.ts
@@ -17,15 +17,16 @@ export type FormattedOrderbookOrder = {
   state?: {
     fundedAmount: Amount,
     priceOfFundedAmount: Amount
-  }
+  },
+  data: BookOffer
 }
 
 export function parseOrderbookOrder(
-  order: BookOffer
+  data: BookOffer
 ): FormattedOrderbookOrder {
-  const direction = (order.Flags & orderFlags.Sell) === 0 ? 'buy' : 'sell'
-  const takerGetsAmount = parseAmount(order.TakerGets)
-  const takerPaysAmount = parseAmount(order.TakerPays)
+  const direction = (data.Flags & orderFlags.Sell) === 0 ? 'buy' : 'sell'
+  const takerGetsAmount = parseAmount(data.TakerGets)
+  const takerPaysAmount = parseAmount(data.TakerPays)
   const quantity = (direction === 'buy') ? takerPaysAmount : takerGetsAmount
   const totalPrice = (direction === 'buy') ? takerGetsAmount : takerPaysAmount
 
@@ -35,25 +36,25 @@ export function parseOrderbookOrder(
     direction: direction,
     quantity: quantity,
     totalPrice: totalPrice,
-    passive: ((order.Flags & orderFlags.Passive) !== 0) || undefined,
-    expirationTime: parseTimestamp(order.Expiration)
+    passive: ((data.Flags & orderFlags.Passive) !== 0) || undefined,
+    expirationTime: parseTimestamp(data.Expiration)
   })
 
   const properties = {
-    maker: order.Account,
-    sequence: order.Sequence,
-    makerExchangeRate: adjustQualityForXRP(order.quality,
+    maker: data.Account,
+    sequence: data.Sequence,
+    makerExchangeRate: adjustQualityForXRP(data.quality,
       takerGetsAmount.currency, takerPaysAmount.currency)
   }
 
-  const takerGetsFunded = order.taker_gets_funded ?
-    parseAmount(order.taker_gets_funded) : undefined
-  const takerPaysFunded = order.taker_pays_funded ?
-    parseAmount(order.taker_pays_funded) : undefined
+  const takerGetsFunded = data.taker_gets_funded ?
+    parseAmount(data.taker_gets_funded) : undefined
+  const takerPaysFunded = data.taker_pays_funded ?
+    parseAmount(data.taker_pays_funded) : undefined
   const available = removeUndefined({
     fundedAmount: takerGetsFunded,
     priceOfFundedAmount: takerPaysFunded
   })
   const state = _.isEmpty(available) ? undefined : available
-  return removeUndefined({specification, properties, state})
+  return removeUndefined({specification, properties, state, data})
 }

--- a/test/fixtures/responses/get-orderbook-with-xrp.json
+++ b/test/fixtures/responses/get-orderbook-with-xrp.json
@@ -17,6 +17,26 @@
         "maker": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "sequence": 5,
         "makerExchangeRate": "3.970260734451929e-8"
+      },
+      "data": {
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "BookDirectory": "A118405CF7C2C89AB0CC084417187B86870DC14325C861A0470E1AEE5CBE20D9",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "9DD36CC7338FEB9E501A33EAAA4C00DBE4ED3A692704C62DDBD1848EE1F6E762",
+        "PreviousTxnLgrSeq": 11,
+        "Sequence": 5,
+        "TakerGets": "254391353000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rp8rJYTpodf8qbSCHVTNacf8nSW8mRakFw",
+          "value": "10.1"
+        },
+        "index": "BF656DABDD84E6128A45039F8D557C9477D4DA31F5B00868F2191F0A11FE3798",
+        "owner_funds": "99999998959999928",
+        "quality": "3970260734451929e-29"
       }
     }
   ],
@@ -38,6 +58,25 @@
         "maker": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "sequence": 6,
         "makerExchangeRate": "0.0000780093458738806"
+      },
+      "data": {
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "BookDirectory": "A118405CF7C2C89AB0CC084417187B86870DC14325C861A0561BB6E89EFF509C",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "CFB5786459E568DFC504E7319C515658DED657A7F4EFB5957B33E5E3BD9A1353",
+        "PreviousTxnLgrSeq": 13,
+        "Sequence": 6,
+        "TakerPays": "134000000",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rp8rJYTpodf8qbSCHVTNacf8nSW8mRakFw",
+          "value": "10453252347.1"
+        },
+        "index": "C72CDC1BA4DA529B062871F22C6D175A4D97D4F1160D0D7E646E60699278B5B5",
+        "quality": "78.0093458738806"
       }
     }
   ]

--- a/test/fixtures/responses/get-orderbook.json
+++ b/test/fixtures/responses/get-orderbook.json
@@ -18,6 +18,30 @@
         "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
         "sequence": 386940,
         "makerExchangeRate": "326.5003614141928"
+      },
+      "data": {
+        "Account": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570B9980E49C7DE8",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000008",
+        "PreviousTxnID": "92DBA0BE18B331AC61FB277211477A255D3B5EA9C5FE689171DE689FB45FE18A",
+        "PreviousTxnLgrSeq": 10714030,
+        "Sequence": 386940,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.2849323720855092"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "93.030522464522"
+        },
+        "index": "8092033091034D94219BC1131AF7A6B469D790D81831CB479AB6F67A32BE4E13",
+        "owner_funds": "31.77682120227525",
+        "quality": "326.5003614141928"
       }
     },
     {
@@ -38,6 +62,30 @@
         "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
         "sequence": 207855,
         "makerExchangeRate": "330.6364334177034"
+      },
+      "data": {
+        "Account": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570BBF1EEFA2FB0A",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "C6BDA152363E3CFE18688A6830B49F3DB2B05976110B5908EA4EB66D93DEEB1F",
+        "PreviousTxnLgrSeq": 10714031,
+        "Sequence": 207855,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.00302447007930511"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1"
+        },
+        "index": "8DB3520FF9CB16A0EA955056C49115F8CFB03A587D0A4AFC844F1D220EFCE0B9",
+        "owner_funds": "0.0670537912615556",
+        "quality": "330.6364334177034"
       }
     },
     {
@@ -59,6 +107,31 @@
         "maker": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
         "sequence": 110103,
         "makerExchangeRate": "331.1338298016111"
+      },
+      "data": {
+        "Account": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570BC3A506FC016F",
+        "BookNode": "0000000000000000",
+        "Expiration": 472785283,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000008F0",
+        "PreviousTxnID": "77E763F1D02F58965CD1AD94F557B37A582FAC7760B71F391B856959836C2F7B",
+        "PreviousTxnLgrSeq": 10713576,
+        "Sequence": 110103,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.3"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "99.34014894048333"
+        },
+        "index": "9ECDFD31B28643FD3A54658398C5715D6DAD574F83F04529CB24765770F9084D",
+        "owner_funds": "4.021116654525635",
+        "quality": "331.1338298016111"
       }
     },
     {
@@ -91,6 +164,40 @@
           "value": "268.2219496064341",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rPyYxUGK8L4dgEvjPs3aRc1B1jEiLr3Hx5",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570BCB85BCA78000",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "D22993C68C94ACE3F2FCE4A334EBEA98CC46DCA92886C12B5E5B4780B5E17D4E",
+        "PreviousTxnLgrSeq": 10711938,
+        "Sequence": 392,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8095"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "268.754"
+        },
+        "index": "18B136E08EF50F0DEE8521EA22D16A950CD8B6DDF5F6E07C35F7FDDBBB09718D",
+        "owner_funds": "0.8095132334507441",
+        "quality": "332",
+        "taker_gets_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8078974385735969"
+        },
+        "taker_pays_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "268.2219496064341"
+        }
       }
     },
     {
@@ -112,6 +219,30 @@
         "maker": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
         "sequence": 110105,
         "makerExchangeRate": "337.7996295968016"
+      },
+      "data": {
+        "Account": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570C00450D461510",
+        "BookNode": "0000000000000000",
+        "Expiration": 472785284,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000008F0",
+        "PreviousTxnID": "1F4D9D859D9AABA888C0708A572B38919A3AEF2C8C1F5A13F58F44C92E5FF3FB",
+        "PreviousTxnLgrSeq": 10713576,
+        "Sequence": 110105,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.4499999999999999"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "152.0098333185607"
+        },
+        "index": "9F380E0B39E2AF8AA9608C3E39A5A8628E6D0F44385C6D12BE06F4FEC8D83351",
+        "quality": "337.7996295968016"
       }
     },
     {
@@ -132,6 +263,30 @@
         "maker": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
         "sequence": 110061,
         "makerExchangeRate": "347.2306949944844"
+      },
+      "data": {
+        "Account": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570C560B764D760C",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000001",
+        "PreviousTxnID": "9A0B6B76F0D86614F965A2FFCC8859D8607F4E424351D4CFE2FBE24510F93F25",
+        "PreviousTxnLgrSeq": 10708382,
+        "Sequence": 110061,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.003768001830745216"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.308365894430151"
+        },
+        "index": "B971769686CE1B9139502770158A4E7C011CFF8E865E5AAE5428E23AAA0E146D",
+        "owner_funds": "0.2229210189326514",
+        "quality": "347.2306949944844"
       }
     },
     {
@@ -153,6 +308,31 @@
         "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
         "sequence": 35788,
         "makerExchangeRate": "352.7092203179974"
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570C87DF25DC4FC6",
+        "BookNode": "0000000000000000",
+        "Expiration": 472783298,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003D2",
+        "PreviousTxnID": "E5F9A10F29A4BB3634D5A84FC96931E17267B58E0D2D5ADE24FFB751E52ADB9E",
+        "PreviousTxnLgrSeq": 10713533,
+        "Sequence": 35788,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.5"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "176.3546101589987"
+        },
+        "index": "D2CB71038AD0ECAF4B5FF0A953AD1257225D0071E6F3AF9ADE67F05590B45C6E",
+        "owner_funds": "6.617688680663627",
+        "quality": "352.7092203179974"
       }
     },
     {
@@ -185,6 +365,40 @@
           "value": "179.1217564870259",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rN6jbxx4H6NxcnmkzBxQnbCWLECNKrgSSf",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570CC0B8E0E2C000",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "2E16ACFEAC2306E3B3483D445787F3496FACF9504F7A5E909620C1A73E2EDE54",
+        "PreviousTxnLgrSeq": 10558020,
+        "Sequence": 491,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.5"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "179.48"
+        },
+        "index": "DA853913C8013C9471957349EDAEE4DF4846833B8CCB92008E2A8994E37BEF0D",
+        "owner_funds": "0.5",
+        "quality": "358.96",
+        "taker_gets_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.499001996007984"
+        },
+        "taker_pays_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "179.1217564870259"
+        }
       }
     },
     {
@@ -206,6 +420,30 @@
         "maker": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
         "sequence": 35789,
         "makerExchangeRate": "360.9637829743709"
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570CD2F24C9C145D",
+        "BookNode": "0000000000000000",
+        "Expiration": 472783299,
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003D2",
+        "PreviousTxnID": "B1B12E47043B4260223A2C4240D19E93526B55B1DB38DEED335DACE7C04FEB23",
+        "PreviousTxnLgrSeq": 10713534,
+        "Sequence": 35789,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "288.7710263794967"
+        },
+        "index": "B89AD580E908F7337CCBB47A0BAAC6417EF13AC3465E34E8B7DD3BED016EA833",
+        "quality": "360.9637829743709"
       }
     },
     {
@@ -238,6 +476,40 @@
           "value": "82.50309772176658",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rUeCeioKJkbYhv4mRGuAbZpPcqkMCoYq6N",
+        "BookDirectory": "6EAB7C172DEFA430DBFAD120FDC373B5F5AF8B191649EC98570D0069F50EA028",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000012",
+        "PreviousTxnID": "F0E8ABF07F83DF0B5EF5B417E8E29A45A5503BA8F26FBC86447CC6B1FAD6A1C4",
+        "PreviousTxnLgrSeq": 10447672,
+        "Sequence": 5255,
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.5"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "182.9814890090516"
+        },
+        "index": "D652DCE4B19C6CB43912651D3A975371D3B2A16A034EDF07BC11BF721AEF94A4",
+        "owner_funds": "0.225891986027944",
+        "quality": "365.9629780181032",
+        "taker_gets_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.2254411038203033"
+        },
+        "taker_pays_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "82.50309772176658"
+        }
       }
     }
   ],
@@ -260,6 +532,30 @@
         "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
         "sequence": 434,
         "makerExchangeRate": "0.003120027456241615"
+      },
+      "data": {
+        "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B15A60037FFCF",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "544932DC56D72E845AF2B738821FE07865E32EC196270678AB0D947F54E9F49F",
+        "PreviousTxnLgrSeq": 10679000,
+        "Sequence": 434,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "3205.1"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "10"
+        },
+        "index": "CE457115A4ADCC8CB351B3E35A0851E48DE16605C23E305017A9B697B156DE5A",
+        "owner_funds": "41952.95917199965",
+        "quality": "0.003120027456241615"
       }
     },
     {
@@ -280,6 +576,30 @@
         "maker": "rDYCRhpahKEhCFV25xScg67Bwf4W9sTYAm",
         "sequence": 233,
         "makerExchangeRate": "0.003125"
+      },
+      "data": {
+        "Account": "rDYCRhpahKEhCFV25xScg67Bwf4W9sTYAm",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B1A2BC2EC5000",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "F68F9658AB3D462FEB027E6C380F054BC6D2514B43EC3C6AD46EE19C59BF1CC3",
+        "PreviousTxnLgrSeq": 10704238,
+        "Sequence": 233,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1599.063669386278"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "4.99707396683212"
+        },
+        "index": "BF14FBB305159DBCAEA91B7E848408F5B559A91B160EBCB6D244958A6A16EA6B",
+        "owner_funds": "3169.910902910102",
+        "quality": "0.003125"
       }
     },
     {
@@ -312,6 +632,41 @@
           "currency": "BTC",
           "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "data": {
+        "Account": "raudnGKfTK23YKfnS7ixejHrqGERTYNFXk",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B2BF1C2F4D4C9",
+        "BookNode": "0000000000000000",
+        "Expiration": 472785284,
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000008F0",
+        "PreviousTxnID": "446410E1CD718AC01929DD16B558FCF6B3A7B8BF208C420E67A280C089C5C59B",
+        "PreviousTxnLgrSeq": 10713576,
+        "Sequence": 110104,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "143.1050962074379"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.4499999999999999"
+        },
+        "index": "67924B0EAA15784CC00CCD5FDD655EE2D6D2AE40341776B5F14E52341E7FC73E",
+        "owner_funds": "0",
+        "quality": "0.003144542101755081",
+        "taker_gets_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        },
+        "taker_pays_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
         }
       }
     },
@@ -346,6 +701,41 @@
           "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B2CD7A2BFBB75",
+        "BookNode": "0000000000000000",
+        "Expiration": 472772651,
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003CD",
+        "PreviousTxnID": "D49164AB68DDA3AEC9DFCC69A35685C4F532B5C231D3C1D25FEA7D5D0224FB84",
+        "PreviousTxnLgrSeq": 10711128,
+        "Sequence": 35625,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "254.329207354604"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.8"
+        },
+        "index": "567BF2825173E3FB28FC94E436B6EB30D9A415FC2335E6D25CDE1BE47B25D120",
+        "owner_funds": "0",
+        "quality": "0.003145529403882357",
+        "taker_gets_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        },
+        "taker_pays_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        }
       }
     },
     {
@@ -366,6 +756,30 @@
         "maker": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
         "sequence": 387756,
         "makerExchangeRate": "0.003155743848271834"
+      },
+      "data": {
+        "Account": "rwBYyfufTzk77zUSKEu4MvixfarC35av1J",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B3621DF140FDA",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000008",
+        "PreviousTxnID": "2E371E2B287C8A9FBB3424E4204B17AD9FA1BAA9F3B33C7D2261E3B038AFF083",
+        "PreviousTxnLgrSeq": 10716291,
+        "Sequence": 387756,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "390.4979"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.23231134568807"
+        },
+        "index": "8CA23E55BF9F46AC7E803D3DB40FD03225EFCA66650D4CF0CBDD28A7CCDC8400",
+        "owner_funds": "5704.824764087842",
+        "quality": "0.003155743848271834"
       }
     },
     {
@@ -386,6 +800,30 @@
         "maker": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
         "sequence": 208927,
         "makerExchangeRate": "0.003160328237957649"
+      },
+      "data": {
+        "Account": "rwjsRktX1eguUr1pHTffyHnC4uyrvX58V1",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B3A4D41FF4211",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "91763FA7089C63CC4D5D14CBA6A5A5BF7ECE949B0D34F00FD35E733AF9F05AF1",
+        "PreviousTxnLgrSeq": 10716292,
+        "Sequence": 208927,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.003160328237957649"
+        },
+        "index": "7206866E39D9843623EE79E570242753DEE3C597F3856AEFB4631DD5AD8B0557",
+        "owner_funds": "45.55665106096075",
+        "quality": "0.003160328237957649"
       }
     },
     {
@@ -406,6 +844,29 @@
         "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
         "sequence": 429,
         "makerExchangeRate": "0.003174603174603175"
+      },
+      "data": {
+        "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B4748E68669A7",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "3B3CF6FF1A336335E78513CF77AFD3A784ACDD7B1B4D3F1F16E22957A060BFAE",
+        "PreviousTxnLgrSeq": 10639969,
+        "Sequence": 429,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "4725"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "15"
+        },
+        "index": "42894809370C7E6B23498EF8E22AD4B05F02B94F08E6983357A51EA96A95FF7F",
+        "quality": "0.003174603174603175"
       }
     },
     {
@@ -426,6 +887,30 @@
         "maker": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
         "sequence": 110099,
         "makerExchangeRate": "0.003193013959408667"
+      },
+      "data": {
+        "Account": "rDbsCJr5m8gHDCNEHCZtFxcXHsD4S9jH83",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B58077ED03C1B",
+        "BookNode": "0000000000000000",
+        "Flags": 131072,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000001",
+        "PreviousTxnID": "98F3F2D02D3BB0AEAC09EECCF2F24BBE5E1AB2C71C40D7BD0A5199E12541B6E2",
+        "PreviousTxnLgrSeq": 10715839,
+        "Sequence": 110099,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.24252537879871"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.003967400879423823"
+        },
+        "index": "F4404D6547149419D3607F81D7080979FBB3AFE2661F9A933E2F6C07AC1D1F6D",
+        "owner_funds": "73.52163803897041",
+        "quality": "0.003193013959408667"
       }
     },
     {
@@ -459,6 +944,40 @@
           "value": "0",
           "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
         }
+      },
+      "data": {
+        "Account": "rDVBvAQScXrGRGnzrxRrcJPeNLeLeUTAqE",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B72A555B981A3",
+        "BookNode": "0000000000000000",
+        "Expiration": 472772652,
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "00000000000003CD",
+        "PreviousTxnID": "146C8DBB047BAAFAE5B8C8DECCCDACD9DFCD7A464E5AB273230FF975E9B83CF7",
+        "PreviousTxnLgrSeq": 10711128,
+        "Sequence": 35627,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "496.5429474010489"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "1.6"
+        },
+        "index": "50CAA04E81D0009115B61C132FC9887FA9E5336E0CB8A2E7D3280ADBF6ABC043",
+        "quality": "0.003222279177208227",
+        "taker_gets_funded": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        },
+        "taker_pays_funded": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0"
+        }
       }
     },
     {
@@ -479,6 +998,29 @@
         "maker": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
         "sequence": 431,
         "makerExchangeRate": "0.003222687721559781"
+      },
+      "data": {
+        "Account": "r49y2xKuKVG2dPkNHgWQAV61cjxk8gryjQ",
+        "BookDirectory": "20294C923E80A51B487EB9547B3835FD483748B170D2D0A4520B730474DD96E5",
+        "BookNode": "0000000000000000",
+        "Flags": 0,
+        "LedgerEntryType": "Offer",
+        "OwnerNode": "0000000000000000",
+        "PreviousTxnID": "624F9ADA85EC3BE845EAC075B47E01E4F89288EAF27823C715777B3DFFB21F24",
+        "PreviousTxnLgrSeq": 10639989,
+        "Sequence": 431,
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "3103"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "10"
+        },
+        "index": "8A319A496288228AD9CAD74375E32FA81805C56A9AD84798A26756A8B3F9EE23",
+        "quality": "0.003222687721559781"
       }
     }
   ]


### PR DESCRIPTION
Include the full `BookOffer` data under `data`

Fix #799