### PR TITLE
Type balanceChanges should be array of changes not array with one change 

### DIFF
--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -66,11 +66,11 @@ export type Outcome = {
   indexInLedger: number,
   fee: string,
   balanceChanges: {
-    [key: string]: [{
+    [key: string]: {
      currency: string,
      counterparty?: string,
      value: string
-    }]
+    }[]
   },
   orderbookChanges: object,
   timestamp?: string


### PR DESCRIPTION
I'm trying to simulate submitting orders on the network with my Typescript application to test my process, but the ts compiler errors when I try to put more than 1 change in the balanceChanges property of the Outcome type.

The Outcome property in FormattedTransactionType objects has a balanceChanges property which is structured as 
```[account: string]: [(format of a change object)]``` 
instead of 
```[account: string]: (format of a change object)[]```

This prevents me from putting multiple value changes in the array because it is looking for an array of size 1. My current workaround is to override the type in my app. 

If preferred, an alternative syntax would be:
```[account: string]: Array<(format of a change object)>```

