### PR TITLE
Add LedgerHistory to Connection

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -535,12 +535,12 @@ class Connection extends EventEmitter {
   }
 
   request(request, timeout?: number): Promise<any> {
+    // Temporary: Lint error has already been refactored in PR #1141
+    // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       if (!this._shouldBeConnected) {
         reject(new NotConnectedError())
       }
-
-      await this._waitForReady()
       
       let timer = null
       const self = this

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -79,6 +79,25 @@ describe('Connection', function() {
     })
   })
 
+  it('ledger methods work as expected', async function() {
+    assert.strictEqual(await this.api.connection.getLedgerVersion(), 8819951)
+    assert.strictEqual(
+      await this.api.connection.hasLedgerVersion(8819951),
+      true
+    )
+    assert.strictEqual(
+      await this.api.connection.hasLedgerVersions(8819951, undefined),
+      true
+    )
+    // It would be nice to test a better range, but the mocked ledger only supports this single number
+    assert.strictEqual(
+      await this.api.connection.hasLedgerVersions(8819951, 8819951),
+      true
+    )
+    assert.strictEqual(await this.api.connection.getFeeBase(), 10)
+    assert.strictEqual(await this.api.connection.getFeeRef(), 10)
+  })
+
   it('with proxy', function(done) {
     if (isBrowser) {
       done()


### PR DESCRIPTION
Implements a change suggested in #1110.

- Moved ledger logic off of the Connection class and into it's own `Ledger` class.
- Updated `_whenReady(promise)` -> `_waitForReady()`. The old method appeared to not be working as expected: it was meant to run a promise after the connection was ready, but a promise would always start immediately at creation time.  Instead we just remove the promise argument, and resolve once the connection is ready. Then, the caller can wait for this to resolve before moving on to start the thing that needed to wait.
- There's a little bit of implicit behavior that I didn't get rid of: we assume that `waitForReady` will set some ledger data, so that methods like `getBaseFee()` will always return a number and never return null. It would be considered a bug if this promise was ever broken, but we could go one step further to throw an error OR add "null" as a possible return value so that the user had to handle this error case just in case. LMK your thoughts if you have any.