### PR TITLE
Catch possible error in reconnect() on _heartbeat(), emit reconnect error

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -371,7 +371,11 @@ export class Connection extends EventEmitter {
    * If this succeeds, we're good. If it fails, disconnect so that the consumer can reconnect, if desired.
    */
   private _heartbeat = () => {
-    return this.request({command: 'ping'}).catch(() => this.reconnect())
+    return this.request({command: 'ping'}).catch(() => { 
+        this.reconnect().catch((error) => {
+          this.emit('error', 'reconnect', error.message, error)
+        })
+    })
   }
 
   /**


### PR DESCRIPTION
This addresses a possible uncaught error on run of `this._heartbeat` and subsequently `this.reconnect()` as the reconnection promise could throw.

Emits an error event if `this.reconnect()` does throw as seen in other reconnect failures.