### PR TITLE
Update getTransactions example request/response

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1673,7 +1673,11 @@ This method returns a promise that resolves with an array of transaction object 
 
 ```javascript
 const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-return api.getTransactions(address).then(transaction => {
+const options = {
+  maxLedgerVersion: 46220792,
+  minLedgerVersion: 42885331
+};
+return api.getTransactions(address, options).then(transaction => {
   /* ... */
 });
 ```
@@ -1683,188 +1687,641 @@ return api.getTransactions(address).then(transaction => {
 [
   {
     "type": "payment",
-    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "sequence": 4,
-    "id": "99404A34E8170319521223A6C604AF48B9F1E3000C377E6141F9A1BF60B0B865",
+    "address": "rpbYHfU2J7skPWRvoNAm91T2Uo279dNUhX",
+    "sequence": 1,
+    "id": "81CF63F4039FCCF33105407D8F23566F91ED5A768C95E730BF759CD1B4397E75",
     "specification": {
-      "memos": [
-        {
-          "type": "client",
-          "format": "rt1.5.2"
-        }
-      ],
       "source": {
-        "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+        "address": "rpbYHfU2J7skPWRvoNAm91T2Uo279dNUhX",
         "maxAmount": {
           "currency": "XRP",
-          "value": "1.112209"
+          "value": "0.858"
         }
       },
       "destination": {
-        "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-      },
-      "paths": "[[{\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"}]]"
+        "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
+      }
     },
     "outcome": {
       "result": "tesSUCCESS",
+      "timestamp": "2019-04-01T07:39:01.000Z",
       "fee": "0.00001",
-      "deliveredAmount": {
-        "currency": "USD",
-        "value": "0.001",
-        "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-      },
       "balanceChanges": {
-        "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo": [
+        "rpbYHfU2J7skPWRvoNAm91T2Uo279dNUhX": [
           {
-            "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
-            "currency": "USD",
-            "value": "-0.001"
-          },
-          {
-            "counterparty": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
-            "currency": "USD",
-            "value": "0.001002"
-          }
-        ],
-        "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM": [
-          {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-            "currency": "USD",
-            "value": "0.001"
+            "currency": "XRP",
+            "value": "-0.85801"
           }
         ],
         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
           {
             "currency": "XRP",
-            "value": "-1.101208"
-          }
-        ],
-        "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr": [
-          {
-            "currency": "XRP",
-            "value": "1.101198"
-          },
-          {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-            "currency": "USD",
-            "value": "-0.001002"
+            "value": "0.858"
           }
         ]
       },
-      "orderbookChanges": {
-        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
-          {
-            "direction": "buy",
-            "quantity": {
-              "currency": "XRP",
-              "value": "1.101198"
-            },
-            "totalPrice": {
-              "currency": "USD",
-              "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-              "value": "0.001002"
-            },
-            "makerExchangeRate": "1099",
-            "sequence": 58,
-            "status": "partially-filled"
-          }
-        ]
-      },
-      "ledgerVersion": 348859,
-      "indexInLedger": 0
+      "orderbookChanges": {},
+      "ledgerVersion": 46220792,
+      "indexInLedger": 18,
+      "deliveredAmount": {
+        "currency": "XRP",
+        "value": "0.858"
+      }
     }
   },
   {
     "type": "payment",
-    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "id": "99404A34E8170319521223A6C604AF48B9F1E3000C377E6141F9A1BF60B0B865",
-    "sequence": 4,
+    "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+    "sequence": 1578764,
+    "id": "8C55AFC2A2AA42B5CE624AEECDB3ACFDD1E5379D4E5BF74A8460C5E97EF8706B",
     "specification": {
-      "memos": [
-        {
-          "type": "client",
-          "format": "rt1.5.2"
-        }
-      ],
       "source": {
-        "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+        "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
         "maxAmount": {
           "currency": "XRP",
-          "value": "1.112209"
+          "value": "4199.9958"
         }
       },
       "destination": {
-        "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
+        "address": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
       },
-      "paths": "[[{\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"}]]"
+      "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"DOG\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"JPY\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"ETH\",\"issuer\":\"rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"EUR\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}]]",
+      "allowPartialPayment": true,
+      "noDirectRipple": true,
+      "limitQuality": true
     },
     "outcome": {
       "result": "tesSUCCESS",
-      "fee": "0.00001",
-      "deliveredAmount": {
-        "currency": "USD",
-        "value": "0.001",
-        "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-      },
+      "timestamp": "2018-11-26T01:16:41.000Z",
+      "fee": "0.000011",
       "balanceChanges": {
-        "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo": [
+        "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P": [
           {
-            "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "currency": "USD",
-            "value": "-0.001"
+            "value": "1"
           },
           {
-            "counterparty": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
             "currency": "USD",
-            "value": "0.001002"
+            "value": "-1"
           }
         ],
-        "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM": [
+        "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun": [
           {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
             "currency": "USD",
-            "value": "0.001"
+            "value": "-1"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "rd5Sx93pCMgfxwBuofjen2csoFYmY8VrT": [
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "0.99800399201"
+          },
+          {
+            "currency": "XRP",
+            "value": "-2.788706"
+          }
+        ],
+        "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq": [
+          {
+            "counterparty": "rd5Sx93pCMgfxwBuofjen2csoFYmY8VrT",
+            "currency": "USD",
+            "value": "-0.99800399201"
+          },
+          {
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "currency": "XRP",
+            "value": "0.055098"
+          },
+          {
+            "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+            "currency": "GCB",
+            "value": "-2.788706"
+          }
+        ],
+        "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq",
+            "currency": "USD",
+            "value": "1.002"
           }
         ],
         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
           {
-            "currency": "XRP",
-            "value": "-1.101208"
-          }
-        ],
-        "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr": [
-          {
-            "currency": "XRP",
-            "value": "1.101198"
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "1"
           },
           {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "currency": "USD",
-            "value": "-0.001002"
+            "value": "-1"
+          }
+        ],
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
+          {
+            "currency": "XRP",
+            "value": "2.733597"
+          },
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "-1.002"
+          }
+        ],
+        "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8": [
+          {
+            "counterparty": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+            "currency": "GCB",
+            "value": "2.788706"
           }
         ]
       },
       "orderbookChanges": {
-        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
           {
             "direction": "buy",
             "quantity": {
               "currency": "XRP",
-              "value": "1.101198"
+              "value": "2.733597"
             },
             "totalPrice": {
               "currency": "USD",
-              "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-              "value": "0.001002"
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "1.002"
             },
-            "makerExchangeRate": "1099",
-            "sequence": 58,
-            "status": "partially-filled"
+            "sequence": 407556,
+            "status": "partially-filled",
+            "makerExchangeRate": "2.728140772063838"
+          }
+        ],
+        "r9ZoLsJHzMMJLpvsViWQ4Jgx17N8cz1997": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "ETH",
+              "counterparty": "rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h",
+              "value": "0.05"
+            },
+            "totalPrice": {
+              "currency": "EUR",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "2.5"
+            },
+            "sequence": 7,
+            "status": "cancelled",
+            "makerExchangeRate": "0.02"
+          }
+        ],
+        "rd5Sx93pCMgfxwBuofjen2csoFYmY8VrT": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "0.998003992015"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "2.788706"
+            },
+            "sequence": 273,
+            "status": "partially-filled",
+            "makerExchangeRate": "0.3578735582618422"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "2.788706"
+            },
+            "totalPrice": {
+              "currency": "GCB",
+              "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+              "value": "2.788706"
+            },
+            "sequence": 39018,
+            "status": "partially-filled",
+            "makerExchangeRate": "1"
           }
         ]
       },
