### PR TITLE
Cleanup the connection trace logic

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -82,7 +82,6 @@ export interface APIOptions extends ConnectionOptions {
   server?: string,
   feeCushion?: number,
   maxFeeXRP?: string,
-  trace?: boolean,
   proxy?: string,
   timeout?: number
 }

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -8,7 +8,7 @@ import {RippledError, DisconnectedError, NotConnectedError,
   RippledNotInitializedError} from './errors'
 
 export interface ConnectionOptions {
-  trace?: boolean | ((id: string, msg: string) => void)
+  trace?: boolean | ((id: string, message: string) => void)
   proxy?: string
   proxyAuthorization?: string
   authorization?: string
@@ -46,7 +46,7 @@ class Connection extends EventEmitter {
   private _fee_ref: null|number = null
   private _connectionTimeout: number
 
-  private _trace: (id: string, msg: string) => void = () => {}
+  private _trace: (id: string, message: string) => void = () => {}
 
   constructor(url, options: ConnectionOptions = {}) {
     super()

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -47,7 +47,7 @@ describe('Connection', function() {
 
     it('as false', function() {
       const messages = [];
-      console.log = (id, msg) => messages.push([id, msg]);
+      console.log = (id, message) => messages.push([id, message]);
       const connection: any = new utils.common.Connection('url', {trace: false});
       connection._ws = {send: function() {}};
       connection._send(message1);
@@ -57,7 +57,7 @@ describe('Connection', function() {
 
     it('as true', function() {
       const messages = [];
-      console.log = (id, msg) => messages.push([id, msg]);
+      console.log = (id, message) => messages.push([id, message]);
       const connection: any = new utils.common.Connection('url', {trace: true});
       connection._ws = {send: function() {}};
       connection._send(message1);
@@ -68,7 +68,7 @@ describe('Connection', function() {
     it('as a function', function() {
       const messages = [];
       const connection: any = new utils.common.Connection('url', {
-        trace: (id, msg) => messages.push([id, msg])
+        trace: (id, message) => messages.push([id, message])
       });
       connection._ws = {send: function() {}};
       connection._send(message1);


### PR DESCRIPTION
Changes trace from a `boolean` to a `boolean | function`, where the user can provide a function for logging the request/response (vs. having to monkey-patch the _console message in our tests).

The public API docs only mention the current boolean behavior, do we want to also mention that a function works as an option? It's fairly advanced usage, but could still be good to mention.