### PR TITLE
fix AccountObjectsResponse structure

### DIFF
--- a/src/common/types/objects/ledger_entries.ts
+++ b/src/common/types/objects/ledger_entries.ts
@@ -166,7 +166,7 @@ export interface SignerListLedgerEntry {
   LedgerEntryType: 'SignerList'
   OwnerNode: string
   SignerQuorum: number
-  SignerEntries: SignerEntry[]
+  SignerEntries: { SignerEntry: SignerEntry }[]
   SignerListID: number
   PreviousTxnID: string
   PreviousTxnLgrSeq: number

--- a/src/common/types/objects/ledger_entries.ts
+++ b/src/common/types/objects/ledger_entries.ts
@@ -166,7 +166,7 @@ export interface SignerListLedgerEntry {
   LedgerEntryType: 'SignerList'
   OwnerNode: string
   SignerQuorum: number
-  SignerEntries: { SignerEntry: SignerEntry }[]
+  SignerEntries: SignerEntry[]
   SignerListID: number
   PreviousTxnID: string
   PreviousTxnLgrSeq: number

--- a/src/common/types/objects/signers.ts
+++ b/src/common/types/objects/signers.ts
@@ -1,4 +1,6 @@
 export interface SignerEntry {
-  Account: string
-  SignerWeight: number
+  SignerEntry: {
+    Account: string
+    SignerWeight: number
+  }
 }


### PR DESCRIPTION
Does not match the structure returned by the API.

```:sample code
import {RippleAPI} from '.'

const main = async() => {
  const api = new RippleAPI({server: 'wss://s1.ripple.com'})
  await api.connect()
  const object = await api.getAccountObjects('rDbWJ9C7uExThZYAwV8m6LsZ5YSX3sa6US')
  for(const accountObject of object.account_objects){
    if(accountObject.LedgerEntryType === 'SignerList'){
      console.log(accountObject.SignerEntries[0].SignerEntry.Account)
    }
  }
}
main()
```