-      "ledgerVersion": 348858,
-      "indexInLedger": 0
+      "ledgerVersion": 43251698,
+      "indexInLedger": 38,
+      "deliveredAmount": {
+        "currency": "GCB",
+        "value": "2.788706",
+        "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      }
+    }
+  },
+  {
+    "type": "payment",
+    "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+    "sequence": 1573492,
+    "id": "28B271F7C27C1A267F32FFCD8B1795C5D3B1DC761AD705E3A480139AA8B61B09",
+    "specification": {
+      "source": {
+        "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+        "maxAmount": {
+          "currency": "XRP",
+          "value": "4199.9958"
+        }
+      },
+      "destination": {
+        "address": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      },
+      "paths": "[[{\"currency\":\"ETH\",\"issuer\":\"rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"BTC\",\"issuer\":\"rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"USD\",\"issuer\":\"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"CNY\",\"issuer\":\"rKowFMuGTmUXukGjos5FkWBpj5DMPC1xUr\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"STR\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rPT74sUcTBTQhkHVD54WGncoqXEAMYbmH7\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}]]",
+      "allowPartialPayment": true,
+      "noDirectRipple": true,
+      "limitQuality": true
+    },
+    "outcome": {
+      "result": "tesSUCCESS",
+      "timestamp": "2018-11-25T10:17:41.000Z",
+      "fee": "0.000011",
+      "balanceChanges": {
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "currency": "XRP",
+            "value": "0.006648"
+          },
+          {
+            "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+            "currency": "GCB",
+            "value": "-3.106659"
+          }
+        ],
+        "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+          {
+            "counterparty": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+            "currency": "USD",
+            "value": "-0.998003992015968"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe": [
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "0.998003992015968"
+          },
+          {
+            "currency": "XRP",
+            "value": "-3.106659"
+          }
+        ],
+        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "rhK6GEkRZMvBZbFrXJ5fNmqjmsaxyjWiUH": [
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "currency": "XRP",
+            "value": "3.1"
+          }
+        ],
+        "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun": [
+          {
+            "counterparty": "rhK6GEkRZMvBZbFrXJ5fNmqjmsaxyjWiUH",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "-1"
+          }
+        ],
+        "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8": [
+          {
+            "counterparty": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+            "currency": "GCB",
+            "value": "3.106659"
+          }
+        ]
+      },
+      "orderbookChanges": {
+        "rhK6GEkRZMvBZbFrXJ5fNmqjmsaxyjWiUH": [
+          {
+            "direction": "sell",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+              "value": "1"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "3.1"
+            },
+            "sequence": 10091,
+            "status": "partially-filled",
+            "makerExchangeRate": "3.099999988108245"
+          }
+        ],
+        "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe": [
+          {
+            "direction": "sell",
+            "quantity": {
+              "currency": "XRP",
+              "value": "3.106659"
+            },
+            "totalPrice": {
+              "currency": "USD",
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "0.9980039920159"
+            },
+            "sequence": 22788962,
+            "status": "partially-filled",
+            "makerExchangeRate": "0.3212467875",
+            "expirationTime": "2018-11-25T11:17:33.000Z"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "3.106659"
+            },
+            "totalPrice": {
+              "currency": "GCB",
+              "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+              "value": "3.106659"
+            },
+            "sequence": 39018,
+            "status": "partially-filled",
+            "makerExchangeRate": "1"
+          }
+        ]
+      },
+      "ledgerVersion": 43237130,
+      "indexInLedger": 25,
+      "deliveredAmount": {
+        "currency": "GCB",
+        "value": "3.106659",
+        "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      }
+    }
+  },
+  {
+    "type": "payment",
+    "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+    "sequence": 1432221,
+    "id": "3EA0582856E43772DD1C7C2BFC1E8F9AF2D13614D206C383EAE479414E160232",
+    "specification": {
+      "source": {
+        "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+        "maxAmount": {
+          "currency": "XRP",
+          "value": "4199.9958"
+        }
+      },
+      "destination": {
+        "address": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      },
+      "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"ETH\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rDaRsjRvV9ZP6FXBcht81zYVp8AXAr33Hv\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"USD\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"RJP\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"LTC\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"JPY\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"BTC\",\"issuer\":\"rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}]]",
+      "allowPartialPayment": true,
+      "noDirectRipple": true,
+      "limitQuality": true
+    },
+    "outcome": {
+      "result": "tesSUCCESS",
+      "timestamp": "2018-11-10T19:23:11.000Z",
+      "fee": "0.000011",
+      "balanceChanges": {
+        "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P": [
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "-1"
+          }
+        ],
+        "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun": [
+          {
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "currency": "XRP",
+            "value": "0.020385"
+          },
+          {
+            "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+            "currency": "GCB",
+            "value": "-2.020037"
+          }
+        ],
+        "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq",
+            "currency": "USD",
+            "value": "1.001999999999"
+          }
+        ],
+        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "-1"
+          }
+        ],
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
+          {
+            "currency": "XRP",
+            "value": "1.999641"
+          },
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "-1.001999999999"
+          }
+        ],
+        "rGu3s6nDXqKNJTmcPZhd7nwqksbRJfghZ9": [
+          {
+            "currency": "XRP",
+            "value": "-0.671746"
+          },
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "0.3319097620159"
+          }
+        ],
+        "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8": [
+          {
+            "counterparty": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+            "currency": "GCB",
+            "value": "2.020037"
+          }
+        ],
+        "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq": [
+          {
+            "counterparty": "rGu3s6nDXqKNJTmcPZhd7nwqksbRJfghZ9",
+            "currency": "USD",
+            "value": "-0.3319097620159"
+          },
+          {
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "rnNze4PCD5meYw9u1fv44Tw9jkdWS6MneW",
+            "currency": "USD",
+            "value": "-0.66609423"
+          }
+        ],
+        "rnNze4PCD5meYw9u1fv44Tw9jkdWS6MneW": [
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "0.66609423"
+          },
+          {
+            "currency": "XRP",
+            "value": "-1.348291"
+          }
+        ]
+      },
+      "orderbookChanges": {
+        "rGu3s6nDXqKNJTmcPZhd7nwqksbRJfghZ9": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "0.331909762015968"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "0.671746"
+            },
+            "sequence": 43008,
+            "status": "partially-filled",
+            "makerExchangeRate": "0.4941001663625631"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "2.020037"
+            },
+            "totalPrice": {
+              "currency": "GCB",
+              "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+              "value": "2.020037"
+            },
+            "sequence": 39018,
+            "status": "partially-filled",
+            "makerExchangeRate": "1"
+          }
+        ],
+        "rnNze4PCD5meYw9u1fv44Tw9jkdWS6MneW": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "0.66609423"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "1.348291"
+            },
+            "sequence": 84709,
+            "status": "filled",
+            "makerExchangeRate": "0.4940285368662996"
+          }
+        ],
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "1.999641"
+            },
+            "totalPrice": {
+              "currency": "USD",
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "1.0019999999999"
+            },
+            "sequence": 369690,
+            "status": "partially-filled",
+            "makerExchangeRate": "1.995649484124608"
+          }
+        ]
+      },
+      "ledgerVersion": 42885331,
+      "indexInLedger": 0,
+      "deliveredAmount": {
+        "currency": "GCB",
+        "value": "2.020037",
+        "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      }
     }
   }
 ]

