### PR TITLE
Add deliveredAmount as optional field for type Outcome

### DIFF
--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -82,6 +82,11 @@ export type Outcome = {
     }[]
   },
   orderbookChanges: object,
+  deliveredAmount?: {
+    currency: string;
+    value: string;
+    counterparty?: string;
+  };
   timestamp?: string
 }
 

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -83,10 +83,10 @@ export type Outcome = {
   },
   orderbookChanges: object,
   deliveredAmount?: {
-    currency: string;
-    value: string;
-    counterparty?: string;
-  };
+    currency: string,
+    counterparty?: string,
+    value: string
+  },
   timestamp?: string
 }
 


### PR DESCRIPTION
This PR is created according to issue https://github.com/ripple/ripple-lib/issues/995

**The gist**
Adding back the `deliveredAmount` field to the type `Outcome` based on the `getTransaction` api call from https://developers.ripple.com/rippleapi-reference.html#gettransaction,