### PR TITLE
Fix Node.js Testing Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - 8
   - 10
-  - 11
+  - 12
+  - 13
 script:
   - yarn test
   - yarn build


### PR DESCRIPTION
Updated our testing matrix based on: https://nodejs.org/en/about/releases/

- Node 11 is no longer supported (not LTS)
- Node 12 added (active LTS)
- Node 13 added ("current" release) 