### PR TITLE
Add DepositPreauth

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@
   - [getAccountObjects](#getaccountobjects)
   - [getPaymentChannel](#getpaymentchannel)
   - [getLedger](#getledger)
+  - [prepareTransaction](#preparetransaction)
   - [preparePayment](#preparepayment)
   - [prepareTrustline](#preparetrustline)
   - [prepareOrder](#prepareorder)
@@ -4103,6 +4104,64 @@ return api.getLedger()
 ```
 
 
+## prepareTransaction
+
+`prepareTransaction(address: string, transaction: object, instructions: object): Promise<object>`
+
+Prepare a transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
+
+This method works with any of [the transaction types supported by rippled](https://developers.ripple.com/transaction-types.html).
+
+Notably, this is the preferred method for preparing a `DepositPreauth` transaction (added in rippled 1.1.0).
+
+### Parameters
+
+Name | Type | Description
+---- | ---- | -----------
+transaction | [transaction](https://developers.ripple.com/transaction-formats.html) | The specification (JSON) of the transaction to prepare. Set `Account` to the address of the account that is creating the transaction. Common fields like `Fee`, `Flags`, and `Sequence` may be omitted; `prepareTransaction` will set them automatically.
+instructions | [instructions](#transaction-instructions) | *Optional* Instructions for executing the transaction
+
+### Return Value
+
+This method returns a promise that resolves with an object with the following structure:
+
+<aside class="notice">
+All "prepare*" methods have the same return type.
+</aside>
+
+Name | Type | Description
+---- | ---- | -----------
+txJSON | string | The prepared transaction in rippled JSON format.
+instructions | object | The instructions for how to execute the transaction after adding automatic defaults.
+*instructions.* fee | [value](#value) | An exact fee to pay for the transaction. See [Transaction Fees](#transaction-fees) for more information.
+*instructions.* sequence | [sequence](#account-sequence-number) | The initiating account's sequence number for this transaction.
+*instructions.* maxLedgerVersion | integer,null | The highest ledger version that the transaction can be included in. Set to `null` if there is no maximum.
+*instructions.* maxLedgerVersion | string,null | The highest ledger version that the transaction can be included in. Set to `null` if there is no maximum.
+
+### Example
+
+```javascript
+async function preparedPreauth() {
+  const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
+  return api.prepareTransaction({
+    TransactionType: 'DepositPreauth',
+    Account: address,
+    Authorize: 'rMyVso4p83khNyHdV1m1PggV9QNadCj8wM'
+  });
+}
+```
+
+```javascript
+{
+  txJSON: '{"TransactionType":"DepositPreauth","Account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59","Authorize":"rMyVso4p83khNyHdV1m1PggV9QNadCj8wM","Flags":2147483648,"LastLedgerSequence":13561714,"Fee":"12","Sequence":1}',
+  instructions: {
+    fee: '0.000012',
+    sequence: 1,
+    maxLedgerVersion: 13561714
+  }
+}
+```
+
 ## preparePayment
 
 `preparePayment(address: string, payment: object, instructions: object): Promise<object>`
@@ -4954,6 +5013,10 @@ sign(txJSON: string, keypair: object, options: object): {signedTransaction: stri
 ```
 
 Sign a prepared transaction. The signed transaction must subsequently be [submitted](#submit).
+
+This method can sign any of [the transaction types supported by ripple-binary-codec](https://github.com/ripple/ripple-binary-codec/blob/cfcde79c19c359e9a0466d7bc3dc9a3aef47bb99/src/enums/definitions.json#L1637). When a new transaction type is added, it will be unrecognized until ripple-binary-codec is updated. An error will be thrown:
+
+`Error: [TRANSACTION_TYPE] is not a valid name or ordinal for TransactionType`
 
 ### Parameters
 

--- a/docs/src/index.md.ejs
+++ b/docs/src/index.md.ejs
@@ -28,6 +28,7 @@
 <% include getAccountObjects.md.ejs %>
 <% include getPaymentChannel.md.ejs %>
 <% include getLedger.md.ejs %>
+<% include prepareTransaction.md.ejs %>
 <% include preparePayment.md.ejs %>
 <% include prepareTrustline.md.ejs %>
 <% include prepareOrder.md.ejs %>

--- a/docs/src/prepareTransaction.md.ejs
+++ b/docs/src/prepareTransaction.md.ejs
@@ -1,0 +1,50 @@
+## prepareTransaction
+
+`prepareTransaction(address: string, transaction: object, instructions: object): Promise<object>`
+
+Prepare a transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
+
+This method works with any of [the transaction types supported by rippled](https://developers.ripple.com/transaction-types.html).
+
+Notably, this is the preferred method for preparing a `DepositPreauth` transaction (added in rippled 1.1.0).
+
+### Parameters
+
+Name | Type | Description
+---- | ---- | -----------
+transaction | [transaction](https://developers.ripple.com/transaction-formats.html) | The specification (JSON) of the transaction to prepare. Set `Account` to the address of the account that is creating the transaction. Common fields like `Fee`, `Flags`, and `Sequence` may be omitted; `prepareTransaction` will set them automatically.
+instructions | [instructions](#transaction-instructions) | *Optional* Instructions for executing the transaction
+
+### Return Value
+
+This method returns a promise that resolves with an object with the following structure:
+
+<aside class="notice">
+All "prepare*" methods have the same return type.
+</aside>
+
+<%- renderSchema("output/prepare.json") %>
+
+### Example
+
+```javascript
+async function preparedPreauth() {
+  const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
+  return api.prepareTransaction({
+    TransactionType: 'DepositPreauth',
+    Account: address,
+    Authorize: 'rMyVso4p83khNyHdV1m1PggV9QNadCj8wM'
+  });
+}
+```
+
+```javascript
+{
+  txJSON: '{"TransactionType":"DepositPreauth","Account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59","Authorize":"rMyVso4p83khNyHdV1m1PggV9QNadCj8wM","Flags":2147483648,"LastLedgerSequence":13561714,"Fee":"12","Sequence":1}',
+  instructions: {
+    fee: '0.000012',
+    sequence: 1,
+    maxLedgerVersion: 13561714
+  }
+}
+```

--- a/docs/src/sign.md.ejs
+++ b/docs/src/sign.md.ejs
@@ -7,6 +7,10 @@ sign(txJSON: string, keypair: object, options: object): {signedTransaction: stri
 
 Sign a prepared transaction. The signed transaction must subsequently be [submitted](#submit).
 
+This method can sign any of [the transaction types supported by ripple-binary-codec](https://github.com/ripple/ripple-binary-codec/blob/cfcde79c19c359e9a0466d7bc3dc9a3aef47bb99/src/enums/definitions.json#L1637). When a new transaction type is added, it will be unrecognized until ripple-binary-codec is updated. An error will be thrown:
+
+`Error: [TRANSACTION_TYPE] is not a valid name or ordinal for TransactionType`
+
 ### Parameters
 
 <%- renderSchema("input/sign.json") %>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jsonschema": "1.2.2",
     "lodash": "^4.17.4",
     "ripple-address-codec": "^2.0.1",
-    "ripple-binary-codec": "^0.1.13",
+    "ripple-binary-codec": "0.2.0",
     "ripple-hashes": "^0.3.1",
     "ripple-keypairs": "^0.10.1",
     "ripple-lib-transactionparser": "0.7.1",

--- a/src/ledger/parse/deposit-preauth.ts
+++ b/src/ledger/parse/deposit-preauth.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert'
+import {removeUndefined} from '../../common'
+
+export type FormattedDepositPreauth = {
+  // account (address) of the sender to preauthorize
+  authorize: string,
+
+  // account (address) of the sender whose preauthorization should be revoked
+  unauthorize: string
+}
+
+function parseDepositPreauth(tx: any): FormattedDepositPreauth {
+  assert(tx.TransactionType === 'DepositPreauth')
+
+  return removeUndefined({
+    authorize: tx.Authorize,
+    unauthorize: tx.Unauthorize
+  })
+}
+
+export default parseDepositPreauth

--- a/src/transaction/sign.ts
+++ b/src/transaction/sign.ts
@@ -79,6 +79,12 @@ function sign(
       options
     )
   } else {
+    if (!keypair && !secret) {
+      // Clearer message than 'ValidationError: instance is not exactly one from [subschema 0],[subschema 1]'
+      throw new utils.common.errors.ValidationError(
+        'sign: Missing secret or keypair.'
+      )
+    }
     return signWithKeypair(
       this,
       txJSON,

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -883,6 +883,30 @@ describe('RippleAPI', function () {
           'prepare'));
   });
 
+  it('prepareTransaction - DepositPreauth', function () {
+    const localInstructions = _.defaults({
+      maxFee: '0.000012'
+    }, instructions)
+
+    const txJSON = {
+      TransactionType: 'DepositPreauth',
+      Account: address,
+      Authorize: 'rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo'
+    }
+
+    return this.api.prepareTransaction(txJSON, localInstructions).then(response => {
+      const expected = {
+        txJSON: '{"TransactionType":"DepositPreauth","Account":"' + address + '","Authorize":"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo","Flags":2147483648,"LastLedgerSequence":8820051,"Fee":"12","Sequence":23}',
+        instructions: {
+          fee: '0.000012',
+          sequence: 23,
+          maxLedgerVersion: 8820051
+        }
+      }
+      return checkResult(expected, 'prepare', response)
+    })
+  })
+
   describe('prepareTransaction - Payment', function () {
 
     it('normal', function () {

--- a/tslint.json
+++ b/tslint.json
@@ -57,7 +57,7 @@
     "triple-equals": true,
     "forin": false,
     "handle-callback-err": true,
-    "ter-max-len": [true, 80],
+    "ter-max-len": [true, 120],
     "new-parens": true,
     "object-curly-spacing": [true, "never"],
     "object-literal-shorthand": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,7 +4800,20 @@ ripple-address-codec@^2.0.1:
     hash.js "^1.0.3"
     x-address-codec "^0.7.0"
 
-ripple-binary-codec@^0.1.0, ripple-binary-codec@^0.1.13:
+ripple-binary-codec@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.2.0.tgz#cef049f671f398de255e5c190b9f6545c7c7c36f"
+  integrity sha512-qCf3syhtwPFq70JIh/7VSegynj5gWXVNI5T5I7dobqiNxY3fZQvOePRnchnN1OzC0jMh8x0b2ASmkvIlf259zQ==
+  dependencies:
+    babel-runtime "^6.6.1"
+    bn.js "^4.11.3"
+    create-hash "^1.1.2"
+    decimal.js "^5.0.8"
+    inherits "^2.0.1"
+    lodash "^4.12.0"
+    ripple-address-codec "^2.0.1"
+
+ripple-binary-codec@^0.1.0:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.1.13.tgz#c68951405a17a71695551e789966ff376da552e4"
   integrity sha1-xolRQFoXpxaVVR54mWb/N22lUuQ=


### PR DESCRIPTION
- Add documentation of `prepareTransaction`, the preferred method for preparing `DepositPreauth` transactions.
  - ripple-lib was already capable of signing `DepositPreauth` transactions thanks to ripple-binary-codec v0.1.15. However, this release was not tagged on GitHub, so I incremented the library's version to v0.2.0 and published it to npm and GitHub.
  - I'm pinning ripple-lib to use ripple-binary-codec v0.2.0 so that we can be explicit about using updates of this dependency in the future.
- Add support for parsing `DepositPreauth` transactions.
- Allow ripple-lib to parse unrecognized transaction types, so that ripple-lib is still usable when new transaction types are added in the future.
  - For unrecognized transaction types, no `specification` will be provided, but `rawTransaction` will be included.