### PR TITLE
fix: build fails with strict checks

### DIFF
--- a/src/transaction/utils.ts
+++ b/src/transaction/utils.ts
@@ -18,7 +18,7 @@ export type TransactionJSON = {
   Memos?: {Memo: ApiMemo}[],
   Flags?: number,
   Fulfillment?: string,
-  [Field: string]: string | number | Array<any> | RippledAmount
+  [Field: string]: string | number | Array<any> | RippledAmount | undefined
 }
 
 function formatPrepareResponse(txJSON: any): Prepare {


### PR DESCRIPTION
This resolves the following build error thrown by type definitions that extend `TransactionJSON` and have optional properties (X of type T) if compiling in strict mode:

```
transaction/types.d.ts:LL;L - error TS2411: Property 'X' of type 'T | undefined' is not assignable to string index type 'string | number | any[] | Amount'
```