### PR TITLE
Fix Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 10
   - 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 10
   - 11
 script:
-  - yarn compile
   - yarn test
   - yarn build
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - 8
   - 10
   - 11
+install:
+  - npm i -g yarn
 script:
   - yarn compile
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - 8
   - 10
   - 11
-install:
-  - npm i -g yarn
 script:
   - yarn compile
   - yarn test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# ripple-lib [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
-
+[![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
+# ripple-lib
 
 A JavaScript API for interacting with the XRP Ledger
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
- [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
-# ripple-lib
+# ripple-lib [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
+
 
 A JavaScript API for interacting with the XRP Ledger
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
+ [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
 # ripple-lib
 
 A JavaScript API for interacting with the XRP Ledger

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# ripple-lib [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
-
+ [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
+# ripple-lib
 
 A JavaScript API for interacting with the XRP Ledger
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
+
 # ripple-lib
 
 A JavaScript API for interacting with the XRP Ledger

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
+# ripple-lib [![Build Status](https://travis-ci.org/ripple/ripple-lib.svg?branch=master)](https://travis-ci.org/ripple/ripple-lib)
 
-# ripple-lib
 
 A JavaScript API for interacting with the XRP Ledger
 


### PR DESCRIPTION
# Changes:
- **Drop support for Node v6:**
This library looks like it's [dropping support for node v6](https://github.com/ripple/ripple-lib/issues/1070) anyway and `eslint` is not compatible with Node v6 so the [build fails](https://travis-ci.org/ripple/ripple-lib/jobs/606802258).
- **Add a build status badge to `README.md`**

# Notes
To get Travis building, the toggles for Push and Pulled builds need to get turned on in the [Travis Settings Panel](https://travis-ci.org/ripple/ripple-lib/settings).  

I have permissions to do this, but wanted to check with a library owner before I messed with settings. Let me know if I should make it so. Once this happens, I can tickle the build request here. 


