### PR TITLE
Improve getTransaction() error when tx has not been validated yet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {RippleAPI} from './api'
+export * from './api'
 
 export {
     FormattedTransactionType

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './api'
+export {RippleAPI} from './api'
 
 export {
     FormattedTransactionType

--- a/src/ledger/transaction.ts
+++ b/src/ledger/transaction.ts
@@ -30,8 +30,12 @@ function attachTransactionDate(connection: Connection, tx: any
 
   if (!ledgerVersion) {
     return new Promise(() => {
-      throw new errors.NotFoundError(
-        'ledger_index and LedgerSequence not found in tx')
+      const error = new errors.NotFoundError(
+        'Transaction has not been validated yet; try again later')
+      error.data = {
+        details: '(ledger_index and LedgerSequence not found in tx)'
+      }
+      throw error
     })
   }
 


### PR DESCRIPTION
The current error message, `ledger_index and LedgerSequence not found in tx`, is not helpful. The new message is `Transaction has not been validated yet; try again later` which should be accurate.