### PR TITLE
Reduce dependency size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-lib-cov
-coverage.html
-src
-dist/bower

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A JavaScript API for interacting with Ripple in Node.js and the browser",
   "files": [
     "dist/npm/*",
-    "build/*"
+    "build/ripple-latest-min.js"
   ],
   "main": "dist/npm/",
   "types": "dist/npm/index.d.ts",


### PR DESCRIPTION
We can cut the size of the npm tarball by about 78% by excluding the other files in `build/` (including only `ripple-latest-min.js`, which I think is the one that people should use most of the time).

- Remove .npmignore since it is overridden by package.json 'files'
- Include build/ripple-latest-min.js, not everything in build/

Before:
```
% npm publish --dry-run
[...]
npm notice === Tarball Details === 
npm notice name:          ripple-lib                              
npm notice version:       1.4.0-b2                                
npm notice package size:  1.9 MB                                  
npm notice unpacked size: 7.8 MB                                  
npm notice shasum:        5a28c5b629bdfa7299381d9d639673d0407f3233
npm notice integrity:     sha512-90mGTucpK5CcR[...]onwZt9ReLv7Yg==
npm notice total files:   570
```

After:
```
% npm publish --dry-run
[...]
npm notice === Tarball Details === 
npm notice name:          ripple-lib                              
npm notice version:       1.4.0-b2                                
npm notice package size:  419.5 kB                                
npm notice unpacked size: 1.6 MB                                  
npm notice shasum:        7ca4fc567916666447363a9be47f5305a727ba77
npm notice integrity:     sha512-VuyZ7b1T1gOOC[...]lmX8O4/96Dstw==
npm notice total files:   566
```