--- a/docs/src/getTransactions.md.ejs
+++ b/docs/src/getTransactions.md.ejs
@@ -16,7 +16,11 @@ This method returns a promise that resolves with an array of transaction object 
 
 ```javascript
 const address = 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59';
-return api.getTransactions(address).then(transaction => {
+const options = {
+  maxLedgerVersion: 46220792,
+  minLedgerVersion: 42885331
+};
+return api.getTransactions(address, options).then(transaction => {
   /* ... */
 });
 ```

--- a/test/fixtures/responses/get-transactions.json
+++ b/test/fixtures/responses/get-transactions.json
@@ -1,188 +1,641 @@
 [
   {
     "type": "payment",
-    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "sequence": 4,
-    "id": "99404A34E8170319521223A6C604AF48B9F1E3000C377E6141F9A1BF60B0B865",
+    "address": "rpbYHfU2J7skPWRvoNAm91T2Uo279dNUhX",
+    "sequence": 1,
+    "id": "81CF63F4039FCCF33105407D8F23566F91ED5A768C95E730BF759CD1B4397E75",
     "specification": {
-      "memos": [
-        {
-          "type": "client",
-          "format": "rt1.5.2"
-        }
-      ],
       "source": {
-        "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+        "address": "rpbYHfU2J7skPWRvoNAm91T2Uo279dNUhX",
         "maxAmount": {
           "currency": "XRP",
-          "value": "1.112209"
+          "value": "0.858"
         }
       },
       "destination": {
-        "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-      },
-      "paths": "[[{\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"}]]"
+        "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
+      }
     },
     "outcome": {
       "result": "tesSUCCESS",
+      "timestamp": "2019-04-01T07:39:01.000Z",
       "fee": "0.00001",
-      "deliveredAmount": {
-        "currency": "USD",
-        "value": "0.001",
-        "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-      },
       "balanceChanges": {
-        "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo": [
+        "rpbYHfU2J7skPWRvoNAm91T2Uo279dNUhX": [
           {
-            "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
-            "currency": "USD",
-            "value": "-0.001"
-          },
-          {
-            "counterparty": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
-            "currency": "USD",
-            "value": "0.001002"
-          }
-        ],
-        "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM": [
-          {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-            "currency": "USD",
-            "value": "0.001"
+            "currency": "XRP",
+            "value": "-0.85801"
           }
         ],
         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
           {
             "currency": "XRP",
-            "value": "-1.101208"
-          }
-        ],
-        "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr": [
-          {
-            "currency": "XRP",
-            "value": "1.101198"
-          },
-          {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-            "currency": "USD",
-            "value": "-0.001002"
+            "value": "0.858"
           }
         ]
       },
-      "orderbookChanges": {
-        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
-          {
-            "direction": "buy",
-            "quantity": {
-              "currency": "XRP",
-              "value": "1.101198"
-            },
-            "totalPrice": {
-              "currency": "USD",
-              "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-              "value": "0.001002"
-            },
-            "makerExchangeRate": "1099",
-            "sequence": 58,
-            "status": "partially-filled"
-          }
-        ]
-      },
-      "ledgerVersion": 348859,
-      "indexInLedger": 0
+      "orderbookChanges": {},
+      "ledgerVersion": 46220792,
+      "indexInLedger": 18,
+      "deliveredAmount": {
+        "currency": "XRP",
+        "value": "0.858"
+      }
     }
   },
   {
     "type": "payment",
-    "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-    "id": "99404A34E8170319521223A6C604AF48B9F1E3000C377E6141F9A1BF60B0B865",
-    "sequence": 4,
+    "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+    "sequence": 1578764,
+    "id": "8C55AFC2A2AA42B5CE624AEECDB3ACFDD1E5379D4E5BF74A8460C5E97EF8706B",
     "specification": {
-      "memos": [
-        {
-          "type": "client",
-          "format": "rt1.5.2"
-        }
-      ],
       "source": {
-        "address": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+        "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
         "maxAmount": {
           "currency": "XRP",
-          "value": "1.112209"
+          "value": "4199.9958"
         }
       },
       "destination": {
-        "address": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
+        "address": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
       },
-      "paths": "[[{\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"},{\"account\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"issuer\":\"rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo\",\"currency\":\"USD\"}]]"
+      "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"DOG\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"JPY\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"ETH\",\"issuer\":\"rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"EUR\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}]]",
+      "allowPartialPayment": true,
+      "noDirectRipple": true,
+      "limitQuality": true
     },
     "outcome": {
       "result": "tesSUCCESS",
-      "fee": "0.00001",
-      "deliveredAmount": {
-        "currency": "USD",
-        "value": "0.001",
-        "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM"
-      },
+      "timestamp": "2018-11-26T01:16:41.000Z",
+      "fee": "0.000011",
       "balanceChanges": {
-        "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo": [
+        "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P": [
           {
-            "counterparty": "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM",
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "currency": "USD",
-            "value": "-0.001"
+            "value": "1"
           },
           {
-            "counterparty": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
             "currency": "USD",
-            "value": "0.001002"
+            "value": "-1"
           }
         ],
-        "rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM": [
+        "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun": [
           {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
             "currency": "USD",
-            "value": "0.001"
+            "value": "-1"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "rd5Sx93pCMgfxwBuofjen2csoFYmY8VrT": [
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "0.99800399201"
+          },
+          {
+            "currency": "XRP",
+            "value": "-2.788706"
+          }
+        ],
+        "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq": [
+          {
+            "counterparty": "rd5Sx93pCMgfxwBuofjen2csoFYmY8VrT",
+            "currency": "USD",
+            "value": "-0.99800399201"
+          },
+          {
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "currency": "XRP",
+            "value": "0.055098"
+          },
+          {
+            "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+            "currency": "GCB",
+            "value": "-2.788706"
+          }
+        ],
+        "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq",
+            "currency": "USD",
+            "value": "1.002"
           }
         ],
         "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
           {
-            "currency": "XRP",
-            "value": "-1.101208"
-          }
-        ],
-        "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr": [
-          {
-            "currency": "XRP",
-            "value": "1.101198"
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "1"
           },
           {
-            "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "currency": "USD",
-            "value": "-0.001002"
+            "value": "-1"
+          }
+        ],
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
+          {
+            "currency": "XRP",
+            "value": "2.733597"
+          },
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "-1.002"
+          }
+        ],
+        "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8": [
+          {
+            "counterparty": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+            "currency": "GCB",
+            "value": "2.788706"
           }
         ]
       },
       "orderbookChanges": {
-        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
           {
             "direction": "buy",
             "quantity": {
               "currency": "XRP",
-              "value": "1.101198"
+              "value": "2.733597"
             },
             "totalPrice": {
               "currency": "USD",
-              "counterparty": "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-              "value": "0.001002"
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "1.002"
             },
-            "makerExchangeRate": "1099",
-            "sequence": 58,
-            "status": "partially-filled"
+            "sequence": 407556,
+            "status": "partially-filled",
+            "makerExchangeRate": "2.728140772063838"
+          }
+        ],
+        "r9ZoLsJHzMMJLpvsViWQ4Jgx17N8cz1997": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "ETH",
+              "counterparty": "rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h",
+              "value": "0.05"
+            },
+            "totalPrice": {
+              "currency": "EUR",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "2.5"
+            },
+            "sequence": 7,
+            "status": "cancelled",
+            "makerExchangeRate": "0.02"
+          }
+        ],
+        "rd5Sx93pCMgfxwBuofjen2csoFYmY8VrT": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "0.998003992015"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "2.788706"
+            },
+            "sequence": 273,
+            "status": "partially-filled",
+            "makerExchangeRate": "0.3578735582618422"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "2.788706"
+            },
+            "totalPrice": {
+              "currency": "GCB",
+              "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+              "value": "2.788706"
+            },
+            "sequence": 39018,
+            "status": "partially-filled",
+            "makerExchangeRate": "1"
           }
         ]
       },
