### PR TITLE
Add a heartbeat to detect hung connections

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -384,12 +384,14 @@ class Connection extends EventEmitter {
   }
 
   reconnect() {
+    this.emit('reconnect');
     return this.disconnect().then(() => this.connect())
   }
 
   private _clearHeartbeatInterval = () => {
     clearInterval(this._heartbeatInterval);
   }
+
   private _startHeartbeatInterval = () => {
     this._clearHeartbeatInterval()
     this._heartbeatInterval = setInterval(() => this._heartbeat(), 1000 * 60);
@@ -400,7 +402,7 @@ class Connection extends EventEmitter {
    * If this succeeds, we're good. If it fails, disconnect so that the consumer can reconnect, if desired.
    */
   private _heartbeat = () => {
-    return this.request({command: "ping"}).catch(() => this.disconnect());
+    return this.request({command: "ping"}).catch(() => this.reconnect());
   }
 
   _whenReady<T>(promise: Promise<T>): Promise<T> {

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -384,6 +384,10 @@ class Connection extends EventEmitter {
   }
 
   reconnect() {
+    // NOTE: We currently have a "reconnecting" event, but that only triggers through
+    // _retryConnect, which was written in a way that is required to run as an internal 
+    // part of the post-disconnect connect() flow.
+    // See: https://github.com/ripple/ripple-lib/pull/1101#issuecomment-565360423
     this.emit('reconnect');
     return this.disconnect().then(() => this.connect())
   }

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -39,8 +39,9 @@ class Connection extends EventEmitter {
   private _availableLedgerVersions = new RangeSet()
   private _nextRequestID: number = 1
   private _retry: number = 0
-  private _connectTimer: null|NodeJS.Timer = null
-  private _retryTimer: null|NodeJS.Timer = null
+  private _connectTimer: null|NodeJS.Timeout = null
+  private _retryTimer: null|NodeJS.Timeout = null
+  private _heartbeatInterval: null|NodeJS.Timeout = null;
   private _onOpenErrorBound: null| null|((...args: any[]) => void) = null
   private _onUnexpectedCloseBound: null|((...args: any[]) => void) = null
   private _fee_base: null|number = null
@@ -295,7 +296,8 @@ class Connection extends EventEmitter {
   connect(): Promise<void> {
     this._clearConnectTimer()
     this._clearReconnectTimer()
-    return new Promise<void>((resolve, reject) => {
+    this._clearHeartbeatInterval()
+    return new Promise<void>((_resolve, reject) => {
       this._connectTimer = setTimeout(() => {
           reject(new ConnectionError(`Error: connect() timed out after ${this._connectionTimeout} ms. ` +
           `If your internet connection is working, the rippled server may be blocked or inaccessible.`))
@@ -303,6 +305,10 @@ class Connection extends EventEmitter {
       if (!this._url) {
         reject(new ConnectionError(
           'Cannot connect because no server was specified'))
+      }
+      const resolve = () => {
+        this._startHeartbeatInterval();
+        _resolve();
       }
       if (this._state === WebSocket.OPEN) {
         resolve()
@@ -348,6 +354,7 @@ class Connection extends EventEmitter {
   }
 
   _disconnect(calledByUser): Promise<void> {
+    this._clearHeartbeatInterval()
     if (calledByUser) {
       this._clearConnectTimer()
       this._clearReconnectTimer()
@@ -378,6 +385,22 @@ class Connection extends EventEmitter {
 
   reconnect() {
     return this.disconnect().then(() => this.connect())
+  }
+
+  private _clearHeartbeatInterval = () => {
+    clearInterval(this._heartbeatInterval);
+  }
+  private _startHeartbeatInterval = () => {
+    this._clearHeartbeatInterval()
+    this._heartbeatInterval = setInterval(() => this._heartbeat(), 1000 * 60);
+  }
+
+  /**
+   * A heartbeat is just a "ping" command, sent on an interval.
+   * If this succeeds, we're good. If it fails, disconnect so that the consumer can reconnect, if desired.
+   */
+  private _heartbeat = () => {
+    return this.request({command: "ping"}).catch(() => this.disconnect());
   }
 
   _whenReady<T>(promise: Promise<T>): Promise<T> {

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -266,6 +266,29 @@ describe('Connection', function() {
     });
   });
 
+  it('disconnect event on heartbeat failure', function(done) {
+    if (isBrowser) {
+      const phantomTest = /PhantomJS/;
+      if (phantomTest.test(navigator.userAgent)) {
+        // inside PhantomJS this one just hangs, so skip as not very relevant
+        done();
+        return;
+      }
+    }
+    this.timeout(20001);
+    this.api.connection.on('reconnecting', () => {
+      done(new Error('automatic reconnection not expected'));
+    });
+    this.api.connection.on('disconnected', _code => {
+      done();
+    });
+    // Set the heartbeat to less than the 1 second ping response
+    this.api.connection._timeout = 500;
+    // Trigger a reset of the heartbeat, using the new timeout val
+    this.api.connection._startHeartbeatInterval();
+});
+
+
   it('should emit disconnected event with code 1000 (CLOSE_NORMAL)',
   function(done
   ) {

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -266,7 +266,7 @@ describe('Connection', function() {
     });
   });
 
-  it('disconnect event on heartbeat failure', function(done) {
+  it('reconnect event on heartbeat failure', function(done) {
     if (isBrowser) {
       const phantomTest = /PhantomJS/;
       if (phantomTest.test(navigator.userAgent)) {
@@ -275,17 +275,14 @@ describe('Connection', function() {
         return;
       }
     }
-    this.timeout(20001);
-    this.api.connection.on('reconnecting', () => {
-      done(new Error('automatic reconnection not expected'));
-    });
-    this.api.connection.on('disconnected', _code => {
-      done();
-    });
     // Set the heartbeat to less than the 1 second ping response
     this.api.connection._timeout = 500;
-    // Trigger a reset of the heartbeat, using the new timeout val
-    this.api.connection._startHeartbeatInterval();
+    // Drop the test runner timeout, since this should be a quick test
+    this.timeout(5000);
+    // Hook up a listener for the reconnect event
+    this.api.connection.on('reconnect', () => done());
+    // Trigger a heartbeat
+    this.api.connection._heartbeat();
 });
 
 

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -336,6 +336,19 @@ export function createMockRippled(port) {
     }
   });
 
+  mock.on('request_ping', function (request, conn) {
+    // NOTE: We give the response a timeout of 2 second, so that tests can
+    // set their timeout threshold to greater than or less than this number
+    // to test timeouts.
+    setTimeout(() => {
+      conn.send(createResponse(request, {
+        "result": {},
+        "status": "success",
+        "type": "response"
+      }));
+    }, 1000 * 2);
+  });
+
   mock.on('request_tx', function (request, conn) {
     assert.strictEqual(request.command, 'tx');
     if (request.transaction === hashes.VALID_TRANSACTION_HASH) {


### PR DESCRIPTION
ripple-lib now keeps a constant heartbeat to detect broken/hung connections. Every minute, a "ping" command is sent by the RippleAPI connection instance. If that fails, the connection is disconnected so that the consumer can reconnect.

I was able to test this by dropping the timeout down to below the mocked "ping" response, to simulate a hung connection receiving no responses from the server. It's not perfect, but it's a fair enough representation, especially considering how tricky it is to test server disconnect/reconnect logic.

## Questions

- Is "disconnect" the proper action? With a little more complexity, we could also reconnect automatically (silently so that the user never knows, or with emitted "disconnect" and "reconnect" events).  
  - **A:** Talked with @intelliot, and we'll make "reconnect" the default behavior.
- I'm assuming that there's no concern here for added load on the network (1 ping request, every minute, for everyone who uses the official Ripple SDK). If there is a concern there, let me know and we can bump up the interval or make it opt-in.
  - **A:** This is fine.

## Alternative Designs / Considerations

For a while I worked to do this in some clever way using the ledgerClosed stream that we already connect to (so no extra ping requests needed). But ultimately it felt more maintainable/reliable to just add a true heartbeat that wouldn't have to rely on the behavior of that stream's implementation on both the server and the client.


