### PR TITLE
Use Buffer.from and clean up a few things

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -268,7 +268,7 @@ class Connection extends EventEmitter {
       options.agent = new HttpsProxyAgent(proxyOptions)
     }
     if (this._authorization !== undefined) {
-      const base64 = new Buffer(this._authorization).toString('base64')
+      const base64 = Buffer.from(this._authorization).toString('base64')
       options.headers = {Authorization: `Basic ${base64}`}
     }
     const optionsOverrides = _.omitBy({

--- a/src/common/types/objects/ledger.ts
+++ b/src/common/types/objects/ledger.ts
@@ -18,5 +18,6 @@ export interface Ledger {
   hash?: string,
   close_flags?: number,
   parent_close_time?: number,
-  accountState?: any[]
+  accountState?: any[],
+  validated?: boolean
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -125,7 +125,6 @@ function removeUndefined<T extends object>(obj: T): T {
 /**
  * @param {Number} rpepoch (seconds since 1/1/2000 GMT)
  * @return {Number} ms since unix epoch
- *
  */
 function rippleToUnixTimestamp(rpepoch: number): number {
   return (rpepoch + 0x386D4380) * 1000

--- a/src/ledger/parse/fields.ts
+++ b/src/ledger/parse/fields.ts
@@ -5,7 +5,7 @@ const AccountFields = constants.AccountFields
 
 function parseField(info, value) {
   if (info.encoding === 'hex' && !info.length) { // e.g. "domain"
-    return new Buffer(value, 'hex').toString('ascii')
+    return Buffer.from(value, 'hex').toString('ascii')
   }
   if (info.shift) {
     return (new BigNumber(value)).shift(-info.shift).toNumber()

--- a/src/ledger/parse/ledger.ts
+++ b/src/ledger/parse/ledger.ts
@@ -59,6 +59,11 @@ function parseState(state) {
   return {rawState: JSON.stringify(state)}
 }
 
+/**
+ * @param {Ledger} ledger must be a *closed* ledger with valid `close_time` and `parent_close_time`
+ * @returns {FormattedLedger} formatted ledger
+ * @throws RangeError: Invalid time value (rippleTimeToISO8601)
+ */
 export function parseLedger(ledger: Ledger): FormattedLedger {
   const ledgerVersion = parseInt(ledger.ledger_index || ledger.seqNum, 10)
   return removeUndefined(Object.assign(

--- a/src/ledger/parse/utils.ts
+++ b/src/ledger/parse/utils.ts
@@ -122,7 +122,7 @@ function parseOutcome(tx: any): any|undefined {
 }
 
 function hexToString(hex: string): string|undefined {
-  return hex ? new Buffer(hex, 'hex').toString('utf-8') : undefined
+  return hex ? Buffer.from(hex, 'hex').toString('utf-8') : undefined
 }
 
 function parseMemos(tx: any): Array<Memo>|undefined {

--- a/src/offline/derive.ts
+++ b/src/offline/derive.ts
@@ -4,4 +4,3 @@ export {
   deriveKeypair,
   deriveAddress
 }
-

--- a/src/transaction/combine.ts
+++ b/src/transaction/combine.ts
@@ -7,7 +7,7 @@ import {validate} from '../common'
 import {computeBinaryTransactionHash} from 'ripple-hashes'
 
 function addressToBigNumber(address) {
-  const hex = (new Buffer(decodeAddress(address))).toString('hex')
+  const hex = (Buffer.from(decodeAddress(address))).toString('hex')
   return new BigNumber(hex, 16)
 }
 

--- a/src/transaction/utils.ts
+++ b/src/transaction/utils.ts
@@ -81,7 +81,7 @@ function prepareTransaction(txJSON: any, api: RippleAPI,
           (txJSON.TransactionType !== 'EscrowFinish' ||
             txJSON.Fulfillment === undefined) ? 0 :
             (cushion * feeRef * (32 + Math.floor(
-              new Buffer(txJSON.Fulfillment, 'hex').length / 16)))
+              Buffer.from(txJSON.Fulfillment, 'hex').length / 16)))
         const feeDrops = common.xrpToDrops(fee)
         const maxFeeXRP = instructions.maxFee ?
           BigNumber.min(api._maxFeeXRP, instructions.maxFee) : api._maxFeeXRP
@@ -114,7 +114,7 @@ function prepareTransaction(txJSON: any, api: RippleAPI,
 }
 
 function convertStringToHex(string: string): string {
-return new Buffer(string, 'utf8').toString('hex').toUpperCase()
+return Buffer.from(string, 'utf8').toString('hex').toUpperCase()
 }
 
 function convertMemo(memo: Memo): {Memo: ApiMemo} {


### PR DESCRIPTION
Fixes `(node:41150) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`