### PR TITLE
Fix browser builds

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -53,12 +53,13 @@ function getWebpackConfig(extension, overrides) {
         use: [{
           loader: 'ts-loader',
           options: {
-            compilerOptions: {declaration: false}
+            compilerOptions: {
+              composite: false,
+              declaration: false,
+              declarationMap: false
+            }
           },
         }],
-      }, {
-        test: /\.json/,
-        use: 'json-loader',
       }]
     },
     resolve: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "main": "dist/npm/",
   "types": "dist/npm/index.d.ts",
   "browser": {
-    "ws": "./dist/npm/common/wswrapper.js"
+    "ws": "./dist/npm/common/wswrapper.js",
+    "https-proxy-agent": false
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
This is a minimal set of fixes from #1005 that are required for browser builds to work.

tsconfig:
- Must set composite: false
- Must set declarationMap: false in order to use declaration: false

json-loader:
- Not needed with webpack >= v2.0.0 and in fact does not work

https-proxy-agent cannot be used in the browser