### PR TITLE
use any instead of object

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -128,19 +128,16 @@ class RippleAPI extends EventEmitter {
   }
 
 
+  /**
+   * Makes a request to the API with the given command and
+   * additional request body parameters.
+   */
   async request(command: 'account_info', params: AccountInfoRequest):
     Promise<AccountInfoResponse>
   async request(command: 'account_lines', params: AccountLinesRequest):
     Promise<AccountLinesResponse>
-
-  /**
-   * Returns objects owned by an account.
-   * For an account's trust lines and balances,
-   * see `getTrustlines` and `getBalances`.
-   */
   async request(command: 'account_objects', params: AccountObjectsRequest):
     Promise<AccountObjectsResponse>
-
   async request(command: 'account_offers', params: AccountOffersRequest):
   Promise<AccountOffersResponse>
   async request(command: 'book_offers', params: BookOffersRequest):
@@ -151,15 +148,9 @@ class RippleAPI extends EventEmitter {
     Promise<LedgerResponse>
   async request(command: 'ledger_entry', params: LedgerEntryRequest):
     Promise<LedgerEntryResponse>
-
-  async request(command: string, params: object):
-    Promise<object>
-
-  /**
-   * Makes a request to the API with the given command and
-   * additional request body parameters.
-   */
-  async request(command: string, params: object = {}): Promise<object> {
+  async request(command: string, params: any):
+    Promise<any>
+  async request(command: string, params: any = {}): Promise<any> {
     return this.connection.request({
       ...params,
       command


### PR DESCRIPTION
In TS, the `object` type is just an empty `{}` object. Instead, use `any` to represent an object as a flexible, undefined object type.

Without this change, you get errors when using an untyped request/response.

(this PR also cleaned up the request() jsdoc a bit as well)