### PR TITLE
Protects Connection _onUnexpectedClose fn from possibly null _ws property

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -134,12 +134,14 @@ class Connection extends EventEmitter {
   }
 
   _onUnexpectedClose(beforeOpen, resolve, reject, code) {
-    if (this._onOpenErrorBound) {
+    if (this._onOpenErrorBound && this._ws) {
       this._ws!.removeListener('error', this._onOpenErrorBound)
-      this._onOpenErrorBound = null
     }
-    // just in case
-    this._ws!.removeAllListeners('open')
+    this._onOpenErrorBound = null
+    if (this._ws) {
+      // just in case
+      this._ws!.removeAllListeners('open')
+    }
     this._ws = null
     this._isReady = false
     if (beforeOpen) {


### PR DESCRIPTION
This PR applies to master branch as the Connection class is heavily refactored in the develop branch.

This protects Connection `_onUnexpectedClose` from the possibility of `this._ws` being null which would cause an uncaught TypeError when removing listeners on the property.