### PR TITLE
Option to include system root certificates when a trustedCertificates API option is used

### DIFF
--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -63,8 +63,8 @@ class Connection extends EventEmitter {
     this._proxyURL = options.proxy
     this._proxyAuthorization = options.proxyAuthorization
     this._authorization = options.authorization
-    this._trustedCertificates = options.trustedCertificates
-    this._includeSystemTrustedCertificates = (typeof options.includeSystemTrustedCertificates === 'undefined') ? true : options.includeSystemTrustedCertificates
+    this._trustedCertificates = (typeof options.trustedCertificates === 'undefined') ? [] : options.trustedCertificates;
+    this._includeSystemTrustedCertificates = (typeof options.includeSystemTrustedCertificates === 'undefined') ? true : options.includeSystemTrustedCertificates;
     this._key = options.key
     this._passphrase = options.passphrase
     this._certificate = options.certificate

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -257,9 +257,9 @@ class Connection extends EventEmitter {
   _createWebSocket(): WebSocket {
     const options: WebSocket.ClientOptions = {}
 
-    const trustedCertificates = this._trustedCertificates
+    let trustedCertificates = this._trustedCertificates
     if (this._includeSystemTrustedCertificates)
-      trustedCertificates.concat(rootCertificates)
+      trustedCertificates = trustedCertificates.concat(rootCertificates)
 
     if (this._proxyURL !== undefined) {
       const parsedURL = parseUrl(this._url)

--- a/src/common/schemas/input/api-options.json
+++ b/src/common/schemas/input/api-options.json
@@ -47,6 +47,10 @@
         "description": "A PEM-formatted SSL certificate to trust when connecting to a proxy."
       }
     },
+    "includeSystemTrustedCertificates": {
+      "type": "boolean",
+      "description": "If true, include system trusted certificates (default: true), in addition to the trustedCertificates provided"
+    },
     "key": {
       "type": "string",
       "description": "A string containing the private key of the client in PEM format. (Can be an array of keys)."

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -483,4 +483,34 @@ describe('Connection', function() {
       data: {disconnectIn: 10}
     }));
   });
+
+
+  it('Cannot connect because SSL certificate mismatch (CA trust empty)', function() {
+    const connection = new RippleAPI({
+      server: 'wss://s.devnet.rippletest.net:51233',
+      trustedCertificates: [],
+      includeSystemTrustedCertificates: false
+    })
+
+    return connection.connect().then(() => {
+      assert(false, 'Should throw NotConnectedError')
+    }).catch(error => {
+      assert(error instanceof this.api.errors.NotConnectedError, 'Should throw NotConnectedError');
+    });
+  });
+
+  it('Cannot connect because SSL certificate mismatch (CA trust missing trusted issuer)', function() {
+    const connection = new RippleAPI({
+      server: 'wss://s.devnet.rippletest.net:51233',
+      trustedCertificates: [],
+      includeSystemTrustedCertificates: true
+    })
+
+    return connection.connect().then(() => {
+      assert(false, 'Should throw NotConnectedError')
+    }).catch(error => {
+      assert(error instanceof this.api.errors.NotConnectedError, 'Should throw NotConnectedError');
+    });
+  });
+
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ function getDefaultConfiguration() {
   performance: { hints: false },
   stats: 'errors-only',
   externals: [{
+    'tls': 'tls',
     'lodash': '_'
   }],
   entry: './dist/npm/index.js',


### PR DESCRIPTION
Update for open issue 1191 to include system root certificates when a trustedCertificates API option is used, otherwise you have to specify the entire end-to-end trust.  Alternatively, the parameter includeSystemTrustedCertificates can be set to `false` to preserve existing functionality.