### PR TITLE
Add support for tick size

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3939,6 +3939,7 @@ return api.getSettings(address).then(settings =>
   "emailHash": "23463B99B62A72F26ED677CC556C44E8",
   "domain": "example.com",
   "transferRate": 1.002,
+  "tickSize": 5,
   "signers": {
     "threshold": 3,
     "weights": [

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -77,7 +77,8 @@ const AccountFields = {
     length: 32, defaults: '0'},
   MessageKey: {name: 'messageKey'},
   Domain: {name: 'domain', encoding: 'hex'},
-  TransferRate: {name: 'transferRate', defaults: 0, shift: 9}
+  TransferRate: {name: 'transferRate', defaults: 0, shift: 9},
+  TickSize: {name: 'tickSize', defaults: 0}
 }
 
 export {

--- a/src/common/schemas/objects/settings-plus-memos.json
+++ b/src/common/schemas/objects/settings-plus-memos.json
@@ -98,11 +98,15 @@
       "additionalProperties": false
     },
     "transferRate": {
-      "description": " The fee to charge when users transfer this account’s issuances, as the decimal amount that must be sent to deliver 1 unit. Has precision up to 9 digits beyond the decimal point. Use `null` to set no fee.",
+      "description": "The fee to charge when users transfer this account’s issuances, as the decimal amount that must be sent to deliver 1 unit. Has precision up to 9 digits beyond the decimal point. Use `null` to set no fee.",
       "oneOf": [
         {"type": "null"},
         {"type": "number", "minimum": 1, "maximum": 4.294967295}
       ]
+    },
+    "tickSize": {
+      "description": "Tick size to use for offers involving a currency issued by this address. The exchange rates of those offers is rounded to this many significant digits. Valid values are 3 to 15 inclusive, or 0 to disable.",
+      "enum": [0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     }
   },
   "additionalProperties": false

--- a/src/common/types/objects/settings.ts
+++ b/src/common/types/objects/settings.ts
@@ -27,5 +27,6 @@ export type FormattedSettings = {
   requireAuthorization?: boolean,
   requireDestinationTag?: boolean,
   signers?: Signers,
-  transferRate?: number|null
+  transferRate?: number|null,
+  tickSize?: number|null
 }

--- a/src/common/types/objects/settings.ts
+++ b/src/common/types/objects/settings.ts
@@ -28,5 +28,5 @@ export type FormattedSettings = {
   requireDestinationTag?: boolean,
   signers?: Signers,
   transferRate?: number|null,
-  tickSize?: number|null
+  tickSize?: number
 }

--- a/test/fixtures/responses/get-settings.json
+++ b/test/fixtures/responses/get-settings.json
@@ -4,6 +4,7 @@
   "emailHash": "23463B99B62A72F26ED677CC556C44E8",
   "domain": "example.com",
   "transferRate": 1.002,
+  "tickSize": 5,
   "signers": {
     "threshold": 3,
     "weights": [

--- a/test/fixtures/rippled/account-info.json
+++ b/test/fixtures/rippled/account-info.json
@@ -15,6 +15,7 @@
       "PreviousTxnLgrSeq": 6614625,
       "Sequence": 23,
       "TransferRate": 1002000000,
+      "TickSize": 5,
       "WalletLocator": "00000000000000000000000000000000000000000000000000000000DEADBEEF",
       "index": "396400950EA27EB5710C0D5BE1D2B4689139F168AC5D07C13B8140EC3F82AE71",
       "urlgravatar": "http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8",


### PR DESCRIPTION
This PR adds support for the tick size field introduced by the TickSize amendement (https://xrpl.org/known-amendments.html#ticksize)

The implementation follows the documentation in https://xrpl.org/accountset.html#accountset-fields, meaning that valid values are 3 to 15 inclusive and 0 is used to disable the custom tick size.