### PR TITLE
Fix getPaths

### DIFF
--- a/src/ledger/pathfind.ts
+++ b/src/ledger/pathfind.ts
@@ -1,7 +1,13 @@
 import * as _ from 'lodash'
 import BigNumber from 'bignumber.js'
 import {getXRPBalance, renameCounterpartyToIssuer} from './utils'
-import {validate, toRippledAmount, errors, xrpToDrops} from '../common'
+import {
+  validate,
+  toRippledAmount,
+  errors,
+  xrpToDrops,
+  dropsToXrp
+} from '../common'
 import {Connection} from '../common'
 import parsePathfind from './parse/pathfind'
 import {RippledAmount, Amount} from '../common/types/objects'
@@ -23,7 +29,11 @@ function addParams(request: PathFindRequest, result: RippledPathsResponse
 function requestPathFind(connection: Connection, pathfind: PathFind
 ): Promise<RippledPathsResponse> {
   const destinationAmount: Amount = _.assign(
-    {value: '-1'},
+    {
+      // This is converted back to drops by toRippledAmount()
+      value: pathfind.destination.amount.currency === 'XRP' ?
+        dropsToXrp('-1') : '-1'
+    },
     pathfind.destination.amount
   )
   const request: PathFindRequest = {

--- a/src/ledger/pathfind.ts
+++ b/src/ledger/pathfind.ts
@@ -100,8 +100,11 @@ function filterSourceFundsLowPaths(pathfind: PathFind,
       let pathfindSourceAmountValue: BigNumber
       if (typeof alt.source_amount === 'string') {
         altSourceAmountValue = new BigNumber(alt.source_amount)
-      } else {
+      } else if (alt.source_amount) {
         altSourceAmountValue = new BigNumber(alt.source_amount.value)
+      } else {
+        // No alt.source_amount
+        return false
       }
       if (pathfind.source.amount.currency === 'XRP') {
         pathfindSourceAmountValue =
@@ -109,8 +112,7 @@ function filterSourceFundsLowPaths(pathfind: PathFind,
       } else {
         pathfindSourceAmountValue = new BigNumber(pathfind.source.amount.value)
       }
-      return !!alt.source_amount &&
-        altSourceAmountValue.eq(pathfindSourceAmountValue)
+      return altSourceAmountValue.eq(pathfindSourceAmountValue)
     })
   }
   return paths

--- a/src/ledger/pathfind.ts
+++ b/src/ledger/pathfind.ts
@@ -106,22 +106,18 @@ function filterSourceFundsLowPaths(pathfind: PathFind,
   if (pathfind.source.amount &&
       pathfind.destination.amount.value === undefined && paths.alternatives) {
     paths.alternatives = _.filter(paths.alternatives, alt => {
-      let altSourceAmountValue: BigNumber
-      let pathfindSourceAmountValue: BigNumber
-      if (typeof alt.source_amount === 'string') {
-        altSourceAmountValue = new BigNumber(alt.source_amount)
-      } else if (alt.source_amount) {
-        altSourceAmountValue = new BigNumber(alt.source_amount.value)
-      } else {
-        // No alt.source_amount
+      if (!alt.source_amount) {
         return false
       }
-      if (pathfind.source.amount.currency === 'XRP') {
-        pathfindSourceAmountValue =
-          new BigNumber(xrpToDrops(pathfind.source.amount.value))
-      } else {
-        pathfindSourceAmountValue = new BigNumber(pathfind.source.amount.value)
-      }
+      const pathfindSourceAmountValue = new BigNumber(
+        pathfind.source.amount.currency === 'XRP' ?
+        xrpToDrops(pathfind.source.amount.value) :
+        pathfind.source.amount.value)
+      const altSourceAmountValue = new BigNumber(
+        typeof alt.source_amount === 'string' ?
+        alt.source_amount :
+        alt.source_amount.value
+      )
       return altSourceAmountValue.eq(pathfindSourceAmountValue)
     })
   }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -2292,6 +2292,45 @@ describe('RippleAPI', function () {
       _.partial(checkResult, responses.getPaths.XrpToUsd, 'getPaths'));
   });
 
+  it('getPaths - result path has source_amount in drops', function () {
+    return this.api.getPaths({
+      source: {
+          address: 'rB2NTuTTS3eNCsWxZYzJ4wqRqxNLZqA9Vx',
+          amount: {
+              value: this.api.dropsToXrp(1000000),
+              currency: 'XRP'
+          }
+      },
+      destination: {
+          address: 'rhpJkBfZGQyT1xeDbwtKEuSrSXw3QZSAy5',
+          amount: {
+              counterparty: 'rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u',
+              currency: 'EUR'
+          }
+      }
+  }).then(
+      _.partial(checkResult, [
+        {
+          "source": {
+            "address": "rB2NTuTTS3eNCsWxZYzJ4wqRqxNLZqA9Vx",
+            "amount": {
+              "currency": "XRP",
+              "value": "1"
+            }
+          },
+          "destination": {
+            "address": "rhpJkBfZGQyT1xeDbwtKEuSrSXw3QZSAy5",
+            "minAmount": {
+              "currency": "EUR",
+              "value": "1",
+              "counterparty": "rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u"
+            }
+          },
+          "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u\"},{\"currency\":\"EUR\",\"issuer\":\"rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u\"}]]"
+        }
+      ], 'getPaths'));
+  });
+
   it('getPaths - queuing', function () {
     return Promise.all([
       this.api.getPaths(requests.getPaths.normal),

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -2295,18 +2295,18 @@ describe('RippleAPI', function () {
   it('getPaths - result path has source_amount in drops', function () {
     return this.api.getPaths({
       source: {
-          address: 'rB2NTuTTS3eNCsWxZYzJ4wqRqxNLZqA9Vx',
-          amount: {
-              value: this.api.dropsToXrp(1000000),
-              currency: 'XRP'
-          }
+        address: 'rB2NTuTTS3eNCsWxZYzJ4wqRqxNLZqA9Vx',
+        amount: {
+          value: this.api.dropsToXrp(1000000),
+          currency: 'XRP'
+        }
       },
       destination: {
-          address: 'rhpJkBfZGQyT1xeDbwtKEuSrSXw3QZSAy5',
-          amount: {
-              counterparty: 'rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u',
-              currency: 'EUR'
-          }
+        address: 'rhpJkBfZGQyT1xeDbwtKEuSrSXw3QZSAy5',
+        amount: {
+          counterparty: 'rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u',
+          currency: 'EUR'
+        }
       }
     }).then(
       _.partial(checkResult, [

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -2308,7 +2308,7 @@ describe('RippleAPI', function () {
               currency: 'EUR'
           }
       }
-  }).then(
+    }).then(
       _.partial(checkResult, [
         {
           "source": {

--- a/test/mock-rippled.js
+++ b/test/mock-rippled.js
@@ -480,7 +480,57 @@ module.exports = function createMockRippled(port) {
     if (request.subcommand === 'close') {   // for path_find command
       return;
     }
-    if (request.source_account === addresses.NOTFOUND) {
+    if (request.source_account === 'rB2NTuTTS3eNCsWxZYzJ4wqRqxNLZqA9Vx') {
+      // getPaths - result path has source_amount in drops
+      response = createResponse(request, {
+        "id": 0,
+        "type": "response",
+        "status": "success",
+        "result": {
+          "alternatives": [
+            {
+              "destination_amount": {
+                "currency": "EUR",
+                "issuer": "rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u",
+                "value": "1"
+              },
+              "paths_canonical": [],
+              "paths_computed": [
+                [
+                  {
+                    "currency": "USD",
+                    "issuer": "rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u",
+                    "type": 48,
+                    "type_hex": "0000000000000030"
+                  },
+                  {
+                    "currency": "EUR",
+                    "issuer": "rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u",
+                    "type": 48,
+                    "type_hex": "0000000000000030"
+                  }
+                ]
+              ],
+              "source_amount": "1000000"
+            }
+          ],
+          "destination_account": "rhpJkBfZGQyT1xeDbwtKEuSrSXw3QZSAy5",
+          "destination_amount": {
+            "currency": "EUR",
+            "issuer": "rGpGaj4sxEZGenW1prqER25EUi7x4fqK9u",
+            "value": "-1"
+          },
+          "destination_currencies": [
+            "EUR",
+            "XRP"
+          ],
+          "full_reply": true,
+          "id": 2,
+          "source_account": "rB2NTuTTS3eNCsWxZYzJ4wqRqxNLZqA9Vx",
+          "status": "success"
+        }
+      })
+    } else if (request.source_account === addresses.NOTFOUND) {
       response = createResponse(request, fixtures.path_find.srcActNotFound);
     } else if (request.source_account === addresses.SOURCE_LOW_FUNDS) {
       response = createResponse(request, fixtures.path_find.sourceAmountLow);

--- a/test/mock-rippled.js
+++ b/test/mock-rippled.js
@@ -542,8 +542,9 @@ module.exports = function createMockRippled(port) {
         destination_address: request.destination_address
       });
     } else if (request.source_account === addresses.ACCOUNT) {
-      if (request.destination_account ===
-        'ra5nK24KXen9AHvsdFTKHSANinZseWnPcX') {
+      if (request.destination_account === 'ra5nK24KXen9AHvsdFTKHSANinZseWnPcX' &&
+          // Important: Ensure that destination_amount.value is correct
+          request.destination_amount.value === "-1") {
         response = createResponse(request, fixtures.path_find.sendAll);
       } else {
         response = fixtures.path_find.generate.generateIOUPaymentPaths(


### PR DESCRIPTION
When pathfinding with a source amount, rippled can return paths where the source amount in the returned path is not equal to the requested source amount. These are known as "insufficient source funds paths."

ripple-lib removes these paths from the response, but the filter did not handle the case where the amount is specified in drops, rather than an IOU with a `value` field.

The pathfinding request asks to find paths that deliver as much as possible of the destination amount by spending up to X source amount. In the returned path, if the source amount is less than X, that means there is not enough liquidity to spend it all. This means a payment that was meant to convert the entire amount of the `send max` would fail. It may be useful to know how much of the `send max` would be spent, so this may be something to revisit in the future. Of course, advanced users can already use `request()` with `ripple_path_find` to get the raw results.