### PR TITLE
Fix PendingLedgerVersionError message and export FormattedTransactionType

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -70,7 +70,7 @@ class MissingLedgerHistoryError extends RippleError {
 
 class PendingLedgerVersionError extends RippleError {
   constructor(message?: string) {
-    super(message || 'maxLedgerVersion is greater than server\'s most recent ' +
+    super(message || 'maxLedgerVersion is greater than server\'s most recent' +
       ' validated ledger')
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-
-
 export {RippleAPI} from './api'
+
+export {
+    FormattedTransactionType
+} from './transaction/types'
+
 // Broadcast api is experimental
 export {RippleAPIBroadcast} from './broadcast'

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1629,6 +1629,8 @@ describe('RippleAPI', function () {
         assert(false, 'Should throw PendingLedgerVersionError');
       }).catch(error => {
         assert(error instanceof this.api.errors.PendingLedgerVersionError);
+        assert.strictEqual(error.message, 'maxLedgerVersion is greater than server\'s'
+          + ' most recent validated ledger')
       });
     });
 


### PR DESCRIPTION
- The PendingLedgerVersionError message had an extra space in it
- FormattedTransactionType is useful for apps that want to work with the response from `getTransaction()`