### PR TITLE
Assign event listener to socket close event on open before attempting post-open logic

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -521,7 +521,9 @@ export class Connection extends EventEmitter {
         this.emit('connected')
       } catch (error) {
         this._connectionManager.rejectAllAwaiting(error)
-        await this.disconnect().catch(() => {}) // Ignore this error
+        await this.disconnect().catch(() => {
+          this.emit('error', 'disconnect', error.message, error)
+        })
       }
     })
     return this._connectionManager.awaitConnection()

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -489,18 +489,6 @@ export class Connection extends EventEmitter {
       this._ws.on('error', error =>
         this.emit('error', 'websocket', error.message, error)
       )
-      // Finalize the connection and resolve all awaiting connect() requests
-      try {
-        this._retryConnectionBackoff.reset()
-        await this._subscribeToLedger()
-        this._startHeartbeatInterval()
-        this._connectionManager.resolveAllAwaiting()
-        this.emit('connected')
-      } catch (error) {
-        this._connectionManager.rejectAllAwaiting(error)
-        this.disconnect()
-        return
-      }
       // Handle a closed connection: reconnect if it was unexpected
       this._ws.once('close', code => {
         this._clearHeartbeatInterval()
@@ -524,6 +512,17 @@ export class Connection extends EventEmitter {
           }, retryTimeout)
         }
       })
+      // Finalize the connection and resolve all awaiting connect() requests
+      try {
+        this._retryConnectionBackoff.reset()
+        await this._subscribeToLedger()
+        this._startHeartbeatInterval()
+        this._connectionManager.resolveAllAwaiting()
+        this.emit('connected')
+      } catch (error) {
+        this._connectionManager.rejectAllAwaiting(error)
+        await this.disconnect().catch(() => {}) // Ignore this error
+      }
     })
     return this._connectionManager.awaitConnection()
   }

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -521,9 +521,7 @@ export class Connection extends EventEmitter {
         this.emit('connected')
       } catch (error) {
         this._connectionManager.rejectAllAwaiting(error)
-        await this.disconnect().catch(() => {
-          this.emit('error', 'disconnect', error.message, error)
-        })
+        await this.disconnect().catch(() => {}) // Ignore this error, propagate the root cause.
       }
     })
     return this._connectionManager.awaitConnection()

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -604,11 +604,7 @@ describe('Connection', function() {
       // _ws.close event listener should have cleaned up the socket when disconnect _ws.close is run on connection error
       // do not fail on connection anymore
       this.api.connection._subscribeToLedger = async () => {}
-      await new Promise((resolve, reject) => {
-        setTimeout(() => {
-          this.api.connect().then(resolve).catch(reject); // should succeed and not throw websocket not cleaned up error
-        }, 1000)
-      })
+      await this.api.connection.reconnect();
     }
   })
 

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -602,15 +602,11 @@ describe('Connection', function() {
       // _ws.close event listener should have cleaned up the socket when disconnect _ws.close is run on connection error
       // do not fail on connection anymore
       this.api.connection._subscribeToLedger = async () => {}
-      try {
-        await new Promise((resolve, reject) => {
-          setTimeout(async () => {
-            this.api.connect().then(resolve).catch(reject); // should succeed and not throw websocket not cleaned up error
-          }, 1)
-        })
-      } catch (err) {
-        throw err;
-      }
+      await new Promise((resolve, reject) => {
+        setTimeout(async () => {
+          this.api.connect().then(resolve).catch(reject); // should succeed and not throw websocket not cleaned up error
+        }, 1)
+      })
     }
   })
 

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -598,12 +598,14 @@ describe('Connection', function() {
     }
     try {
       await this.api.connect();
+      throw new Error('expected connect() to reject, but it resolved')
     } catch (err) {
+      assert(err.message === 'error on _subscribeToLedger');
       // _ws.close event listener should have cleaned up the socket when disconnect _ws.close is run on connection error
       // do not fail on connection anymore
       this.api.connection._subscribeToLedger = async () => {}
       await new Promise((resolve, reject) => {
-        setTimeout(async () => {
+        setTimeout(() => {
           this.api.connect().then(resolve).catch(reject); // should succeed and not throw websocket not cleaned up error
         }, 1000)
       })

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -605,7 +605,7 @@ describe('Connection', function() {
       await new Promise((resolve, reject) => {
         setTimeout(async () => {
           this.api.connect().then(resolve).catch(reject); // should succeed and not throw websocket not cleaned up error
-        }, 1)
+        }, 1000)
       })
     }
   })


### PR DESCRIPTION
This commit adds the Connection `_ws.close` event listener post `_ws.open` before executing any post `_ws.open` logic, i.e. `Connection._subscribeToLedger`.  This prevents a reconnection error loop that occurs if `Connection._ws` is never cleaned up by the unreachable `_ws.close` event listener. Also, this ensures that a possible disconnect() promise rejection is not unhandled if any `_ws.open` logic in `Connection.connect()` throws.