### PR TITLE
Fix incorrect eslint matching glob

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "no-useless-constructor": 0,
     "no-unused-vars": 0,
     "no-prototype-builtins": 0,
-    "require-atomic-updates": 0
+    "require-atomic-updates": 0,
+    "no-dupe-class-members": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test": "TS_NODE_PROJECT=src/tsconfig.json nyc mocha --exit",
     "test:watch": "TS_NODE_PROJECT=src/tsconfig.json mocha --watch --reporter dot",
     "format": "prettier --write '{src,test}/**/*.ts'",
-    "lint": "eslint src/**/*.ts 'test/*-test.{ts,js}'",
+    "lint": "eslint 'src/**/*.ts' 'test/*-test.{ts,js}'",
     "perf": "./scripts/perf_test.sh",
     "start": "node scripts/http.js"
   },

--- a/src/common/hashes/shamap.ts
+++ b/src/common/hashes/shamap.ts
@@ -142,15 +142,18 @@ export class Leaf extends Node {
 
   public get hash(): string | void {
     switch (this.type) {
-      case NodeType.ACCOUNT_STATE:
+      case NodeType.ACCOUNT_STATE: {
         const leafPrefix = hashPrefix.LEAF_NODE.toString(16)
         return sha512Half(leafPrefix + this.data + this.tag)
-      case NodeType.TRANSACTION_NO_METADATA:
+      }
+      case NodeType.TRANSACTION_NO_METADATA: {
         const txIDPrefix = hashPrefix.TRANSACTION_ID.toString(16)
         return sha512Half(txIDPrefix + this.data)
-      case NodeType.TRANSACTION_METADATA:
+      }
+      case NodeType.TRANSACTION_METADATA: {
         const txNodePrefix = hashPrefix.TRANSACTION_NODE.toString(16)
         return sha512Half(txNodePrefix + this.data + this.tag)
+      }
       default:
         throw new Error('Tried to hash a SHAMap node of unknown type.')
     }


### PR DESCRIPTION
Our eslint invocation was using a glob (a file system matcher using `*` wildcards, regex, etc) that wasn't stringified, which meant that the unix system converts it into a list of files before passing it to eslint. Unix's globbing is less flexible than eslint, meaning we weren't linting as many deeply nested files as we meant to. 

The PR fixes our invocation by making sure that eslint gets the unmodified string, and then fixes a two issues that were found by running our linter on some files for the first time:
- no-dupe-class-members - This should be turned off for TypeScript, since method overloading is allowed in TS (for typing purposes) and actual duplicate class methods would be caught by the TypeScript compiler.
- [no-case-declarations](https://eslint.org/docs/rules/no-case-declarations): any time you declare a variable in a switch-case, you should define a block so that it's scope isn't hoisted out of the case statement. Minor, but good to fix when you catch it.