### PR TITLE
Fix CDNs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build/ripple-latest-min.js"
   ],
   "main": "dist/npm/",
+  "unpkg": "build/ripple-latest-min.js",
+  "jsdelivr": "build/ripple-latest-min.js",
   "types": "dist/npm/index.d.ts",
   "browser": {
     "ws": "./dist/npm/common/wswrapper.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = [
   function(env, argv) {
     const config = getDefaultConfiguration();
     config.mode = 'production';
-    config.output.filename = `ripple-latest.min.js`;
+    config.output.filename = `ripple-latest-min.js`;
     if (process.argv.includes('--analyze')) {
       config.plugins.push(new BundleAnalyzerPlugin());
     }


### PR DESCRIPTION
- Browser build should be named `ripple-latest-min.js`
- Add unpkg and jsdelivr fields