### PR TITLE
Doc update for sign() method

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5434,6 +5434,10 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 
 ```javascript
 const RippleAPI = require('ripple-lib').RippleAPI;
+const api = new RippleAPI({
+  server: 'wss://s.altnet.rippletest.net:51233' 
+
+});
 
 // jon's address has a multi-signing setup with a qourum of 2
 const jon = {
@@ -5477,6 +5481,9 @@ api.connect().then(() => {
     console.log(response);
   }).catch(console.error);
 }).catch(console.error)
+.then(() => {
+  return api.disconnect();
+}).catch(console.error);
 ```
 
 Assuming the multisigning account was setup properly, the above example will respond with `resultCode: 'tesSUCCESS'`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5402,7 +5402,7 @@ options | object | *Optional* Options that control the type of signature that wi
 *options.* signAs | [address](#address) | *Optional* The account that the signature should count for in multisigning.
 secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field is exclusive with keypair).
 
-Please note that when this method is used for multisigning, the `options` parameter is not *Optional* anymore. It will be compulsary. See the multisigning example in this section for more details. 
+Please note that when this method is used for multisigning, the `options` parameter is not *Optional* anymore. It will be compulsory. See the multisigning example in this section for more details. 
 
 ### Return Value
 
@@ -5436,10 +5436,9 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 const RippleAPI = require('ripple-lib').RippleAPI;
 const api = new RippleAPI({
   server: 'wss://s.altnet.rippletest.net:51233' 
-
 });
 
