### PR TITLE
Proposed 1.4.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,18 @@
 # ripple-lib Release History
 
+## 1.4.1 (2019-11-06)
+
+* Compatibility: Change TypeScript compile target back to `es6` (#1071)
+  * WARNING: This allows for the use of Node v6, which is no longer supported by Node.js, as it was end-of-life'd in April 2019
+  * We recommend updating to Node v8/v10 ASAP in order to get security updates and fixes from the Node.js team
+  * We are not actively running tests against Node v6 (ref #1076)
+* Docs: `getAccountObjects` doc fix
+* Dependencies:
+  * Update `bignumber.js`
+  * Update `ripple-keypairs`
+  * Update `ws`
+* Build process: Update `webpack` flow
+
 ## 1.4.0 (2019-10-28)
 
 * Unref timer so it does not hang the Node.js process

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-lib",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [


### PR DESCRIPTION
This updates the README and HISTORY files to document the new release. Once this PR is merged, I'll do the release on GitHub/npm, send [the release announcement email](https://groups.google.com/forum/#!forum/ripple-lib-announce), and open a PR to update the docs site.