### PR TITLE
Update email hash default to allow proper clearing

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -74,7 +74,7 @@ const AccountFlagIndices = {
 
 const AccountFields = {
   EmailHash: {name: 'emailHash', encoding: 'hex',
-    length: 32, defaults: '0'},
+    length: 32, defaults: '00000000000000000000000000000000'},
   MessageKey: {name: 'messageKey'},
   Domain: {name: 'domain', encoding: 'hex'},
   TransferRate: {name: 'transferRate', defaults: 0, shift: 9}


### PR DESCRIPTION
This PR relates to issue https://github.com/ripple/ripple-lib/issues/965 and the documented behaviour of the email hash value (https://xrpl.org/rippleapi-reference.html#settings) "use null to clear".

While the intended behaviour of preparing a settings transaction with `{"emailHash": null}` is to clear the email hash, the setTransactionFields method in `/src/transaction/settings.ts` sets the email hash to `'0'`. This is invalid according to the current validation rules, as a length check fails (32 characters). By defaulting to `'00000000000000000000000000000000'`, assuming that the validation rules are correct, we fix the bug and ensure the email hash can be cleared.