### PR TITLE
Phrasing cleanup in schema descriptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -273,7 +273,7 @@ A *balance* is an amount than can have a negative value.
 Name | Type | Description
 ---- | ---- | -----------
 currency | [currency](#currency) | The three-character code or hexadecimal string used to denote currencies, or "drops" for the smallest unit of XRP.
-counterparty | [address](#address) | *Optional* The Ripple address of the account that owes or is owed the funds (omitted if `currency` is "XRP" or "drops")
+counterparty | [address](#address) | *Optional* The XRP Ledger address of the account that owes or is owed the funds (omitted if `currency` is "XRP" or "drops")
 value | [value](#value) | *Optional* The quantity of the currency, denoted as a string to retain floating point precision
 
 # Transaction Overview
@@ -375,14 +375,14 @@ Name | Type | Description
 ---- | ---- | -----------
 source | object | The source of the funds to be sent.
 *source.* address | [address](#address) | The address to send from.
-*source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
+*source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with source.maxAmount)
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
+*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field cannot be used with source.amount)
 destination | object | The destination of the funds to be sent.
 *destination.* address | [address](#address) | An address representing the destination of the transaction.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with `destination.minAmount`.)
 *destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field is exclusive with destination.amount)
+*destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field cannot be used with destination.amount)
 allowPartialPayment | boolean | *Optional* If true, this payment should proceed even if the whole amount cannot be delivered due to a lack of liquidity or a lack of funds in the source account.
 invoiceID | string | *Optional* A 256-bit hash that can be used to identify a particular payment.
 limitQuality | boolean | *Optional* Only take paths where all the conversions have an input:output ratio that is equal or better than the ratio of destination.amount:source.maxAmount.
@@ -2020,7 +2020,7 @@ Name | Type | Description
 ---- | ---- | -----------
 currency | [currency](#currency) | The three-character code or hexadecimal string used to denote currencies
 value | [signedValue](#value) | The balance on the trustline
-counterparty | [address](#address) | *Optional* The Ripple address of the account that owes or is owed the funds.
+counterparty | [address](#address) | *Optional* The XRP Ledger address of the account that owes or is owed the funds.
 
 ### Example
 
@@ -2171,7 +2171,7 @@ Returns aggregate balances by currency plus a breakdown of assets and obligation
 
 Name | Type | Description
 ---- | ---- | -----------
-address | [address](#address) | The Ripple address of the account to get the balance sheet of.
+address | [address](#address) | The XRP Ledger address of the account to get the balance sheet of.
 options | object | *Optional* Options to determine how the balances will be calculated.
 *options.* excludeAddresses | array\<[address](#address)\> | *Optional* Addresses to exclude from the balance totals.
 *options.* ledgerVersion | integer | *Optional* Get the balance sheet as of this historical ledger version.
@@ -2269,7 +2269,7 @@ Name | Type | Description
 ---- | ---- | -----------
 pathfind | object | Specification of a pathfind request.
 *pathfind.* source | object | Properties of the source of funds.
-*pathfind.source.* address | [address](#address) | The Ripple address of the account where funds will come from.
+*pathfind.source.* address | [address](#address) | The XRP Ledger address of the account where funds will come from.
 *pathfind.source.* amount | [laxAmount](#amount) | *Optional* The amount of funds to send.
 *pathfind.source.* currencies | array | *Optional* An array of currencies (with optional counterparty) that may be used in the payment paths.
 *pathfind.source.* currencies[] | object | A currency with optional counterparty.
@@ -2287,14 +2287,14 @@ Name | Type | Description
 ---- | ---- | -----------
 source | object | Properties of the source of the payment.
 *source.* address | [address](#address) | The address to send from.
-*source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)
+*source.* amount | [laxAmount](#amount) | An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with source.maxAmount)
 *source.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field is exclusive with source.amount)
+*source.* maxAmount | [laxAmount](#amount) | The maximum amount to send. (This field cannot be used with source.amount)
 destination | object | Properties of the destination of the payment.
 *destination.* address | [address](#address) | An address representing the destination of the transaction.
 *destination.* amount | [laxAmount](#amount) | An exact amount to deliver to the recipient. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with `destination.minAmount`.)
 *destination.* tag | integer | *Optional* An arbitrary unsigned 32-bit integer that identifies a reason for payment or a non-Ripple account.
-*destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field is exclusive with destination.amount)
+*destination.* minAmount | [laxAmount](#amount) | The minimum amount to be delivered. (This field cannot be used with destination.amount)
 paths | string | The paths of trustlines and orders to use in executing the payment.
 
 ### Example
@@ -2388,7 +2388,7 @@ Returns open orders for the specified account. Open orders are orders that have 
 
 Name | Type | Description
 ---- | ---- | -----------
-address | [address](#address) | The Ripple address of the account to get open orders for.
+address | [address](#address) | The XRP Ledger address of the account to get open orders for.
 options | object | *Optional* Options that determine what orders will be returned.
 *options.* ledgerVersion | integer | *Optional* Return orders as of this historical ledger version.
 *options.* ledgerVersion | string | *Optional* Return orders as of this historical ledger version.
@@ -5395,12 +5395,12 @@ This method can sign any of [the transaction types supported by ripple-binary-co
 Name | Type | Description
 ---- | ---- | -----------
 txJSON | string | Transaction represented as a JSON string in rippled format.
-keypair | object | *Optional* The private and public key of the account that is initiating the transaction. (This field is exclusive with secret).
+keypair | object | *Optional* The private and public key of the account that is initiating the transaction. (This field cannot be used with secret).
 *keypair.* privateKey | privateKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key.
 *keypair.* publicKey | publicKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key.
 options | object | *Optional* Options that control the type of signature that will be generated.
 *options.* signAs | [address](#address) | *Optional* The account that the signature should count for in multisigning.
-secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field is exclusive with keypair).
+secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field cannot be used with keypair).
 
 ### Return Value
 

--- a/src/common/schemas/input/get-balance-sheet.json
+++ b/src/common/schemas/input/get-balance-sheet.json
@@ -6,7 +6,7 @@
   "properties": {
     "address": {
       "$ref": "address",
-      "description": "The Ripple address of the account to get the balance sheet of."
+      "description": "The XRP Ledger address of the account to get the balance sheet of."
     },
     "options": {
       "properties": {

--- a/src/common/schemas/input/get-orders.json
+++ b/src/common/schemas/input/get-orders.json
@@ -6,7 +6,7 @@
   "properties": {
     "address": {
       "$ref": "address",
-      "description": "The Ripple address of the account to get open orders for."
+      "description": "The XRP Ledger address of the account to get open orders for."
     },
     "options": {
       "description": "Options that determine what orders will be returned.",

--- a/src/common/schemas/input/get-paths.json
+++ b/src/common/schemas/input/get-paths.json
@@ -12,7 +12,7 @@
           "properties": {
             "address": {
               "$ref": "address",
-              "description": "The Ripple address of the account where funds will come from."
+              "description": "The XRP Ledger address of the account where funds will come from."
             },
             "amount": {
               "$ref": "laxAmount",

--- a/src/common/schemas/input/sign.json
+++ b/src/common/schemas/input/sign.json
@@ -10,7 +10,7 @@
     "secret": {
       "type": "string",
       "format": "secret",
-      "description": "The secret of the account that is initiating the transaction. (This field is exclusive with keypair)."
+      "description": "The secret of the account that is initiating the transaction. (This field cannot be used with keypair)."
     },
     "keypair": {
       "type": "object",
@@ -24,7 +24,7 @@
           "description": "The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key."
         }
       },
-      "description": "The private and public key of the account that is initiating the transaction. (This field is exclusive with secret).",
+      "description": "The private and public key of the account that is initiating the transaction. (This field cannot be used with secret).",
       "required": ["privateKey", "publicKey"],
       "additionalProperties": false
     },

--- a/src/common/schemas/objects/amountbase.json
+++ b/src/common/schemas/objects/amountbase.json
@@ -13,7 +13,7 @@
       "$ref": "currency"
     },
     "counterparty": {
-      "description": "The Ripple address of the account that owes or is owed the funds (omitted if `currency` is \"XRP\" or \"drops\")",
+      "description": "The XRP Ledger address of the account that owes or is owed the funds (omitted if `currency` is \"XRP\" or \"drops\")",
       "$ref": "address"
     }
   },

--- a/src/common/schemas/objects/balance.json
+++ b/src/common/schemas/objects/balance.json
@@ -14,7 +14,7 @@
       "$ref": "currency"
     },
     "counterparty": {
-      "description": "The Ripple address of the account that owes or is owed the funds.",
+      "description": "The XRP Ledger address of the account that owes or is owed the funds.",
       "$ref": "address"
     }
   },

--- a/src/common/schemas/objects/max-adjustment.json
+++ b/src/common/schemas/objects/max-adjustment.json
@@ -9,7 +9,7 @@
     },
     "maxAmount": {
       "$ref": "laxAmount",
-      "description": "The maximum amount to send. (This field is exclusive with source.amount)"
+      "description": "The maximum amount to send. (This field cannot be used with source.amount)"
     },
     "tag": {"$ref": "tag"}
   },

--- a/src/common/schemas/objects/min-adjustment.json
+++ b/src/common/schemas/objects/min-adjustment.json
@@ -9,7 +9,7 @@
     },
     "minAmount": {
       "$ref": "laxAmount",
-      "description": "The minimum amount to be delivered. (This field is exclusive with destination.amount)"
+      "description": "The minimum amount to be delivered. (This field cannot be used with destination.amount)"
     },
     "tag": {"$ref": "tag"}
   },

--- a/src/common/schemas/objects/source-exact-adjustment.json
+++ b/src/common/schemas/objects/source-exact-adjustment.json
@@ -9,7 +9,7 @@
     },
     "amount": {
       "$ref": "laxAmount",
-      "description": "An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field is exclusive with source.maxAmount)"
+      "description": "An exact amount to send. If the counterparty is not specified, amounts with any counterparty may be used. (This field cannot be used with source.maxAmount)"
     },
     "tag": {"$ref": "tag"}
   },


### PR DESCRIPTION
Just a find/replace on the schema text that goes into the README, to fix some style issues:

- Change 'Ripple address'→'XRP Ledger address'
- Change 'is exclusive with'→'cannot be used with'