-// jon's address has a multi-signing setup with a qourum of 2
+// jon's address has a multi-signing setup with a quorum of 2
 const jon = {
   account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
   secret: 'shfC5QySdfhCUaEfEF9gxPhAhy58u'
@@ -5466,23 +5465,20 @@ const multiSignPaymentTransaction = {
 };
 
 api.connect().then(() => {
-  let tx = JSON.stringify(multiSignPaymentTransaction, null, '\t');
-  
-  // Jon signs the original payment transaction
-  let jonSign = api.sign(tx, jon.secret).signedTransaction;
-  
-  // Aya and Bran sign it too but with 'signAs' set to their own account
-  let ayaSign = api.sign(tx, aya.secret, {'signAs': aya.account}).signedTransaction;
-  let branSign = api.sign(tx, bran.secret, {'signAs': bran.account})).signedTransaction;
-  
-  // signatures are combined and submitted
-  let combinedTx = api.combine([ayaSign, branSign]);
-  api.submit(combinedTx.signedTransaction).then ( (response) => {
-    console.log(response);
+  api.prepareTransaction(multiSignPaymentTransaction).then(prepared => {
+      console.log(prepared);
+      
+      // Aya and Bran sign it too but with 'signAs' set to their own account
+      let ayaSign = api.sign(tx, aya.secret, {'signAs': aya.account}).signedTransaction;
+      let branSign = api.sign(tx, bran.secret, {'signAs': bran.account})).signedTransaction;
+      
+      // signatures are combined and submitted
+      let combinedTx = api.combine([evaSig, giliSig, sincanSig]);
+      api.submit(combinedTx.signedTransaction).then ( (response) => {
+          console.log(response.tx_json.hash);
+          return api.disconnect();
+      }).catch(console.error);
   }).catch(console.error);
-}).catch(console.error)
-.then(() => {
-  return api.disconnect();
 }).catch(console.error);
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5434,55 +5434,85 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 
 ```javascript
 const RippleAPI = require('ripple-lib').RippleAPI;
-const api = new RippleAPI({
-  server: 'wss://s.altnet.rippletest.net:51233' 
-});
 
-// jon's address has a multi-signing setup with a quorum of 2
+// jon's address will have a multi-signing setup with a quorum of 2
 const jon = {
-  account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
-  secret: 'shfC5QySdfhCUaEfEF9gxPhAhy58u'
+    account: 'rJKpme4m2zBQceBuU89d7vLMzgoUw2Ptj',
+    secret: 'sh4Va7b1wQof8knHFV2sxwX12fSgK'
 };
-
 const aya = {
-  account: 'rnrPdBjs98fFFfmRpL6hM7exT788SWQPFN',
-  secret: 'snaMuMrXeVc2Vd4NYvHofeGNjgYoe'
+    account: 'rnrPdBjs98fFFfmRpL6hM7exT788SWQPFN',
+    secret: 'snaMuMrXeVc2Vd4NYvHofeGNjgYoe'
+};
+const bran = {
+    account: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
+    secret: 'shQtQ8Um5MS218yvEU3Ehy1eZQKqH'
 };
 
-const bran = {
-  account: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
-  secret: 'shQtQ8Um5MS218yvEU3Ehy1eZQKqH'
+// Setup the signers list with a quorum of 2
+const multiSignSetupTransaction = {
+    "Flags": 0,
+    "TransactionType": "SignerListSet",
+    "Account": "rJKpme4m2zBQceBuU89d7vLMzgoUw2Ptj",
+    "Fee": "120",
+    "SignerQuorum": 2,
+    "SignerEntries": [
+        {
+            "SignerEntry": {
+                "Account": "rnrPdBjs98fFFfmRpL6hM7exT788SWQPFN",
+                "SignerWeight": 2
+            }
+        },
+        {
+            "SignerEntry": {
+                "Account": "rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH",
+                "SignerWeight": 1
+            }
+        },
+    ]
 };
 
 // a transaction which requires multi signing
 const multiSignPaymentTransaction = {
     TransactionType: 'Payment',
-    Account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
-    Sequence: 4,
+    Account: 'rJKpme4m2zBQceBuU89d7vLMzgoUw2Ptj',
     Destination: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
-    Fee: '120',
-    Amount: '1888000000'
+    Amount: '88000000'
 };
 
+const api = new RippleAPI({
+    server: 'wss://s.altnet.rippletest.net:51233'
+});
+
 api.connect().then(() => {
-  api.prepareTransaction(multiSignPaymentTransaction).then(prepared => {
-      console.log(prepared);
-      
-      // Aya and Bran sign it too but with 'signAs' set to their own account
-      let ayaSign = api.sign(tx, aya.secret, {'signAs': aya.account}).signedTransaction;
-      let branSign = api.sign(tx, bran.secret, {'signAs': bran.account})).signedTransaction;
-      
-      // signatures are combined and submitted
-      let combinedTx = api.combine([evaSig, giliSig, sincanSig]);
-      api.submit(combinedTx.signedTransaction).then ( (response) => {
-          console.log(response.tx_json.hash);
-          return api.disconnect();
-      }).catch(console.error);
-  }).catch(console.error);
+    // adding the multi signing feature to jon's account
+    api.prepareTransaction(multiSignSetupTransaction).then((prepared) => {
+        console.log(prepared);
+        jonSign = api.sign(prepared.txJSON, jon.secret).signedTransaction;
+        api.submit(jonSign).then( response => {
+            console.log(response.resultCode, response.resultMessage);
+
+            // multi sign a transaction
+            api.prepareTransaction(multiSignPaymentTransaction).then(prepared => {
+                console.log(prepared);
+
+                // Aya and Bran sign it too but with 'signAs' set to their own account
+                let ayaSign = api.sign(prepared.txJSON, aya.secret, {'signAs': aya.account}).signedTransaction;
+                let branSign = api.sign(prepared.txJSON, bran.secret, {'signAs': bran.account}).signedTransaction;
+
+                // signatures are combined and submitted
+                let combinedTx = api.combine([ayaSign, branSign]);
+                api.submit(combinedTx.signedTransaction).then(response => {
+                    console.log(response.tx_json.hash);
+                    return api.disconnect();
+                }).catch(console.error);
+            }).catch(console.error);
+        }).catch(console.error)
+    }).catch(console.error);
 }).catch(console.error);
 ```
 
-Assuming the multisigning account was setup properly, the above example will respond with `resultCode: 'tesSUCCESS'`.
+Assuming the multisigning account was setup properly, the above example will respond with `resultCode: 'tesSUCCESS'` and the hash for the transaction.
 If any of `{signAs: some_address}` options were missing the code will return a validation error as follow:
 ```
 [ValidationError(txJSON is not the same for all signedTransactions)]

--- a/docs/index.md
+++ b/docs/index.md
@@ -5402,6 +5402,8 @@ options | object | *Optional* Options that control the type of signature that wi
 *options.* signAs | [address](#address) | *Optional* The account that the signature should count for in multisigning.
 secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field is exclusive with keypair).
 
+Please note that when this method is used for multisigning, the `options` parameter is not *Optional* anymore. It will be compulsary. See the multisigning example in this section for more details. 
+
 ### Return Value
 
 This method returns an object with the following structure:
@@ -5428,6 +5430,60 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 }
 ```
 
+### Example (multisigning)
+
+```javascript
+const RippleAPI = require('ripple-lib').RippleAPI;
+
+// jon's address has a multi-signing setup with a qourum of 2
+const jon = {
+  account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
+  secret: 'shfC5QySdfhCUaEfEF9gxPhAhy58u'
+};
+
+const aya = {
+  account: 'rnrPdBjs98fFFfmRpL6hM7exT788SWQPFN',
+  secret: 'snaMuMrXeVc2Vd4NYvHofeGNjgYoe'
+};
+
+const bran = {
+  account: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
+  secret: 'shQtQ8Um5MS218yvEU3Ehy1eZQKqH'
+};
+
+// a transaction which requires multi signing
+const multiSignPaymentTransaction = {
+    TransactionType: 'Payment',
+    Account: 'ranYTqDRUKKAqnXAAVDwWBUvvc5op4pXoP',
+    Sequence: 4,
+    Destination: 'rJ93RLnT1t5A8fCr7HTScw7WtfKJMRXodH',
+    Fee: '120',
+    Amount: '1888000000'
+};
+
+api.connect().then(() => {
+  let tx = JSON.stringify(multiSignPaymentTransaction, null, '\t');
+  
+  // Jon signs the original payment transaction
+  let jonSign = api.sign(tx, jon.secret).signedTransaction;
+  
+  // Aya and Bran sign it too but with 'signAs' set to their own account
+  let ayaSign = api.sign(tx, aya.secret, {'signAs': aya.account}).signedTransaction;
+  let branSign = api.sign(tx, bran.secret, {'signAs': bran.account})).signedTransaction;
+  
+  // signatures are combined and submitted
+  let combinedTx = api.combine([ayaSign, branSign]);
+  api.submit(combinedTx.signedTransaction).then ( (response) => {
+    console.log(response);
+  }).catch(console.error);
+}).catch(console.error)
+```
+
+Assuming the multisigning account was setup properly, the above example will respond with `resultCode: 'tesSUCCESS'`.
+If any of `{signAs: some_address}` options were missing the code will return a validation error as follow:
+```
+[ValidationError(txJSON is not the same for all signedTransactions)]
+```
 
 ## combine
 


### PR DESCRIPTION
Some description and an example added to explain why `signAs` option is compulsory for multi-signing scenarios.
