### PR TITLE
Fix Unhandled Promise Rejection Warning on message _send

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -382,6 +382,7 @@ class Connection extends EventEmitter {
 
   _whenReady<T>(promise: Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
+      promise.catch(reject);
       if (!this._shouldBeConnected) {
         reject(new NotConnectedError())
       } else if (this._state === WebSocket.OPEN && this._isReady) {


### PR DESCRIPTION
Adds an immediate catch to the `_send` promise passed to `_whenReady` in case there is rejection before async handlers are added. If there is no rejection, the added async handlers would take precedence. In the case of immediate rejection, the error is returned to the  `_whenReady.catch` appropriately. In the case of successful resolution `_whenReady.then` is called.

The behavior can be reproduced in this way: 

```
const passThe = function(promise) {
  return new Promise((resolve, reject) => {
    setTimeout(() => {
      promise.then(resolve, reject);
    }, 500);
  });
}

const promise = function(message) {
  return new Promise((resolve, reject) => {
    return reject(new Error(message));
  });
}

passThe(promise('helloWorld')).then((res) => {
  console.log(res, 'passThe fn res')
}).catch((e) => {
  console.log(e, 'passThe fn err')
});
```