### PR TITLE
Cleanup the connection config state

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -75,10 +75,10 @@ import * as schemaValidator from './common/schema-validator'
 import {getServerInfo, getFee} from './common/serverinfo'
 import {clamp, renameCounterpartyToIssuer} from './ledger/utils'
 import {TransactionJSON, Instructions, Prepare} from './transaction/types'
-import {ConnectionOptions} from './common/connection'
+import {ConnectionUserOptions} from './common/connection'
 import {isValidXAddress, isValidClassicAddress} from 'ripple-address-codec'
 
-export interface APIOptions extends ConnectionOptions {
+export interface APIOptions extends ConnectionUserOptions {
   server?: string,
   feeCushion?: number,
   maxFeeXRP?: string,

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -31,8 +31,8 @@ describe('Connection', function() {
   it('default options', function() {
     const connection: any = new utils.common.Connection('url');
     assert.strictEqual(connection._url, 'url');
-    assert(_.isUndefined(connection._proxyURL));
-    assert(_.isUndefined(connection._authorization));
+    assert(_.isUndefined(connection._config.proxy));
+    assert(_.isUndefined(connection._config.authorization));
   });
 
   describe('trace', () => {
@@ -299,7 +299,7 @@ describe('Connection', function() {
       }
     }
     // Set the heartbeat to less than the 1 second ping response
-    this.api.connection._timeout = 500;
+    this.api.connection._config.timeout = 500;
     // Drop the test runner timeout, since this should be a quick test
     this.timeout(5000);
     // Hook up a listener for the reconnect event


### PR DESCRIPTION
This moves all of the configuration state into a single `_config` property. The _config object is created from the user-provided config after the constructor cleans it (basically just sets some defaults).

This is nice because it gets all the user-provided configuration into a single property, which should scale nicely / not pollute the global `Connection` object with config values. However the is probably the most subjective of everything suggested in #1110, so if you prefer it as-is let me know.