### PR TITLE
Docs: fix ripple/ripple-dev-portal#574

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -379,10 +379,9 @@ source | object | The source of the funds to be sent.
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 *source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
 destination | object | The destination of the funds to be sent.
-*destination.* address | [address](#address) | The address to receive at.
+*destination.* address | [address](#address) | An address representing the destination of the transaction.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with `destination.minAmount`.)
 *destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*destination.* address | [address](#address) | The address to send to.
 *destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field is exclusive with destination.amount)
 allowPartialPayment | boolean | *Optional* If true, this payment should proceed even if the whole amount cannot be delivered due to a lack of liquidity or a lack of funds in the source account.
 invoiceID | string | *Optional* A 256-bit hash that can be used to identify a particular payment.
@@ -2277,7 +2276,7 @@ pathfind | object | Specification of a pathfind request.
 *pathfind.source.currencies[].* currency | [currency](#currency) | The three-character code or hexadecimal string used to denote currencies
 *pathfind.source.currencies[].* counterparty | [address](#address) | *Optional* The counterparty for the currency; if omitted any counterparty may be used.
 *pathfind.* destination | object | Properties of the destination of funds.
-*pathfind.destination.* address | [address](#address) | The address to send to.
+*pathfind.destination.* address | [address](#address) | An address representing the destination of the transaction.
 *pathfind.destination.* amount | [laxLaxAmount](#amount) | The amount to be received by the receiver (`value` may be ommitted if a source amount is specified).
 
 ### Return Value
@@ -2292,10 +2291,9 @@ source | object | Properties of the source of the payment.
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
 *source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
 destination | object | Properties of the destination of the payment.
-*destination.* address | [address](#address) | The address to receive at.
+*destination.* address | [address](#address) | An address representing the destination of the transaction.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with `destination.minAmount`.)
 *destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*destination.* address | [address](#address) | The address to send to.
 *destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field is exclusive with destination.amount)
 paths | string | The paths of trustlines and orders to use in executing the payment.
 

--- a/src/common/schemas/input/get-paths.json
+++ b/src/common/schemas/input/get-paths.json
@@ -49,7 +49,7 @@
           "properties": {
             "address": {
               "$ref": "address",
-              "description": "The address to send to."
+              "description": "An address representing the destination of the transaction."
             },
             "amount": {
               "$ref": "laxLaxAmount",

--- a/src/common/schemas/objects/destination-address-tag.json
+++ b/src/common/schemas/objects/destination-address-tag.json
@@ -6,7 +6,7 @@
   "properties": {
     "address": {
       "$ref": "address",
-      "description": "The address to receive at."
+      "description": "An address representing the destination of the transaction."
     },
     "tag": {"$ref": "tag"}
   },

--- a/src/common/schemas/objects/destination-exact-adjustment.json
+++ b/src/common/schemas/objects/destination-exact-adjustment.json
@@ -5,7 +5,7 @@
   "properties": {
     "address": {
       "$ref": "address",
-      "description": "The address to receive at."
+      "description": "An address representing the destination of the transaction."
     },
     "amount": {
       "$ref": "laxAmount",

--- a/src/common/schemas/objects/min-adjustment.json
+++ b/src/common/schemas/objects/min-adjustment.json
@@ -5,7 +5,7 @@
   "properties": {
     "address": {
       "$ref": "address",
-      "description": "The address to send to."
+      "description": "An address representing the destination of the transaction."
     },
     "minAmount": {
       "$ref": "laxAmount",


### PR DESCRIPTION
`destination .address` is showing up twice because the descriptions differ. This makes them the same.

Fixes https://github.com/ripple/ripple-dev-portal/issues/574

Thanks @xrpinnovations