### PR TITLE
added remaining LedgerEntry types

### DIFF
--- a/src/common/types/objects/ledger_entries.ts
+++ b/src/common/types/objects/ledger_entries.ts
@@ -1,4 +1,5 @@
 import {SignerEntry} from './index'
+import { Amount, RippledAmount } from './amounts'
 
 export interface AccountRootLedgerEntry {
   LedgerEntryType: 'AccountRoot',
@@ -44,6 +45,71 @@ export interface CheckLedgerEntry {
   SourceTag: number
 }
 
+export interface DirectoryNodeLedgerEntry {
+  LedgerEntryType: 'DirectoryNode';
+  Flags: number;
+  RootIndex: number;
+  Indexes: string[];
+  IndexNext?: number;
+  IndexPrevious?: number;
+}
+
+export interface OfferDirectoryNodeLedgerEntry extends DirectoryNodeLedgerEntry {
+  Owner?: string;
+  TakerPaysCurrency?: string;
+  TakerPaysIssuer?: string;
+  TakerGetsCurrency?: string;
+  TakerGetsIssuer?: string;
+};
+
+export interface EscrowLedgerEntry {
+  LedgerEntryType: 'Escrow';
+  Account: string;
+  Destination: string;
+  Amount: string;
+  Condition?: string;
+  CancelAfter?: number;
+  FinishAfter?: number;
+  Flags: number;
+  SourceTag?: number;
+  DestinationTag?: number;
+  OwnerNode: string;
+  DestinationNode?: string;
+  PreviousTxnID: string;
+  PreviousTxnLgrSeq: number;
+}
+
+export interface FeeSettingsLedgerEntry {
+  LedgerEntryType: 'FeeSettings';
+  BaseFee: string;
+  ReferenceFeeUnits: number;
+  ReserveBase: number;
+  ReserveIncrement: number;
+  Flags: number;
+};
+
+export interface LedgerHashesLedgerEntry {
+  LedgerEntryType: 'LedgerHashes';
+  LastLedgerSequence: number;
+  Hashes: string[];
+  Flags: number;
+}
+
+export interface OfferLedgerEntry {
+  LedgerEntryType: 'Offer';
+  Flags: number;
+  Account: string;
+  Sequence: number;
+  TakerPays: RippledAmount;
+  TakerGets: RippledAmount;
+  BookDirectory: string;
+  BookNode: string;
+  OwnerNode: string;
+  PreviousTxnID: string;
+  PreviousTxnLgrSeq: number;
+  Expiration?: number;
+}
+
 export interface PayChannelLedgerEntry {
   LedgerEntryType: 'PayChannel',
   Sequence: number,
@@ -63,6 +129,23 @@ export interface PayChannelLedgerEntry {
   index: string
 }
 
+export interface RippleStateLedgerEntry {
+  LedgerEntryType: 'RippleState';
+  Flags: number;
+  Balance: Amount;
+  LowLimit: Amount;
+  HighLimit: Amount;
+  PreviousTxnID: string;
+  PreviousTxnLgrSeq: number;
+  LowNode?: string;
+  HighNode?: string;
+  LowQualityIn?: number;
+  LowQualityOut?: number;
+  HighQualityIn?: number;
+  HighQualityOut?: number;
+
+}
+
 export interface SignerListLedgerEntry {
   LedgerEntryType: 'SignerList',
   OwnerNode: string,
@@ -73,11 +156,16 @@ export interface SignerListLedgerEntry {
   PreviousTxnLgrSeq: number
 }
 
-// TODO: Add the other ledger entry types, then remove the `any` fallback
 // see https://ripple.com/build/ledger-format/#ledger-object-types
 export type LedgerEntry =
   AccountRootLedgerEntry |
   AmendmentsLedgerEntry |
+  DirectoryNodeLedgerEntry |
+  OfferDirectoryNodeLedgerEntry |
+  EscrowLedgerEntry |
+  FeeSettingsLedgerEntry |
+  LedgerHashesLedgerEntry |
+  OfferLedgerEntry | 
   PayChannelLedgerEntry |
-  SignerListLedgerEntry |
-  any
+  RippleStateLedgerEntry |
+  SignerListLedgerEntry


### PR DESCRIPTION
I was looking at the types included in the API and realized that the OfferLedgerEntry type was missing. There was a todo comment indicating that there were several more that were missing as well. 

This commit adds the missing types as indicated by the online documentation (DirectoryNode, OfferDirectoryNode, Escrow, FeeSettings, LedgerHashes, Offer, RippleState) and then joins them with the existing ones under type 'LedgerEntry'. I then removed the 'any' type from the union because all entries found in the documentation were included per the todo comment.

This is my first attempt at a pull request, so please let me know if there is a better way to structure things. 
