### PR TITLE
Fix prepareTransaction method specification

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4475,7 +4475,7 @@ console.log(JSON.stringify(flags, null, 2))
 
 ## prepareTransaction
 
-`prepareTransaction(address: string, transaction: object, instructions: object): Promise<object>`
+`prepareTransaction(transaction: object, instructions: object): Promise<object>`
 
 Prepare a transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 

--- a/docs/src/prepareTransaction.md.ejs
+++ b/docs/src/prepareTransaction.md.ejs
@@ -1,6 +1,6 @@
 ## prepareTransaction
 
-`prepareTransaction(address: string, transaction: object, instructions: object): Promise<object>`
+`prepareTransaction(transaction: object, instructions: object): Promise<object>`
 
 Prepare a transaction. The prepared transaction must subsequently be [signed](#sign) and [submitted](#submit).
 


### PR DESCRIPTION
The docs for `prepareTransaction()` include an errant address parameter. (The examples show the correct way to use the method.)