### PR TITLE
book_offers returns offers type OfferLedgerEntry

### DIFF
--- a/src/common/types/commands/account_objects.ts
+++ b/src/common/types/commands/account_objects.ts
@@ -1,4 +1,9 @@
-import {CheckLedgerEntry, RippleStateLedgerEntry, OfferLedgerEntry, SignerListLedgerEntry, EscrowLedgerEntry, PayChannelLedgerEntry, DepositPreauthLedgerEntry} from '../objects'
+import {
+  CheckLedgerEntry, RippleStateLedgerEntry,
+  OfferLedgerEntry, SignerListLedgerEntry,
+  EscrowLedgerEntry, PayChannelLedgerEntry,
+  DepositPreauthLedgerEntry
+} from '../objects'
 
 export interface GetAccountObjectsOptions {
   type?: string | (
@@ -44,7 +49,7 @@ export interface AccountObjectsResponse {
   account: string,
 
   // Array of objects owned by this account.
-  // per https://developers.ripple.com/rippleapi-reference.html#getaccountobjects
+  // from the getAccountObjects section of the dev center
   account_objects: Array<
     CheckLedgerEntry |
     RippleStateLedgerEntry |

--- a/src/common/types/commands/account_objects.ts
+++ b/src/common/types/commands/account_objects.ts
@@ -1,4 +1,4 @@
-import {CheckLedgerEntry} from '../objects'
+import {CheckLedgerEntry, RippleStateLedgerEntry, OfferLedgerEntry, SignerListLedgerEntry, EscrowLedgerEntry, PayChannelLedgerEntry, DepositPreauthLedgerEntry} from '../objects'
 
 export interface GetAccountObjectsOptions {
   type?: string | (
@@ -44,7 +44,16 @@ export interface AccountObjectsResponse {
   account: string,
 
   // Array of objects owned by this account.
-  account_objects: CheckLedgerEntry | object,
+  // per https://developers.ripple.com/rippleapi-reference.html#getaccountobjects
+  account_objects: Array<
+    CheckLedgerEntry |
+    RippleStateLedgerEntry |
+    OfferLedgerEntry |
+    SignerListLedgerEntry |
+    EscrowLedgerEntry |
+    PayChannelLedgerEntry |
+    DepositPreauthLedgerEntry
+  >,
 
   // (May be omitted) The identifying hash of the ledger
   // that was used to generate this response.

--- a/src/common/types/commands/book_offers.ts
+++ b/src/common/types/commands/book_offers.ts
@@ -1,7 +1,7 @@
 import {
   TakerRequestAmount,
   RippledAmount,
-  OfferCreateTransaction
+  OfferLedgerEntry
 } from '../objects'
 
 export interface BookOffersRequest {
@@ -22,7 +22,7 @@ export interface BookOffersResponse {
   marker?: any
 }
 
-export interface BookOffer extends OfferCreateTransaction {
+export interface BookOffer extends OfferLedgerEntry {
   quality?: string
   owner_funds?: string,
   taker_gets_funded?: RippledAmount,


### PR DESCRIPTION
discovered in [PR#460](https://github.com/ripple/ripple-dev-portal/pull/460)

the rippled-api book_offers functions returns offers with a base type of `OfferLedgerEntry` not `OfferCreateTransaction`.

It appears that there is enough crossover between the two types that I haven't found anything that breaks after switching the type, but any code that is developed in the future would have expected offers to have fields such as `TransactionType: 'OfferCreate` when the offer really had the field 'LedgerEntryType: 'Offer'`.

This corrects the getOrderBook response by indicating that the `data` property of each order included in the bids/asks array of the response is now the correct type

This does not impact the getOrder, getTransaction, getTransactions, or getAccountObjects responses which either do not refer to the `BookOffer` type or clean the offer with the `parseOrderbookOrder` function.
