### PR TITLE
Add prepareTransaction()

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -57,6 +57,7 @@ import {
 
 import RangeSet from './common/rangeset'
 import * as ledgerUtils from './ledger/utils'
+import * as transactionUtils from './transaction/utils'
 import * as schemaValidator from './common/schema-validator'
 import {getServerInfo, getFee} from './common/serverinfo'
 import {clamp} from './ledger/utils'
@@ -194,6 +195,15 @@ class RippleAPI extends EventEmitter {
       marker: currentResponse.marker
     })
     return this.request(command, nextPageParams)
+  }
+
+  /**
+   * Prepare a transaction.
+   *
+   * You can later submit the transaction with `submit()`.
+   */
+  async prepareTransaction(txJSON: object, instructions) {
+    return transactionUtils.prepareTransaction(txJSON, this, instructions)
   }
 
   /**

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -434,6 +434,27 @@ describe('RippleAPI', function () {
           'prepare'));
   });
 
+  it('prepareTransaction - PaymentChannelCreate', function () {
+    const localInstructions = _.defaults({
+      maxFee: '0.000012'
+    }, instructions);
+    return this.api.prepareTransaction({
+      Account: address,
+      TransactionType: 'PaymentChannelCreate',
+      Amount: '1000000', // 1 XRP in drops. Use a string-encoded integer.
+      Destination: 'rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW',
+      SettleDelay: 86400,
+      PublicKey: '32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A'
+      // If cancelAfter is used, you must use RippleTime.
+      // You can use `iso8601ToRippleTime()` to convert to RippleTime.
+
+      // Other fields are available (but not used in this test),
+      // including `sourceTag` and `destinationTag`.
+    }, localInstructions).then(
+        _.partial(checkResult, responses.preparePaymentChannelCreate.normal,
+          'prepare'));
+  });
+
   it('preparePaymentChannelCreate', function () {
     const localInstructions = _.defaults({
       maxFee: '0.000012'


### PR DESCRIPTION
Applying our ideology of exposing the underlying rippled API wherever it makes sense to do so, this PR exposes the `prepareTransaction()` method which takes raw `txJSON` for preparation. This should allow ripple-lib to work with any transaction type that rippled supports.

(Note that transaction signing, which ripple-lib can do without rippled, still only works with [supported types](https://github.com/ripple/ripple-binary-codec/blob/36cfd9f9ff370ef9f922daa2bfe26f321f285f6c/src/enums/definitions.json).)

Instead of:
```
api.preparePaymentChannelCreate(address, {
  amount: '1',
  destination: 'rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW',
  settleDelay: 86400,
  publicKey: '32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A'
}, instructions)
```

Use:
```
api.prepareTransaction({
  Account: address,
  TransactionType: 'PaymentChannelCreate',
  Amount: '1000000',
  Destination: 'rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW',
  SettleDelay: 86400,
  PublicKey: '32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A'
}, instructions)
```

As with all rippled APIs (and unlike ripple-lib's existing `prepare*` methods), amounts must be specified in drops.