### PR TITLE
Add a prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,9 @@
 {
-    "trailingComma": "es5",
-    "printWidth": 80,
-    "tabWidth": 2,
-    "semi": false,
-    "singleQuote": true,
-    "parser": "typescript",
-    "quoteProps": "consistent"
+  "parser": "typescript",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "quoteProps": "consistent"
   }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+    "trailingComma": "es5",
+    "printWidth": 80,
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true,
+    "parser": "typescript",
+    "quoteProps": "consistent"
+  }


### PR DESCRIPTION
Does anyone mind if we add a .prettierrc file to the repo? If you have the either the VSCode plugin setup or the CLI tool installed, you can just run `> Format Document` and get automatic formatting. You can also configure it to auto-format on save. 

I use this in all of my projects at this point and love it. I'd recommend we set it up for the project (`yarn run format` to format the whole repo), but first just adding this config file only for the people who want it would be a good first step.

![demo](https://thumbs.gfycat.com/OblongIlliterateFattaileddunnart-size_restricted.gif)
