### PR TITLE
Allow to remove signerList

### DIFF
--- a/src/transaction/settings.ts
+++ b/src/transaction/settings.ts
@@ -91,12 +91,15 @@ function createSettingsTransactionWithoutMemos(
   }
 
   if (settings.signers !== undefined) {
-    return {
+    const setSignerList = {
       TransactionType: 'SignerListSet',
       Account: account,
-      SignerQuorum: settings.signers.threshold,
-      SignerEntries: _.map(settings.signers.weights, formatSignerEntry)
+      SignerQuorum: settings.signers.threshold
+    };
+    if (settings.signers.weights !== undefined) {
+      setSignerList.SignerEntries = _.map(settings.signers.weights, formatSignerEntry);
     }
+    return setSignerList;
   }
 
   const txJSON: any = {


### PR DESCRIPTION
As SignerEntries always specified it returns temMALFORMED when SignerQuorum is 0. (removing signerList)

to reproduce, submit 
```
settings.signers = {
  threshold: 0
};
```