-      "ledgerVersion": 348858,
-      "indexInLedger": 0
+      "ledgerVersion": 43251698,
+      "indexInLedger": 38,
+      "deliveredAmount": {
+        "currency": "GCB",
+        "value": "2.788706",
+        "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      }
+    }
+  },
+  {
+    "type": "payment",
+    "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+    "sequence": 1573492,
+    "id": "28B271F7C27C1A267F32FFCD8B1795C5D3B1DC761AD705E3A480139AA8B61B09",
+    "specification": {
+      "source": {
+        "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+        "maxAmount": {
+          "currency": "XRP",
+          "value": "4199.9958"
+        }
+      },
+      "destination": {
+        "address": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      },
+      "paths": "[[{\"currency\":\"ETH\",\"issuer\":\"rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"BTC\",\"issuer\":\"rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"USD\",\"issuer\":\"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"CNY\",\"issuer\":\"rKowFMuGTmUXukGjos5FkWBpj5DMPC1xUr\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"STR\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rPT74sUcTBTQhkHVD54WGncoqXEAMYbmH7\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}]]",
+      "allowPartialPayment": true,
+      "noDirectRipple": true,
+      "limitQuality": true
+    },
+    "outcome": {
+      "result": "tesSUCCESS",
+      "timestamp": "2018-11-25T10:17:41.000Z",
+      "fee": "0.000011",
+      "balanceChanges": {
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "currency": "XRP",
+            "value": "0.006648"
+          },
+          {
+            "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+            "currency": "GCB",
+            "value": "-3.106659"
+          }
+        ],
+        "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+          {
+            "counterparty": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+            "currency": "USD",
+            "value": "-0.998003992015968"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe": [
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "0.998003992015968"
+          },
+          {
+            "currency": "XRP",
+            "value": "-3.106659"
+          }
+        ],
+        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "rhK6GEkRZMvBZbFrXJ5fNmqjmsaxyjWiUH": [
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "currency": "XRP",
+            "value": "3.1"
+          }
+        ],
+        "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun": [
+          {
+            "counterparty": "rhK6GEkRZMvBZbFrXJ5fNmqjmsaxyjWiUH",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "-1"
+          }
+        ],
+        "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8": [
+          {
+            "counterparty": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+            "currency": "GCB",
+            "value": "3.106659"
+          }
+        ]
+      },
+      "orderbookChanges": {
+        "rhK6GEkRZMvBZbFrXJ5fNmqjmsaxyjWiUH": [
+          {
+            "direction": "sell",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+              "value": "1"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "3.1"
+            },
+            "sequence": 10091,
+            "status": "partially-filled",
+            "makerExchangeRate": "3.099999988108245"
+          }
+        ],
+        "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe": [
+          {
+            "direction": "sell",
+            "quantity": {
+              "currency": "XRP",
+              "value": "3.106659"
+            },
+            "totalPrice": {
+              "currency": "USD",
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "0.9980039920159"
+            },
+            "sequence": 22788962,
+            "status": "partially-filled",
+            "makerExchangeRate": "0.3212467875",
+            "expirationTime": "2018-11-25T11:17:33.000Z"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "3.106659"
+            },
+            "totalPrice": {
+              "currency": "GCB",
+              "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+              "value": "3.106659"
+            },
+            "sequence": 39018,
+            "status": "partially-filled",
+            "makerExchangeRate": "1"
+          }
+        ]
+      },
+      "ledgerVersion": 43237130,
+      "indexInLedger": 25,
+      "deliveredAmount": {
+        "currency": "GCB",
+        "value": "3.106659",
+        "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      }
+    }
+  },
+  {
+    "type": "payment",
+    "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+    "sequence": 1432221,
+    "id": "3EA0582856E43772DD1C7C2BFC1E8F9AF2D13614D206C383EAE479414E160232",
+    "specification": {
+      "source": {
+        "address": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+        "maxAmount": {
+          "currency": "XRP",
+          "value": "4199.9958"
+        }
+      },
+      "destination": {
+        "address": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      },
+      "paths": "[[{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"ETH\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rDaRsjRvV9ZP6FXBcht81zYVp8AXAr33Hv\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"account\":\"rcA8X3TVMST1n3CJeAdGk1RdRCHii7N2h\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"USD\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"RJP\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"LTC\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"JPY\",\"issuer\":\"rB3gZey7VWHYRqJHLoHDEJXJ2pEPNieKiS\",\"type\":48,\"type_hex\":\"0000000000000030\"}],[{\"currency\":\"XLM\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}],[{\"currency\":\"BTC\",\"issuer\":\"rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"USD\",\"issuer\":\"rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"}]]",
+      "allowPartialPayment": true,
+      "noDirectRipple": true,
+      "limitQuality": true
+    },
+    "outcome": {
+      "result": "tesSUCCESS",
+      "timestamp": "2018-11-10T19:23:11.000Z",
+      "fee": "0.000011",
+      "balanceChanges": {
+        "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P": [
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "-1"
+          }
+        ],
+        "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun": [
+          {
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "1"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "currency": "XRP",
+            "value": "0.020385"
+          },
+          {
+            "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+            "currency": "GCB",
+            "value": "-2.020037"
+          }
+        ],
+        "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B": [
+          {
+            "counterparty": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+            "currency": "USD",
+            "value": "-1"
+          },
+          {
+            "counterparty": "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq",
+            "currency": "USD",
+            "value": "1.001999999999"
+          }
+        ],
+        "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59": [
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+            "currency": "USD",
+            "value": "-1"
+          }
+        ],
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
+          {
+            "currency": "XRP",
+            "value": "1.999641"
+          },
+          {
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "currency": "USD",
+            "value": "-1.001999999999"
+          }
+        ],
+        "rGu3s6nDXqKNJTmcPZhd7nwqksbRJfghZ9": [
+          {
+            "currency": "XRP",
+            "value": "-0.671746"
+          },
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "0.3319097620159"
+          }
+        ],
+        "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8": [
+          {
+            "counterparty": "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok",
+            "currency": "GCB",
+            "value": "2.020037"
+          }
+        ],
+        "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq": [
+          {
+            "counterparty": "rGu3s6nDXqKNJTmcPZhd7nwqksbRJfghZ9",
+            "currency": "USD",
+            "value": "-0.3319097620159"
+          },
+          {
+            "counterparty": "rpvvAvaZ7TXHkNLM8UJwCTU6yBU2jDTJ1P",
+            "currency": "USD",
+            "value": "1"
+          },
+          {
+            "counterparty": "rnNze4PCD5meYw9u1fv44Tw9jkdWS6MneW",
+            "currency": "USD",
+            "value": "-0.66609423"
+          }
+        ],
+        "rnNze4PCD5meYw9u1fv44Tw9jkdWS6MneW": [
+          {
+            "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currency": "USD",
+            "value": "0.66609423"
+          },
+          {
+            "currency": "XRP",
+            "value": "-1.348291"
+          }
+        ]
+      },
+      "orderbookChanges": {
+        "rGu3s6nDXqKNJTmcPZhd7nwqksbRJfghZ9": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "0.331909762015968"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "0.671746"
+            },
+            "sequence": 43008,
+            "status": "partially-filled",
+            "makerExchangeRate": "0.4941001663625631"
+          }
+        ],
+        "r9KG7Du7aFmABzMvDnwuvPaEoMu4Eurwok": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "2.020037"
+            },
+            "totalPrice": {
+              "currency": "GCB",
+              "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8",
+              "value": "2.020037"
+            },
+            "sequence": 39018,
+            "status": "partially-filled",
+            "makerExchangeRate": "1"
+          }
+        ],
+        "rnNze4PCD5meYw9u1fv44Tw9jkdWS6MneW": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "USD",
+              "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value": "0.66609423"
+            },
+            "totalPrice": {
+              "currency": "XRP",
+              "value": "1.348291"
+            },
+            "sequence": 84709,
+            "status": "filled",
+            "makerExchangeRate": "0.4940285368662996"
+          }
+        ],
+        "rBndiPPKs9k5rjBb7HsEiqXKrz8AfUnqWq": [
+          {
+            "direction": "buy",
+            "quantity": {
+              "currency": "XRP",
+              "value": "1.999641"
+            },
+            "totalPrice": {
+              "currency": "USD",
+              "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "value": "1.0019999999999"
+            },
+            "sequence": 369690,
+            "status": "partially-filled",
+            "makerExchangeRate": "1.995649484124608"
+          }
+        ]
+      },
+      "ledgerVersion": 42885331,
+      "indexInLedger": 0,
+      "deliveredAmount": {
+        "currency": "GCB",
+        "value": "2.020037",
+        "counterparty": "rHaans8PtgwbacHvXAL3u6TG28gTAtCwr8"
+      }
     }
   }
 ]


### PR DESCRIPTION
I don't know why the prior example response didn't include `outcome.timestamp`; perhaps it was created using a much older version of ripple-lib, or the transactions were not yet validated at the time.