### PR TITLE
Move tests to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ws": "^3.3.1"
   },
   "devDependencies": {
+    "@types/mocha": "^5.2.7",
     "@types/node": "11.13.0",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/parser": "^2.3.3",
@@ -61,7 +62,7 @@
     "compile": "mkdir -p dist/npm/common && cp -r src/common/schemas dist/npm/common/ && tsc --build",
     "watch": "tsc -w",
     "prepublish": "npm run clean && npm run compile && npm run build",
-    "test": "TS_NODE_PROJECT=src/tsconfig.json nyc mocha --exit",
+    "test": "TS_NODE_PROJECT=test/tsconfig.json nyc mocha --exit",
     "lint": "eslint src/**/*.ts 'test/*-test.{ts,js}'",
     "perf": "./scripts/perf_test.sh",
     "start": "node scripts/http.js"

--- a/test/api-test.ts
+++ b/test/api-test.ts
@@ -1,28 +1,21 @@
-/* eslint-disable max-nested-callbacks */
-'use strict'; // eslint-disable-line
-const _ = require('lodash');
-const assert = require('assert-diff');
-const setupAPI = require('./setup-api');
-const RippleAPI = require('ripple-api').RippleAPI;
-const validate = RippleAPI._PRIVATE.validate;
-const fixtures = require('./fixtures');
-const requests = fixtures.requests;
-const responses = fixtures.responses;
-const addresses = require('./fixtures/addresses');
-const hashes = require('./fixtures/hashes');
+import assert from 'assert-diff';
+import BigNumber from 'bignumber.js';
+import _ from 'lodash';
+import { RippleAPI } from 'ripple-api';
+import { RecursiveData } from 'ripple-api/ledger/utils';
+import binary from 'ripple-binary-codec';
+import { requests, responses } from './fixtures';
+import addresses from './fixtures/addresses';
+import hashes from './fixtures/hashes';
+import ledgerClosed from './fixtures/rippled/ledger-close-newer.json';
+import setupAPI from './setup-api';
+const {validate, schemaValidator} = RippleAPI._PRIVATE;
 const address = addresses.ACCOUNT;
 const utils = RippleAPI._PRIVATE.ledgerUtils;
-const ledgerClosed = require('./fixtures/rippled/ledger-close-newer');
-const schemaValidator = RippleAPI._PRIVATE.schemaValidator;
-const binary = require('ripple-binary-codec');
-const BigNumber = require('bignumber.js');
 assert.options.strict = true;
 
 // how long before each test case times out
 const TIMEOUT = 20000;
-
-function unused() {
-}
 
 function closeLedger(connection) {
   connection._ws.emit('message', JSON.stringify(ledgerClosed));
@@ -3577,9 +3570,9 @@ describe('RippleAPI', function () {
             taker: address
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         assert.deepEqual(orderbook, responses.getOrderbook.normal);
       });
@@ -3613,9 +3606,9 @@ describe('RippleAPI', function () {
             taker: address
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         assert.deepEqual(orderbook, responses.getOrderbook.withXRP);
       });
@@ -3681,9 +3674,9 @@ describe('RippleAPI', function () {
             taker: myAddress
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         assert.deepStrictEqual([], orderbook.bids);
         return checkSortingOfOrders(orderbook.asks);
@@ -3714,9 +3707,9 @@ describe('RippleAPI', function () {
             taker: myAddress
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         return checkSortingOfOrders(orderbook.bids) && checkSortingOfOrders(orderbook.asks);
       });
@@ -3751,9 +3744,9 @@ describe('RippleAPI', function () {
             taker: address
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         
         const bidRates = orderbook.bids.map(bid => bid.properties.makerExchangeRate);
@@ -3795,9 +3788,9 @@ describe('RippleAPI', function () {
             taker: address
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         
         const orders = _.flatten([orderbook.bids, orderbook.asks]);
@@ -3842,9 +3835,9 @@ describe('RippleAPI', function () {
             taker: address
           })
         ]
-      ).then((directOfferResults, reverseOfferResults) => {
-        const directOffers = (directOfferResults ? directOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
-        const reverseOffers = (reverseOfferResults ? reverseOfferResults : []).reduce((acc, res) => acc.concat(res.offers), [])
+      ).then(([directOfferResults, reverseOfferResults]) => {
+        const directOffers = (directOfferResults ? directOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
+        const reverseOffers = (reverseOfferResults ? reverseOfferResults.offers : []).reduce((acc, res) => acc.concat(res), [])
         const orderbook = RippleAPI.formatBidsAndAsks(orderbookInfo, [...directOffers, ...reverseOffers]);
         
         assert(
@@ -4549,8 +4542,7 @@ describe('RippleAPI', function () {
             'D9ABF622DA26EEEE48203085D4BC23B0F77DC6F8724AC33D975DA3CA492D2E44'
         });
         assert.throws(() => {
-          const hash = this.api.computeLedgerHash(ledger);
-          unused(hash);
+          this.api.computeLedgerHash(ledger);
         }, /does not match computed hash of state/);
       });
   });
@@ -4577,20 +4569,21 @@ describe('RippleAPI', function () {
 
   it('ledger utils - renameCounterpartyToIssuerInOrder', function () {
     const order = {
-      taker_gets: { counterparty: '1' },
-      taker_pays: { counterparty: '1' }
+      taker_gets: { counterparty: '1', currency: 'XRP' },
+      taker_pays: { counterparty: '1', currency: 'XRP' }
     };
     const expected = {
-      taker_gets: { issuer: '1' },
-      taker_pays: { issuer: '1' }
+      taker_gets: { issuer: '1', currency: 'XRP' },
+      taker_pays: { issuer: '1', currency: 'XRP' }
     };
     assert.deepEqual(utils.renameCounterpartyToIssuerInOrder(order), expected);
   });
 
   it('ledger utils - compareTransactions', function () {
+    // @ts-ignore
     assert.strictEqual(utils.compareTransactions({}, {}), 0);
-    let first = { outcome: { ledgerVersion: 1, indexInLedger: 100 } };
-    let second = { outcome: { ledgerVersion: 1, indexInLedger: 200 } };
+    let first: any = { outcome: { ledgerVersion: 1, indexInLedger: 100 } };
+    let second: any = { outcome: { ledgerVersion: 1, indexInLedger: 200 } };
 
     assert.strictEqual(utils.compareTransactions(first, second), -1);
 
@@ -4606,17 +4599,17 @@ describe('RippleAPI', function () {
   });
 
   it('ledger utils - getRecursive', function () {
-    function getter(marker, limit) {
-      return new Promise((resolve, reject) => {
-        if (marker === undefined) {
-          resolve({ marker: 'A', limit: limit, results: [1] });
-        } else {
+    function getter(marker) {
+      return new Promise<RecursiveData>((resolve, reject) => {
+        if (marker !== undefined) {
           reject(new Error());
+          return;
         }
+        resolve({ marker: 'A', results: [1] });
       });
     }
     return utils.getRecursive(getter, 10).then(() => {
-      assert(false, 'Should throw Error');
+      assert(false, 'Should th row Error');
     }).catch(error => {
       assert(error instanceof Error);
     });
@@ -4754,18 +4747,18 @@ describe('RippleAPI - offline', function () {
     assert.throws(() => api.computeLedgerHash(header));
   });
 
-  /* eslint-disable no-unused-vars */
   it('RippleAPI - implicit server port', function () {
-    const api = new RippleAPI({ server: 'wss://s1.ripple.com' });
+    new RippleAPI({ server: 'wss://s1.ripple.com' });
   });
-  /* eslint-enable no-unused-vars */
+
   it('RippleAPI invalid options', function () {
-    assert.throws(() => new RippleAPI({ invalid: true }));
+    assert.throws(() => new RippleAPI({ invalid: true } as any));
   });
 
   it('RippleAPI valid options', function () {
     const api = new RippleAPI({ server: 'wss://s:1' });
-    assert.deepEqual(api.connection._url, 'wss://s:1');
+    const privateConnectionUrl = (api.connection as any)._url;
+    assert.deepEqual(privateConnectionUrl, 'wss://s:1');
   });
 
   it('RippleAPI invalid server uri', function () {

--- a/test/api-test.ts
+++ b/test/api-test.ts
@@ -4609,7 +4609,7 @@ describe('RippleAPI', function () {
       });
     }
     return utils.getRecursive(getter, 10).then(() => {
-      assert(false, 'Should th row Error');
+      assert(false, 'Should throw Error');
     }).catch(error => {
       assert(error instanceof Error);
     });

--- a/test/broadcast-api-test.ts
+++ b/test/broadcast-api-test.ts
@@ -1,11 +1,9 @@
-/* eslint-disable max-nested-callbacks */
-'use strict';
-const _ = require('lodash');
-const assert = require('assert-diff');
-const setupAPI = require('./setup-api');
-const responses = require('./fixtures').responses;
-const ledgerClosed = require('./fixtures/rippled/ledger-close');
-const RippleAPI = require('ripple-api').RippleAPI;
+import _ from 'lodash';
+import assert from 'assert-diff';
+import setupAPI from './setup-api';
+import {responses} from './fixtures';
+import ledgerClosed from './fixtures/rippled/ledger-close.json';
+import {RippleAPI} from 'ripple-api';
 const schemaValidator = RippleAPI._PRIVATE.schemaValidator;
 
 const TIMEOUT = 20000;

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -1,19 +1,14 @@
-'use strict'; // eslint-disable-line 
-/* eslint-disable max-nested-callbacks */
-
-const _ = require('lodash');
-const net = require('net');
-const assert = require('assert-diff');
-const setupAPI = require('./setup-api');
-const RippleAPI = require('ripple-api').RippleAPI;
+import _ from 'lodash';
+import net from 'net';
+import assert from 'assert-diff';
+import setupAPI from './setup-api';
+import {RippleAPI} from 'ripple-api';
+import ledgerClose from './fixtures/rippled/ledger-close.json';
 const utils = RippleAPI._PRIVATE.ledgerUtils;
-const ledgerClose = require('./fixtures/rippled/ledger-close.json');
 
 
 const TIMEOUT = 200000;   // how long before each test case times out
-
-function unused() {
-}
+const isBrowser = (process as any).browser;
 
 function createServer() {
   return new Promise((resolve, reject) => {
@@ -34,14 +29,14 @@ describe('Connection', function() {
   afterEach(setupAPI.teardown);
 
   it('default options', function() {
-    const connection = new utils.common.Connection('url');
+    const connection: any = new utils.common.Connection('url');
     assert.strictEqual(connection._url, 'url');
     assert(_.isUndefined(connection._proxyURL));
     assert(_.isUndefined(connection._authorization));
   });
 
   it('trace', function() {
-    const connection = new utils.common.Connection('url', {trace: true});
+    const connection: any = new utils.common.Connection('url', {trace: true});
     const message1 = '{"type": "transaction"}';
     const message2 = '{"type": "path_find"}';
     const messages = [];
@@ -60,11 +55,11 @@ describe('Connection', function() {
   });
 
   it('with proxy', function(done) {
-    if (process.browser) {
+    if (isBrowser) {
       done();
       return;
     }
-    createServer().then(server => {
+    createServer().then((server: any) => {
       const port = server.address().port;
       const expect = 'CONNECT localhost';
       server.on('connection', socket => {
@@ -110,7 +105,7 @@ describe('Connection', function() {
   it('should throw NotConnectedError if server not responding ', function(
     done
   ) {
-    if (process.browser) {
+    if (isBrowser) {
       const phantomTest = /PhantomJS/;
       if (phantomTest.test(navigator.userAgent)) {
         // inside PhantomJS this one just hangs, so skip as not very relevant
@@ -155,7 +150,6 @@ describe('Connection', function() {
 
   it('DisconnectedError on send', function() {
     this.api.connection._ws.send = function(message, options, callback) {
-      unused(message, options);
       callback({message: 'not connected'});
     };
     return this.api.getServerInfo().then(() => {
@@ -216,7 +210,7 @@ describe('Connection', function() {
     });
 
     it('reconnect on several unexpected close', function(done) {
-      if (process.browser) {
+      if (isBrowser) {
         const phantomTest = /PhantomJS/;
         if (phantomTest.test(navigator.userAgent)) {
           // inside PhantomJS this one just hangs, so skip as not very relevant
@@ -316,21 +310,17 @@ describe('Connection', function() {
   });
 
   it('Cannot connect because no server', function() {
-    const connection = new utils.common.Connection();
+    const connection = new utils.common.Connection(undefined as string);
     return connection.connect().then(() => {
       assert(false, 'Should throw ConnectionError');
     }).catch(error => {
-      assert(error instanceof this.api.errors.ConnectionError);
+      assert(error instanceof this.api.errors.ConnectionError, 'Should throw ConnectionError');
     });
   });
 
   it('connect multiserver error', function() {
-    const options = {
-      servers: ['wss://server1.com', 'wss://server2.com']
-    };
     assert.throws(function() {
-      const api = new RippleAPI(options);
-      unused(api);
+       new RippleAPI({servers: ['wss://server1.com', 'wss://server2.com']} as any);
     }, this.api.errors.RippleError);
   });
 

--- a/test/hashes-test.ts
+++ b/test/hashes-test.ts
@@ -1,19 +1,15 @@
-/* eslint-disable max-len, valid-jsdoc */
-'use strict';
-
-var assert = require('assert');
-var fs = require('fs');
-var hashes = require('../src/common/hashes');
+import assert from 'assert';
+import fs from 'fs';
+import * as hashes from '../src/common/hashes';
 
 /**
-* @param ledgerIndex {Number}
 * Expects a corresponding ledger dump in $repo/test/fixtures/rippled folder
 */
-function createLedgerTest(ledgerIndex) {
+function createLedgerTest(ledgerIndex: number) {
   describe(String(ledgerIndex), function() {
     var path = __dirname + '/fixtures/rippled/ledger-full-' + ledgerIndex + '.json';
 
-    var ledgerRaw = fs.readFileSync(path);
+    var ledgerRaw = fs.readFileSync(path, {encoding: 'utf8'});
     var ledgerJSON = JSON.parse(ledgerRaw);
 
     var hasAccounts = Array.isArray(ledgerJSON.accountState)
@@ -22,12 +18,12 @@ function createLedgerTest(ledgerIndex) {
     if (hasAccounts) {
       it('has account_hash of ' + ledgerJSON.account_hash, function() {
         assert.equal(ledgerJSON.account_hash,
-          hashes.computeStateTreeHash(ledgerJSON.accountState, 1));
+          hashes.computeStateTreeHash(ledgerJSON.accountState));
       });
     }
     it('has transaction_hash of ' + ledgerJSON.transaction_hash, function() {
       assert.equal(ledgerJSON.transaction_hash,
-        hashes.computeTransactionTreeHash(ledgerJSON.transactions, 1));
+        hashes.computeTransactionTreeHash(ledgerJSON.transactions));
     });
   });
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,3 +3,4 @@
 --slow 500
 --require ts-node/register
 --require source-map-support/register
+./test/*.{ts,js}

--- a/test/rangeset-test.ts
+++ b/test/rangeset-test.ts
@@ -1,6 +1,6 @@
-'use strict';
-const assert = require('assert');
-const RangeSet = require('ripple-api').RippleAPI._PRIVATE.RangeSet;
+import assert from 'assert';
+import {RippleAPI} from 'ripple-api';
+const RangeSet = RippleAPI._PRIVATE.RangeSet;
 
 describe('RangeSet', function() {
   it('addRange()/addValue()', function() {

--- a/test/shamap-test.ts
+++ b/test/shamap-test.ts
@@ -1,19 +1,14 @@
-/* eslint-disable max-len, valid-jsdoc */
-'use strict';
-
-var assert = require('assert');
-var SHAMap = require('../src/common/hashes/shamap').SHAMap;
-var TYPE_TRANSACTION_NO_METADATA = require('../src/common/hashes/shamap').NodeType.TRANSACTION_NO_METADATA
+import assert from 'assert';
+import {SHAMap, NodeType} from '../src/common/hashes/shamap';
+const TYPE_TRANSACTION_NO_METADATA = NodeType.TRANSACTION_NO_METADATA
 
 var HEX_ZERO = '00000000000000000000000000000000' +
                '00000000000000000000000000000000';
 
 /**
 * Generates data to hash for testing
-* @param {number} v int value
-* @returns {string} 64 length hex string
 */
-function intToVuc(v) {
+function intToVuc(v: number): string {
   var ret = '';
 
   for (var i = 0; i < 32; i++) {
@@ -23,12 +18,7 @@ function intToVuc(v) {
   return ret;
 }
 
-/**
-* @param shamap {Object}
-* @param keys {Array}
-* @param hashes {Array}
-*/
-function fillShamapTest(shamap, keys, hashes) {
+function fillShamapTest(shamap: any, keys: string[], hashes: string[]) {
   for (var i = 0; i < keys.length; i++) {
     var data = intToVuc(i);
     shamap.addItem(keys[i].toUpperCase(), data, TYPE_TRANSACTION_NO_METADATA);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig-base.json",
+  "compilerOptions": {
+    "noEmit": true,
+  }
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -19,6 +19,5 @@
     "suppressImplicitAnyIndexErrors": false,
     "resolveJsonModule": true,
     "preserveSymlinks": true
-
   }
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -13,10 +13,12 @@
     "strictNullChecks": false,
     "noImplicitAny": false,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "removeComments": true,
     "preserveConstEnums": false,
     "esModuleInterop": true,
-    "suppressImplicitAnyIndexErrors": false
+    "suppressImplicitAnyIndexErrors": false,
+    "resolveJsonModule": true,
+    "preserveSymlinks": true
+
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
   integrity sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==
 
+"@types/mocha@^5.2.7":
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
+  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
+
 "@types/node@*":
   version "12.7.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.12.tgz#7c6c571cc2f3f3ac4a59a5f2bd48f5bdbc8653cc"


### PR DESCRIPTION
This moves the test files from JS to TS. We fall back to a few "any" types here just to not block the main move from JS to TS, and then can come back to resolve those after if they're worth it (some uses of any actually make sense, for example testing bad input that TS would disallow but a JS user might do anyway).