### PR TITLE
Release 1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
   - 13

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,17 @@
 
 Subscribe to [the **ripple-lib-announce** mailing list](https://groups.google.com/forum/#!forum/ripple-lib-announce) for release announcements. We recommend that ripple-lib users stay up-to-date with the latest stable release.
 
+## 1.7.0 (2020-04-28)
+
+* Export hashing functions (#1275)
+* Add failHard (fail_hard) option in `submit` method (#1029)
+* Add type for parseAccountFlags (#1258)
+* Add api.connection.getReserveBase() (#1259)
+* Travis: remove node 8 (#1257)
+* Dependencies
+  * Update ripple-address-codec, @types/ws, @types/lodash, https-proxy-agent
+  * Update devDependencies: eventemitter2, nyc, ejs, @types/node, webpack, ts-node, prettier, @typescript-eslint/eslint-plugin
+
 ## 1.6.5 (2020-03-23)
 
 * APPLICATIONS.md: Add xrplorer.com

--- a/docs/index.md
+++ b/docs/index.md
@@ -5600,6 +5600,7 @@ Submits a signed transaction. The transaction is not guaranteed to succeed; it m
 Name | Type | Description
 ---- | ---- | -----------
 signedTransaction | string | A signed transaction as returned by [sign](#sign).
+failHard | boolean | *Optional* If `true`, and the transaction fails locally, do not retry or relay the transaction to other servers. Defaults to `false`.
 
 ### Return Value
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@
   - [hasNextPage](#hasnextpage)
   - [requestNextPage](#requestnextpage)
 - [Static Methods](#static-methods)
+  - [computeBinaryTransactionHash](#computebinarytransactionhash)
   - [renameCounterpartyToIssuer](#renamecounterpartytoissuer)
   - [formatBidsAndAsks](#formatbidsandasks)
 - [API Methods](#api-methods)
@@ -981,6 +982,40 @@ return api.request(command, params).then(response => {
 
 
 # Static Methods
+
+ripple-lib features a number of static methods that you can access directly on the `RippleAPI` object. The most commonly-used one is `computeBinaryTransactionHash`, described below. For the full list, see the [XRP Ledger Hashes README](https://github.com/ripple/ripple-lib/blob/develop/src/common/hashes/README.md).
+
+## computeBinaryTransactionHash
+
+`computeBinaryTransactionHash(txBlobHex: string): string`
+
+Returns the hash (id) of a binary transaction blob.
+
+This is a static method on the `RippleAPI` class.
+
+### Parameters
+
+This method takes one parameter, a string containing a binary transaction in hex.
+
+### Return Value
+
+This method returns a string representing the transaction's id (hash).
+
+### Example
+
+```javascript
+const signed_blob = '120000228000000024000B2E5A201B0066374B61400000003B9ACA0068400000000000000C732102356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC74473045022100B3721EEB1ED6DFF29FB8B209E2DE6B54A0A6E44D52D926342F3D334BE98F08640220367A74107AD5DEAEFA3AB2984C161FC23F30B2704BB5CC984358BA262177A4568114F667B0CA50CC7709A220B0561B85E53A48461FA883142B71D8B09B4EE8DAA68FB936C23E3A974713BDAC'
+if (typeof signed_blob === 'string' && signed_blob.match(/^[A-F0-9]+$/)) {
+  const id = RippleAPI.computeBinaryTransactionHash(signed_blob)
+  console.log('Transaction hash:', id')
+}
+```
+
+```
+Transaction hash: 80C5E11E1A21A626759D6CB944B33DBAAC66BD704A289C86E330B847904F5C13
+```
+
+[RunKit Example: computeBinaryTransactionHash](https://runkit.com/intelliot/computebinarytransactionhash-example)
 
 ## renameCounterpartyToIssuer
 

--- a/docs/src/staticMethods.md.ejs
+++ b/docs/src/staticMethods.md.ejs
@@ -1,1 +1,35 @@
 # Static Methods
+
+ripple-lib features a number of static methods that you can access directly on the `RippleAPI` object. The most commonly-used one is `computeBinaryTransactionHash`, described below. For the full list, see the [XRP Ledger Hashes README](https://github.com/ripple/ripple-lib/blob/develop/src/common/hashes/README.md).
+
+## computeBinaryTransactionHash
+
+`computeBinaryTransactionHash(txBlobHex: string): string`
+
+Returns the hash (id) of a binary transaction blob.
+
+This is a static method on the `RippleAPI` class.
+
+### Parameters
+
+This method takes one parameter, a string containing a binary transaction in hex.
+
+### Return Value
+
+This method returns a string representing the transaction's id (hash).
+
+### Example
+
+```javascript
+const signed_blob = '120000228000000024000B2E5A201B0066374B61400000003B9ACA0068400000000000000C732102356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC74473045022100B3721EEB1ED6DFF29FB8B209E2DE6B54A0A6E44D52D926342F3D334BE98F08640220367A74107AD5DEAEFA3AB2984C161FC23F30B2704BB5CC984358BA262177A4568114F667B0CA50CC7709A220B0561B85E53A48461FA883142B71D8B09B4EE8DAA68FB936C23E3A974713BDAC'
+if (typeof signed_blob === 'string' && signed_blob.match(/^[A-F0-9]+$/)) {
+  const id = RippleAPI.computeBinaryTransactionHash(signed_blob)
+  console.log('Transaction hash:', id')
+}
+```
+
+```
+Transaction hash: 80C5E11E1A21A626759D6CB944B33DBAAC66BD704A289C86E330B847904F5C13
+```
+
+[RunKit Example: computeBinaryTransactionHash](https://runkit.com/intelliot/computebinarytransactionhash-example)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-lib",
-  "version": "1.6.6-beta.1",
+  "version": "1.6.6-beta.2",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-lib",
-  "version": "1.6.5",
+  "version": "1.6.6-beta.1",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [
@@ -37,7 +37,7 @@
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.1.1",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
-    "@typescript-eslint/parser": "^2.3.3",
+    "@typescript-eslint/parser": "^2.27.0",
     "assert-diff": "^3.0.0",
     "doctoc": "^1.4.0",
     "ejs": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "json-schema-to-markdown-table": "^0.4.0",
     "mocha": "^7.1.1",
     "nyc": "^15.0.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "ts-node": "^8.4.1",
     "typescript": "^3.7.5",
     "webpack": "^4.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-lib",
-  "version": "1.6.6-beta.2",
+  "version": "1.7.0",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/lodash": "^4.14.136",
     "@types/ws": "^7.2.0",
     "bignumber.js": "^9.0.0",
-    "https-proxy-agent": "^4.0.0",
+    "https-proxy-agent": "^5.0.0",
     "jsonschema": "1.2.2",
     "lodash": "^4.17.4",
     "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jsonschema": "1.2.2",
     "lodash": "^4.17.4",
     "lodash.isequal": "^4.5.0",
-    "ripple-address-codec": "^4.0.0",
+    "ripple-address-codec": "^4.1.1",
     "ripple-binary-codec": "^0.2.5",
     "ripple-keypairs": "^1.0.0",
     "ripple-lib-transactionparser": "0.8.2",

--- a/src/api.ts
+++ b/src/api.ts
@@ -89,6 +89,19 @@ import {clamp, renameCounterpartyToIssuer} from './ledger/utils'
 import {TransactionJSON, Instructions, Prepare} from './transaction/types'
 import {ConnectionUserOptions} from './common/connection'
 import {isValidXAddress, isValidClassicAddress} from 'ripple-address-codec'
+import {
+  computeBinaryTransactionHash,
+  computeTransactionHash,
+  computeBinaryTransactionSigningHash,
+  computeAccountLedgerObjectID,
+  computeSignerListLedgerObjectID,
+  computeOrderID,
+  computeTrustlineHash,
+  computeTransactionTreeHash,
+  computeStateTreeHash,
+  computeEscrowHash,
+  computePaymentChannelHash
+} from './common/hashes'
 
 export interface APIOptions extends ConnectionUserOptions {
   server?: string
@@ -401,6 +414,31 @@ class RippleAPI extends EventEmitter {
 
   static isValidXAddress = isValidXAddress
   static isValidClassicAddress = isValidClassicAddress
+
+  /**
+   * Static methods that replace functionality from the now-deprecated ripple-hashes library
+   */
+  // Compute the hash of a binary transaction blob.
+  static computeBinaryTransactionHash = computeBinaryTransactionHash // (txBlobHex: string): string
+  // Compute the hash of a transaction in txJSON format.
+  static computeTransactionHash = computeTransactionHash // (txJSON: any): string
+  static computeBinaryTransactionSigningHash = computeBinaryTransactionSigningHash // (txBlobHex: string): string
+  // Compute the hash of an account, given the account's classic address (starting with `r`).
+  static computeAccountLedgerObjectID = computeAccountLedgerObjectID // (address: string): string
+  // Compute the hash (ID) of an account's SignerList.
+  static computeSignerListLedgerObjectID = computeSignerListLedgerObjectID // (address: string): string
+  // Compute the hash of an order, given the owner's classic address (starting with `r`) and the account sequence number of the `OfferCreate` order transaction.
+  static computeOrderID = computeOrderID // (address: string, sequence: number): string
+  // Compute the hash of a trustline, given the two parties' classic addresses (starting with `r`) and the currency code.
+  static computeTrustlineHash = computeTrustlineHash // (address1: string, address2: string, currency: string): string
+  static computeTransactionTreeHash = computeTransactionTreeHash // (transactions: any[]): string
+  static computeStateTreeHash = computeStateTreeHash // (entries: any[]): string
+  // Compute the hash of a ledger.
+  static computeLedgerHash = computeLedgerHash // (ledgerHeader): string
+  // Compute the hash of an escrow, given the owner's classic address (starting with `r`) and the account sequence number of the `EscrowCreate` escrow transaction.
+  static computeEscrowHash = computeEscrowHash // (address, sequence): string
+  // Compute the hash of a payment channel, given the owner's classic address (starting with `r`), the classic address of the destination, and the account sequence number of the `PaymentChannelCreate` payment channel transaction.
+  static computePaymentChannelHash = computePaymentChannelHash // (address, dstAddress, sequence): string
 
   xrpToDrops = xrpToDrops
   dropsToXrp = dropsToXrp

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -39,6 +39,23 @@ export interface ConnectionOptions {
 export type ConnectionUserOptions = Partial<ConnectionOptions>
 
 /**
+ * Ledger Stream Message
+ * https://xrpl.org/subscribe.html#ledger-stream
+ */
+interface LedgerStreamMessage {
+  type?: 'ledgerClosed' // not present in initial `subscribe` response
+  fee_base: number
+  fee_ref: number
+  ledger_hash: string
+  ledger_index: number
+  ledger_time: number
+  reserve_base: number
+  reserve_inc: number
+  txn_count?: number // not present in initial `subscribe` response
+  validated_ledgers?: string
+}
+
+/**
  * Represents an intentionally triggered web-socket disconnect code.
  * WebSocket spec allows 4xxx codes for app/library specific codes.
  * See: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
@@ -118,10 +135,11 @@ function websocketSendAsync(ws: WebSocket, message: string) {
  * captured by the Connection class over time.
  */
 class LedgerHistory {
-  private availableVersions = new RangeSet()
-  latestVersion: null | number = null
   feeBase: null | number = null
   feeRef: null | number = null
+  latestVersion: null | number = null
+  reserveBase: null | number = null
+  private availableVersions = new RangeSet()
 
   /**
    * Returns true if the given version exists.
@@ -143,24 +161,21 @@ class LedgerHistory {
    * of whether ledger history data exists or not. If relevant ledger data
    * is found, we'll update our history (ex: from a "ledgerClosed" event).
    */
-  update(responseData: {
-    ledger_index?: string
-    validated_ledgers?: string
-    fee_base?: string
-    fee_ref?: string
-  }) {
-    this.latestVersion = Number(responseData.ledger_index)
-    if (responseData.validated_ledgers) {
+  update(ledgerMessage: LedgerStreamMessage) {
+    // type: ignored
+    this.feeBase = ledgerMessage.fee_base
+    this.feeRef = ledgerMessage.fee_ref
+    // ledger_hash: ignored
+    this.latestVersion = ledgerMessage.ledger_index
+    // ledger_time: ignored
+    this.reserveBase = ledgerMessage.reserve_base
+    // reserve_inc: ignored (may be useful for advanced use cases)
+    // txn_count: ignored
+    if (ledgerMessage.validated_ledgers) {
       this.availableVersions.reset()
-      this.availableVersions.parseAndAddRanges(responseData.validated_ledgers)
+      this.availableVersions.parseAndAddRanges(ledgerMessage.validated_ledgers)
     } else {
       this.availableVersions.addValue(this.latestVersion)
-    }
-    if (responseData.fee_base) {
-      this.feeBase = Number(responseData.fee_base)
-    }
-    if (responseData.fee_ref) {
-      this.feeRef = Number(responseData.fee_ref)
     }
   }
 }
@@ -563,11 +578,6 @@ export class Connection extends EventEmitter {
     await this.connect()
   }
 
-  async getLedgerVersion(): Promise<number> {
-    await this._waitForReady()
-    return this._ledger.latestVersion!
-  }
-
   async getFeeBase(): Promise<number> {
     await this._waitForReady()
     return this._ledger.feeBase!
@@ -576,6 +586,16 @@ export class Connection extends EventEmitter {
   async getFeeRef(): Promise<number> {
     await this._waitForReady()
     return this._ledger.feeRef!
+  }
+
+  async getLedgerVersion(): Promise<number> {
+    await this._waitForReady()
+    return this._ledger.latestVersion!
+  }
+
+  async getReserveBase(): Promise<number> {
+    await this._waitForReady()
+    return this._ledger.reserveBase!
   }
 
   /**

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -13,7 +13,7 @@ import {
   RippledNotInitializedError,
   RippleError
 } from './errors'
-import {ExponentialBackoff} from './backoff';
+import {ExponentialBackoff} from './backoff'
 
 /**
  * ConnectionOptions is the configuration for the Connection class.
@@ -387,9 +387,9 @@ export class Connection extends EventEmitter {
    */
   private _heartbeat = () => {
     return this.request({command: 'ping'}).catch(() => {
-        this.reconnect().catch((error) => {
-          this.emit('error', 'reconnect', error.message, error)
-        })
+      this.reconnect().catch(error => {
+        this.emit('error', 'reconnect', error.message, error)
+      })
     })
   }
 
@@ -550,8 +550,8 @@ export class Connection extends EventEmitter {
    * If no open websocket connection exists, resolve with no code (`undefined`).
    */
   disconnect(): Promise<number | undefined> {
-    clearTimeout(this._reconnectTimeoutID);
-    this._reconnectTimeoutID = null;
+    clearTimeout(this._reconnectTimeoutID)
+    this._reconnectTimeoutID = null
     if (this._state === WebSocket.CLOSED || !this._ws) {
       return Promise.resolve(undefined)
     }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -59,14 +59,14 @@ const AccountFlags = {
 }
 
 export interface Settings {
-  passwordSpent?: boolean,
-  requireDestinationTag?: boolean,
-  requireAuthorization?: boolean,
-  depositAuth?: boolean,
-  disallowIncomingXRP?: boolean,
-  disableMasterKey?: boolean,
-  noFreeze?: boolean,
-  globalFreeze?: boolean,
+  passwordSpent?: boolean
+  requireDestinationTag?: boolean
+  requireAuthorization?: boolean
+  depositAuth?: boolean
+  disallowIncomingXRP?: boolean
+  disableMasterKey?: boolean
+  noFreeze?: boolean
+  globalFreeze?: boolean
   defaultRipple?: boolean
 }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -58,6 +58,18 @@ const AccountFlags = {
   defaultRipple: accountRootFlags.DefaultRipple
 }
 
+export interface Settings {
+  passwordSpent?: boolean,
+  requireDestinationTag?: boolean,
+  requireAuthorization?: boolean,
+  depositAuth?: boolean,
+  disallowIncomingXRP?: boolean,
+  disableMasterKey?: boolean,
+  noFreeze?: boolean,
+  globalFreeze?: boolean,
+  defaultRipple?: boolean
+}
+
 const AccountFlagIndices = {
   requireDestinationTag: txFlagIndices.AccountSet.asfRequireDest,
   requireAuthorization: txFlagIndices.AccountSet.asfRequireAuth,

--- a/src/common/hashes/README.md
+++ b/src/common/hashes/README.md
@@ -2,7 +2,7 @@
 
 Methods to hash XRP Ledger objects
 
-## Methods
+## Computing a transaction hash (ID)
 
 ### computeBinaryTransactionHash = (txBlobHex: string): string
 
@@ -12,19 +12,35 @@ Compute the hash of a binary transaction blob.
 
 Compute the hash of a transaction in txJSON format.
 
+## [Hash Prefixes](https://xrpl.org/basic-data-types.html#hash-prefixes)
+
+In many cases, the XRP Ledger prefixes an object's binary data with a 4-byte code before calculating its hash, so that objects of different types have different hashes even if the binary data is the same. The existing 4-byte codes are structured as 3 alphabetic characters, encoded as ASCII, followed by a zero byte.
+
+Some types of hashes appear in API requests and responses. Others are only calculated as the first step of signing a certain type of data, or calculating a higher-level hash. Some of following methods internally use some of the 4-byte hash prefixes in order to calculate the appropriate hash.
+
 ### computeBinaryTransactionSigningHash = (txBlobHex: string): string
 
-### computeTransactionSigningHash = (txJSON: any): string
+In order to single-sign a transaction, you must perform these steps:
 
-### computeAccountHash = (address: string): string
+1. Assuming the transaction is in JSON format (txJSON), `encode` the transaction in the XRP Ledger's binary format.
+2. Hash the data with the appropriate prefix (`0x53545800` if single-signing, or `0x534D5400` if multi-signing).
+3. After signing, you must re-serialize the transaction with the `TxnSignature` field included.
+
+The `computeBinaryTransactionSigningHash` helps with step 2, automatically using the `0x53545800` prefix needed for single-signing a transaction.
+
+For details, see [Serialization Format](https://xrpl.org/serialization.html).
+
+_Removed:_ `computeTransactionSigningHash`, which took txJSON as a parameter. It was part of the deprecated ripple-hashes library. If you have txJSON, `encode` it with [ripple-binary-codec](https://github.com/ripple/ripple-binary-codec) first. Example: `return computeBinaryTransactionSigningHash(encode(txJSON))`
+
+### computeAccountLedgerObjectID = (address: string): string
 
 Compute the hash of an account, given the account's classic address (starting with `r`).
 
-### computeSignerListHash = (address: string): string
+### computeSignerListLedgerObjectID = (address: string): string
 
 Compute the hash of an account's SignerList.
 
-### computeOrderHash = (address: string, sequence: number): string
+### computeOrderID = (address: string, sequence: number): string
 
 Compute the hash of an order, given the owner's classic address (starting with `r`) and the account sequence number of the `OfferCreate` order transaction.
 

--- a/src/common/hashes/index.ts
+++ b/src/common/hashes/index.ts
@@ -71,6 +71,14 @@ export const computeTransactionHash = (txJSON: any): string => {
   return computeBinaryTransactionHash(encode(txJSON))
 }
 
+/**
+ * Hash the given binary transaction data with the single-signing prefix.
+ *
+ * See [Serialization Format](https://xrpl.org/serialization.html)
+ *
+ * @param txBlobHex The binary transaction blob as a hexadecimal string
+ * @returns {string} The hash to sign
+ */
 export const computeBinaryTransactionSigningHash = (
   txBlobHex: string
 ): string => {
@@ -78,21 +86,56 @@ export const computeBinaryTransactionSigningHash = (
   return sha512Half(prefix + txBlobHex)
 }
 
-export const computeTransactionSigningHash = (txJSON: any): string => {
-  return computeBinaryTransactionSigningHash(encode(txJSON))
-}
-
-export const computeAccountHash = (address: string): string => {
+/**
+ * Compute Account Ledger Object ID
+ *
+ * All objects in a ledger's state tree have a unique ID.
+ * The Account Ledger Object ID is derived by hashing the
+ * address with a namespace identifier. This ensures every
+ * ID is unique.
+ *
+ * See [Ledger Object IDs](https://xrpl.org/ledger-object-ids.html)
+ *
+ * @param address The classic account address
+ * @returns {string} The Ledger Object ID for the account
+ */
+export const computeAccountLedgerObjectID = (address: string): string => {
   return sha512Half(ledgerSpaceHex('account') + addressToHex(address))
 }
 
-export const computeSignerListHash = (address: string): string => {
+/**
+ * [SignerList ID Format](https://xrpl.org/signerlist.html#signerlist-id-format)
+ *
+ * The ID of a SignerList object is the SHA-512Half of the following values, concatenated in order:
+ *   * The RippleState space key (0x0053)
+ *   * The AccountID of the owner of the SignerList
+ *   * The SignerListID (currently always 0)
+ *
+ * This method computes a SignerList Ledger Object ID.
+ *
+ * @param address The classic account address of the SignerList owner (starting with r)
+ * @return {string} The ID of the account's SignerList object
+ */
+export const computeSignerListLedgerObjectID = (address: string): string => {
   return sha512Half(
     ledgerSpaceHex('signerList') + addressToHex(address) + '00000000'
   ) // uint32(0) signer list index
 }
 
-export const computeOrderHash = (address: string, sequence: number): string => {
+/**
+ * [Offer ID Format](https://xrpl.org/offer.html#offer-id-format)
+ *
+ * The ID of a Offer object is the SHA-512Half of the following values, concatenated in order:
+ *   * The Offer space key (0x006F)
+ *   * The AccountID of the account placing the offer
+ *   * The Sequence number of the OfferCreate transaction that created the offer
+ *
+ * This method computes an Offer ID (aka Order ID).
+ *
+ * @param address The classic account address of the SignerList owner (starting with r)
+ * @returns {string} The ID of the account's Offer object
+ */
+export const computeOrderID = (address: string, sequence: number): string => {
   const prefix = '00' + intToHex(ledgerspaces.offer.charCodeAt(0), 1)
   return sha512Half(prefix + addressToHex(address) + intToHex(sequence, 4))
 }

--- a/src/common/hashes/ledgerspaces.ts
+++ b/src/common/hashes/ledgerspaces.ts
@@ -1,10 +1,12 @@
 /**
- * Ripple ledger namespace prefixes.
+ * XRP Ledger namespace prefixes.
  *
- * The Ripple ledger is a key-value store. In order to avoid name collisions,
+ * The XRP Ledger is a key-value store. In order to avoid name collisions,
  * names are partitioned into namespaces.
  *
  * Each namespace is just a single character prefix.
+ *
+ * See [LedgerNameSpace enum](https://github.com/ripple/rippled/blob/master/src/ripple/protocol/LedgerFormats.h#L100)
  */
 export default {
   account: 'a',
@@ -16,9 +18,12 @@ export default {
   bookDir: 'B', // Directory of order books.
   contract: 'c',
   skipList: 's',
+  escrow: 'u',
   amendment: 'f',
   feeSettings: 'e',
+  ticket: 'T',
   signerList: 'S',
-  escrow: 'u',
-  paychan: 'x'
+  paychan: 'x',
+  check: 'C',
+  depositPreauth: 'p'
 }

--- a/src/common/schemas/input/submit.json
+++ b/src/common/schemas/input/submit.json
@@ -6,6 +6,10 @@
     "signedTransaction": {
       "$ref": "blob",
       "description": "A signed transaction as returned by [sign](#sign)."
+    },
+    "failHard": {
+      "type": "boolean",
+      "description": "If `true`, and the transaction fails locally, do not retry or relay the transaction to other servers. Defaults to `false`."
     }
   },
   "additionalProperties": false,

--- a/src/ledger/settings.ts
+++ b/src/ledger/settings.ts
@@ -4,6 +4,7 @@ import {validate, constants, ensureClassicAddress} from '../common'
 import {FormattedSettings} from '../common/types/objects'
 import {AccountInfoResponse} from '../common/types/commands'
 import {RippleAPI} from '..'
+import { Settings } from '../common/constants'
 
 const AccountFlags = constants.AccountFlags
 
@@ -14,7 +15,7 @@ export type SettingsOptions = {
 export function parseAccountFlags(
   value: number,
   options: {excludeFalse?: boolean} = {}
-) {
+): Settings {
   const settings = {}
   for (const flagName in AccountFlags) {
     if (value & AccountFlags[flagName]) {

--- a/src/ledger/settings.ts
+++ b/src/ledger/settings.ts
@@ -4,7 +4,7 @@ import {validate, constants, ensureClassicAddress} from '../common'
 import {FormattedSettings} from '../common/types/objects'
 import {AccountInfoResponse} from '../common/types/commands'
 import {RippleAPI} from '..'
-import { Settings } from '../common/constants'
+import {Settings} from '../common/constants'
 
 const AccountFlags = constants.AccountFlags
 

--- a/src/offline/generate-address.ts
+++ b/src/offline/generate-address.ts
@@ -28,7 +28,10 @@ export interface GenerateAddressOptions {
 function generateAddressAPI(options: GenerateAddressOptions): GeneratedAddress {
   validate.generateAddress({options})
   try {
-    const generateSeedOptions: { entropy?: Uint8Array; algorithm?: "ecdsa-secp256k1" | "ed25519"; } = {
+    const generateSeedOptions: {
+      entropy?: Uint8Array
+      algorithm?: 'ecdsa-secp256k1' | 'ed25519'
+    } = {
       algorithm: options.algorithm
     }
     if (options.entropy) {

--- a/src/transaction/submit.ts
+++ b/src/transaction/submit.ts
@@ -39,12 +39,15 @@ function formatSubmitResponse(response): FormattedSubmitResponse {
 async function submit(
   this: RippleAPI,
   signedTransaction: string,
-  failHard?: boolean 
+  failHard?: boolean
 ): Promise<FormattedSubmitResponse> {
   // 1. Validate
   validate.submit({signedTransaction})
   // 2. Make Request
-  const response = await this.request('submit', {tx_blob: signedTransaction, ...(failHard ? {fail_hard: failHard} : {})})
+  const response = await this.request('submit', {
+    tx_blob: signedTransaction,
+    ...(failHard ? {fail_hard: failHard} : {})
+  })
   // 3. Return Formatted Response
   return formatSubmitResponse(response)
 }

--- a/src/transaction/submit.ts
+++ b/src/transaction/submit.ts
@@ -38,12 +38,13 @@ function formatSubmitResponse(response): FormattedSubmitResponse {
 
 async function submit(
   this: RippleAPI,
-  signedTransaction: string
+  signedTransaction: string,
+  failHard?: boolean 
 ): Promise<FormattedSubmitResponse> {
   // 1. Validate
   validate.submit({signedTransaction})
   // 2. Make Request
-  const response = await this.request('submit', {tx_blob: signedTransaction})
+  const response = await this.request('submit', {tx_blob: signedTransaction, ...(failHard ? {fail_hard: failHard} : {})})
   // 3. Return Formatted Response
   return formatSubmitResponse(response)
 }

--- a/test/api/generateAddress/index.ts
+++ b/test/api/generateAddress/index.ts
@@ -1,7 +1,7 @@
 import assert from 'assert-diff'
 import responses from '../../fixtures/responses'
 import {TestSuite} from '../../utils'
-import { GenerateAddressOptions } from '../../../src/offline/generate-address'
+import {GenerateAddressOptions} from '../../../src/offline/generate-address'
 const {generateAddress: RESPONSE_FIXTURES} = responses
 
 /**
@@ -10,7 +10,7 @@ const {generateAddress: RESPONSE_FIXTURES} = responses
  * - Check out "test/api/index.ts" for more information about the test runner.
  */
 export default <TestSuite>{
-  'generateAddress': async (api) => {
+  'generateAddress': async api => {
     // GIVEN entropy of all zeros
     function random() {
       return new Array(16).fill(0)
@@ -25,7 +25,7 @@ export default <TestSuite>{
     )
   },
 
-  'generateAddress invalid entropy': async (api) => {
+  'generateAddress invalid entropy': async api => {
     assert.throws(() => {
       // GIVEN entropy of 1 byte
       function random() {
@@ -40,7 +40,7 @@ export default <TestSuite>{
     }, api.errors.UnexpectedError)
   },
 
-  'generateAddress with no options object': async (api) => {
+  'generateAddress with no options object': async api => {
     // GIVEN no options
 
     // WHEN generating an address
@@ -51,7 +51,7 @@ export default <TestSuite>{
     assert(account.secret.startsWith('s'), 'Secret must start with `s`')
   },
 
-  'generateAddress with empty options object': async (api) => {
+  'generateAddress with empty options object': async api => {
     // GIVEN an empty options object
     const options = {}
 
@@ -63,7 +63,7 @@ export default <TestSuite>{
     assert(account.secret.startsWith('s'), 'Secret must start with `s`')
   },
 
-  'generateAddress with algorithm `ecdsa-secp256k1`': async (api) => {
+  'generateAddress with algorithm `ecdsa-secp256k1`': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1'
     const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1'}
 
@@ -72,11 +72,19 @@ export default <TestSuite>{
 
     // THEN we get an object with an address starting with 'r' and a secret starting with 's' (not 'sEd')
     assert(account.address.startsWith('r'), 'Address must start with `r`')
-    assert.deepEqual(account.secret.slice(0, 1), 's', `Secret ${account.secret} must start with 's'`)
-    assert.notStrictEqual(account.secret.slice(0, 3), 'sEd', `secp256k1 secret ${account.secret} must not start with 'sEd'`)
+    assert.deepEqual(
+      account.secret.slice(0, 1),
+      's',
+      `Secret ${account.secret} must start with 's'`
+    )
+    assert.notStrictEqual(
+      account.secret.slice(0, 3),
+      'sEd',
+      `secp256k1 secret ${account.secret} must not start with 'sEd'`
+    )
   },
 
-  'generateAddress with algorithm `ed25519`': async (api) => {
+  'generateAddress with algorithm `ed25519`': async api => {
     // GIVEN we want to use 'ed25519'
     const options: GenerateAddressOptions = {algorithm: 'ed25519'}
 
@@ -85,12 +93,19 @@ export default <TestSuite>{
 
     // THEN we get an object with an address starting with 'r' and a secret starting with 'sEd'
     assert(account.address.startsWith('r'), 'Address must start with `r`')
-    assert.deepEqual(account.secret.slice(0, 3), 'sEd', `Ed25519 secret ${account.secret} must start with 'sEd'`)
+    assert.deepEqual(
+      account.secret.slice(0, 3),
+      'sEd',
+      `Ed25519 secret ${account.secret} must start with 'sEd'`
+    )
   },
 
-  'generateAddress with algorithm `ecdsa-secp256k1` and given entropy': async (api) => {
+  'generateAddress with algorithm `ecdsa-secp256k1` and given entropy': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1', entropy: new Array(16).fill(0)}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ecdsa-secp256k1',
+      entropy: new Array(16).fill(0)
+    }
 
     // WHEN generating an address
     const account = api.generateAddress(options)
@@ -99,28 +114,34 @@ export default <TestSuite>{
     assert.deepEqual(account, responses.generateAddress)
   },
 
-  'generateAddress with algorithm `ed25519` and given entropy': async (api) => {
+  'generateAddress with algorithm `ed25519` and given entropy': async api => {
     // GIVEN we want to use 'ed25519' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ed25519', entropy: new Array(16).fill(0)}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ed25519',
+      entropy: new Array(16).fill(0)
+    }
 
     // WHEN generating an address
     const account = api.generateAddress(options)
 
     // THEN we get the expected return value
     assert.deepEqual(account, {
-
       // generateAddress return value always includes xAddress to encourage X-address adoption
       xAddress: 'X7xq1YJ4xmLSGGLhuakFQB9CebWYthQkgsvFC4LGFH871HB',
 
-      classicAddress: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
-      address: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
+      classicAddress: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7',
+      address: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7',
       secret: 'sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE'
     })
   },
 
-  'generateAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address': async (api) => {
+  'generateAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1', entropy: new Array(16).fill(0), includeClassicAddress: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ecdsa-secp256k1',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true
+    }
 
     // WHEN generating an address
     const account = api.generateAddress(options)
@@ -129,62 +150,72 @@ export default <TestSuite>{
     assert.deepEqual(account, responses.generateAddress)
   },
 
-  'generateAddress with algorithm `ed25519` and given entropy; include classic address': async (api) => {
+  'generateAddress with algorithm `ed25519` and given entropy; include classic address': async api => {
     // GIVEN we want to use 'ed25519' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ed25519', entropy: new Array(16).fill(0), includeClassicAddress: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ed25519',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true
+    }
 
     // WHEN generating an address
     const account = api.generateAddress(options)
 
     // THEN we get the expected return value
     assert.deepEqual(account, {
-
       // generateAddress return value always includes xAddress to encourage X-address adoption
       xAddress: 'X7xq1YJ4xmLSGGLhuakFQB9CebWYthQkgsvFC4LGFH871HB',
 
       secret: 'sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE',
-      classicAddress: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
-      address: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7"
+      classicAddress: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7',
+      address: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7'
     })
   },
 
-  'generateAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address; for test network use': async (api) => {
+  'generateAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address; for test network use': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1', entropy: new Array(16).fill(0), includeClassicAddress: true, test: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ecdsa-secp256k1',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true,
+      test: true
+    }
 
     // WHEN generating an address
     const account = api.generateAddress(options)
 
     // THEN we get the expected return value
     const response = Object.assign({}, responses.generateAddress, {
-
       // generateAddress return value always includes xAddress to encourage X-address adoption
       xAddress: 'TVG3TcCD58BD6MZqsNuTihdrhZwR8SzvYS8U87zvHsAcNw4'
-
     })
     assert.deepEqual(account, response)
   },
 
-  'generateAddress with algorithm `ed25519` and given entropy; include classic address; for test network use': async (api) => {
+  'generateAddress with algorithm `ed25519` and given entropy; include classic address; for test network use': async api => {
     // GIVEN we want to use 'ed25519' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ed25519', entropy: new Array(16).fill(0), includeClassicAddress: true, test: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ed25519',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true,
+      test: true
+    }
 
     // WHEN generating an address
     const account = api.generateAddress(options)
 
     // THEN we get the expected return value
     assert.deepEqual(account, {
-
       // generateAddress return value always includes xAddress to encourage X-address adoption
       xAddress: 'T7t4HeTMF5tT68agwuVbJwu23ssMPeh8dDtGysZoQiij1oo',
 
       secret: 'sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE',
-      classicAddress: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
-      address: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7"
+      classicAddress: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7',
+      address: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7'
     })
   },
 
-  'generateAddress for test network use': async (api) => {
+  'generateAddress for test network use': async api => {
     // GIVEN we want an address for test network use
     const options: GenerateAddressOptions = {test: true}
 
@@ -194,8 +225,16 @@ export default <TestSuite>{
     // THEN we get an object with xAddress starting with 'T' and a secret starting with 's'
 
     // generateAddress return value always includes xAddress to encourage X-address adoption
-    assert.deepEqual(account.xAddress.slice(0, 1), 'T', 'Test addresses start with T')
+    assert.deepEqual(
+      account.xAddress.slice(0, 1),
+      'T',
+      'Test addresses start with T'
+    )
 
-    assert.deepEqual(account.secret.slice(0, 1), 's', `Secret ${account.secret} must start with 's'`)
+    assert.deepEqual(
+      account.secret.slice(0, 1),
+      's',
+      `Secret ${account.secret} must start with 's'`
+    )
   }
 }

--- a/test/api/generateXAddress/index.ts
+++ b/test/api/generateXAddress/index.ts
@@ -1,7 +1,7 @@
 import assert from 'assert-diff'
 import responses from '../../fixtures/responses'
 import {TestSuite} from '../../utils'
-import { GenerateAddressOptions } from '../../../src/offline/generate-address'
+import {GenerateAddressOptions} from '../../../src/offline/generate-address'
 
 /**
  * Every test suite exports their tests in the default object.
@@ -9,7 +9,7 @@ import { GenerateAddressOptions } from '../../../src/offline/generate-address'
  * - Check out "test/api/index.ts" for more information about the test runner.
  */
 export default <TestSuite>{
-  'generateXAddress': async (api) => {
+  'generateXAddress': async api => {
     // GIVEN entropy of all zeros
     function random() {
       return new Array(16).fill(0)
@@ -24,7 +24,7 @@ export default <TestSuite>{
     )
   },
 
-  'generateXAddress invalid entropy': async (api) => {
+  'generateXAddress invalid entropy': async api => {
     assert.throws(() => {
       // GIVEN entropy of 1 byte
       function random() {
@@ -39,18 +39,21 @@ export default <TestSuite>{
     }, api.errors.UnexpectedError)
   },
 
-  'generateXAddress with no options object': async (api) => {
+  'generateXAddress with no options object': async api => {
     // GIVEN no options
 
     // WHEN generating an X-address
     const account = api.generateXAddress()
 
     // THEN we get an object with an xAddress starting with 'X' and a secret starting with 's'
-    assert(account.xAddress.startsWith('X'), 'By default X-addresses start with X')
+    assert(
+      account.xAddress.startsWith('X'),
+      'By default X-addresses start with X'
+    )
     assert(account.secret.startsWith('s'), 'Secrets start with s')
   },
 
-  'generateXAddress with empty options object': async (api) => {
+  'generateXAddress with empty options object': async api => {
     // GIVEN an empty options object
     const options = {}
 
@@ -58,11 +61,14 @@ export default <TestSuite>{
     const account = api.generateXAddress(options)
 
     // THEN we get an object with an xAddress starting with 'X' and a secret starting with 's'
-    assert(account.xAddress.startsWith('X'), 'By default X-addresses start with X')
+    assert(
+      account.xAddress.startsWith('X'),
+      'By default X-addresses start with X'
+    )
     assert(account.secret.startsWith('s'), 'Secrets start with s')
   },
 
-  'generateXAddress with algorithm `ecdsa-secp256k1`': async (api) => {
+  'generateXAddress with algorithm `ecdsa-secp256k1`': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1'
     const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1'}
 
@@ -70,12 +76,23 @@ export default <TestSuite>{
     const account = api.generateXAddress(options)
 
     // THEN we get an object with an xAddress starting with 'X' and a secret starting with 's'
-    assert(account.xAddress.startsWith('X'), 'By default X-addresses start with X')
-    assert.deepEqual(account.secret.slice(0, 1), 's', `Secret ${account.secret} must start with 's'`)
-    assert.notStrictEqual(account.secret.slice(0, 3), 'sEd', `secp256k1 secret ${account.secret} must not start with 'sEd'`)
+    assert(
+      account.xAddress.startsWith('X'),
+      'By default X-addresses start with X'
+    )
+    assert.deepEqual(
+      account.secret.slice(0, 1),
+      's',
+      `Secret ${account.secret} must start with 's'`
+    )
+    assert.notStrictEqual(
+      account.secret.slice(0, 3),
+      'sEd',
+      `secp256k1 secret ${account.secret} must not start with 'sEd'`
+    )
   },
 
-  'generateXAddress with algorithm `ed25519`': async (api) => {
+  'generateXAddress with algorithm `ed25519`': async api => {
     // GIVEN we want to use 'ed25519'
     const options: GenerateAddressOptions = {algorithm: 'ed25519'}
 
@@ -83,13 +100,23 @@ export default <TestSuite>{
     const account = api.generateXAddress(options)
 
     // THEN we get an object with an xAddress starting with 'X' and a secret starting with 'sEd'
-    assert(account.xAddress.startsWith('X'), 'By default X-addresses start with X')
-    assert.deepEqual(account.secret.slice(0, 3), 'sEd', `Ed25519 secret ${account.secret} must start with 'sEd'`)
+    assert(
+      account.xAddress.startsWith('X'),
+      'By default X-addresses start with X'
+    )
+    assert.deepEqual(
+      account.secret.slice(0, 3),
+      'sEd',
+      `Ed25519 secret ${account.secret} must start with 'sEd'`
+    )
   },
 
-  'generateXAddress with algorithm `ecdsa-secp256k1` and given entropy': async (api) => {
+  'generateXAddress with algorithm `ecdsa-secp256k1` and given entropy': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1', entropy: new Array(16).fill(0)}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ecdsa-secp256k1',
+      entropy: new Array(16).fill(0)
+    }
 
     // WHEN generating an X-address
     const account = api.generateXAddress(options)
@@ -98,9 +125,12 @@ export default <TestSuite>{
     assert.deepEqual(account, responses.generateXAddress)
   },
 
-  'generateXAddress with algorithm `ed25519` and given entropy': async (api) => {
+  'generateXAddress with algorithm `ed25519` and given entropy': async api => {
     // GIVEN we want to use 'ed25519' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ed25519', entropy: new Array(16).fill(0)}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ed25519',
+      entropy: new Array(16).fill(0)
+    }
 
     // WHEN generating an X-address
     const account = api.generateXAddress(options)
@@ -112,9 +142,13 @@ export default <TestSuite>{
     })
   },
 
-  'generateXAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address': async (api) => {
+  'generateXAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1', entropy: new Array(16).fill(0), includeClassicAddress: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ecdsa-secp256k1',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true
+    }
 
     // WHEN generating an X-address
     const account = api.generateXAddress(options)
@@ -123,9 +157,13 @@ export default <TestSuite>{
     assert.deepEqual(account, responses.generateAddress)
   },
 
-  'generateXAddress with algorithm `ed25519` and given entropy; include classic address': async (api) => {
+  'generateXAddress with algorithm `ed25519` and given entropy; include classic address': async api => {
     // GIVEN we want to use 'ed25519' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ed25519', entropy: new Array(16).fill(0), includeClassicAddress: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ed25519',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true
+    }
 
     // WHEN generating an X-address
     const account = api.generateXAddress(options)
@@ -134,14 +172,19 @@ export default <TestSuite>{
     assert.deepEqual(account, {
       xAddress: 'X7xq1YJ4xmLSGGLhuakFQB9CebWYthQkgsvFC4LGFH871HB',
       secret: 'sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE',
-      classicAddress: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
-      address: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7"
+      classicAddress: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7',
+      address: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7'
     })
   },
 
-  'generateXAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address; for test network use': async (api) => {
+  'generateXAddress with algorithm `ecdsa-secp256k1` and given entropy; include classic address; for test network use': async api => {
     // GIVEN we want to use 'ecdsa-secp256k1' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ecdsa-secp256k1', entropy: new Array(16).fill(0), includeClassicAddress: true, test: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ecdsa-secp256k1',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true,
+      test: true
+    }
 
     // WHEN generating an X-address
     const account = api.generateXAddress(options)
@@ -153,9 +196,14 @@ export default <TestSuite>{
     assert.deepEqual(account, response)
   },
 
-  'generateXAddress with algorithm `ed25519` and given entropy; include classic address; for test network use': async (api) => {
+  'generateXAddress with algorithm `ed25519` and given entropy; include classic address; for test network use': async api => {
     // GIVEN we want to use 'ed25519' with entropy of zero
-    const options: GenerateAddressOptions = {algorithm: 'ed25519', entropy: new Array(16).fill(0), includeClassicAddress: true, test: true}
+    const options: GenerateAddressOptions = {
+      algorithm: 'ed25519',
+      entropy: new Array(16).fill(0),
+      includeClassicAddress: true,
+      test: true
+    }
 
     // WHEN generating an X-address
     const account = api.generateXAddress(options)
@@ -164,12 +212,12 @@ export default <TestSuite>{
     assert.deepEqual(account, {
       xAddress: 'T7t4HeTMF5tT68agwuVbJwu23ssMPeh8dDtGysZoQiij1oo',
       secret: 'sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE',
-      classicAddress: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7",
-      address: "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7"
+      classicAddress: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7',
+      address: 'r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7'
     })
   },
 
-  'generateXAddress for test network use': async (api) => {
+  'generateXAddress for test network use': async api => {
     // GIVEN we want an X-address for test network use
     const options: GenerateAddressOptions = {test: true}
 
@@ -177,7 +225,15 @@ export default <TestSuite>{
     const account = api.generateXAddress(options)
 
     // THEN we get an object with xAddress starting with 'T' and a secret starting with 's'
-    assert.deepEqual(account.xAddress.slice(0, 1), 'T', 'Test X-addresses start with T')
-    assert.deepEqual(account.secret.slice(0, 1), 's', `Secret ${account.secret} must start with 's'`)
+    assert.deepEqual(
+      account.xAddress.slice(0, 1),
+      'T',
+      'Test X-addresses start with T'
+    )
+    assert.deepEqual(
+      account.secret.slice(0, 1),
+      's',
+      `Secret ${account.secret} must start with 's'`
+    )
   }
 }

--- a/test/api/getTransaction/index.ts
+++ b/test/api/getTransaction/index.ts
@@ -355,7 +355,8 @@ export default <TestSuite>{
   },
 
   'AccountDelete': async (api, address) => {
-    const hash = 'EC2AB14028DC84DE525470AB4DAAA46358B50A8662C63804BFF38244731C0CB9'
+    const hash =
+      'EC2AB14028DC84DE525470AB4DAAA46358B50A8662C63804BFF38244731C0CB9'
     const response = await api.getTransaction(hash)
     assertResultMatch(
       response,

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -224,26 +224,29 @@ describe('Connection', function() {
   it('DisconnectedError on initial _onOpen send', async function() {
     // _onOpen previously could throw PromiseRejectionHandledWarning: Promise rejection was handled asynchronously
     // do not rely on the api.setup hook to test this as it bypasses the case, disconnect api connection first
-    await this.api.disconnect();
+    await this.api.disconnect()
 
     // stub _onOpen to only run logic relevant to test case
     this.api.connection._onOpen = () => {
       // overload websocket send on open when _ws exists
       this.api.connection._ws.send = function(data, options, cb) {
         // recent ws throws this error instead of calling back
-        throw new Error('WebSocket is not open: readyState 0 (CONNECTING)');
+        throw new Error('WebSocket is not open: readyState 0 (CONNECTING)')
       }
-      const request = {command: 'subscribe', streams: ['ledger']};
-      return this.api.connection.request(request);
+      const request = {command: 'subscribe', streams: ['ledger']}
+      return this.api.connection.request(request)
     }
 
     try {
-      await this.api.connect();
+      await this.api.connect()
     } catch (error) {
-      assert(error instanceof this.api.errors.DisconnectedError);
-      assert.strictEqual(error.message, 'WebSocket is not open: readyState 0 (CONNECTING)');
+      assert(error instanceof this.api.errors.DisconnectedError)
+      assert.strictEqual(
+        error.message,
+        'WebSocket is not open: readyState 0 (CONNECTING)'
+      )
     }
-  });
+  })
 
   it('ResponseFormatError', function() {
     return this.api
@@ -380,7 +383,7 @@ describe('Connection', function() {
     }
     // Hook up a listener for the reconnect error event
     this.api.on('error', (error, message) => {
-      if(error === 'reconnect' && message === 'error on reconnect') {
+      if (error === 'reconnect' && message === 'error on reconnect') {
         return done()
       }
       return done(new Error('Expected error on reconnect'))
@@ -592,20 +595,20 @@ describe('Connection', function() {
   )
 
   it('should clean up websocket connection if error after websocket is opened', async function() {
-    await this.api.disconnect();
+    await this.api.disconnect()
     // fail on connection
     this.api.connection._subscribeToLedger = async () => {
       throw new Error('error on _subscribeToLedger')
     }
     try {
-      await this.api.connect();
+      await this.api.connect()
       throw new Error('expected connect() to reject, but it resolved')
     } catch (err) {
-      assert(err.message === 'error on _subscribeToLedger');
+      assert(err.message === 'error on _subscribeToLedger')
       // _ws.close event listener should have cleaned up the socket when disconnect _ws.close is run on connection error
       // do not fail on connection anymore
       this.api.connection._subscribeToLedger = async () => {}
-      await this.api.connection.reconnect();
+      await this.api.connection.reconnect()
     }
   })
 

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -98,6 +98,7 @@ describe('Connection', function() {
     )
     assert.strictEqual(await this.api.connection.getFeeBase(), 10)
     assert.strictEqual(await this.api.connection.getFeeRef(), 10)
+    assert.strictEqual(await this.api.connection.getReserveBase(), 20000000) // 20 XRP
   })
 
   it('with proxy', function(done) {
@@ -378,7 +379,7 @@ describe('Connection', function() {
       throw new Error('error on reconnect')
     }
     // Hook up a listener for the reconnect error event
-    this.api.on('error', (error, message) => { 
+    this.api.on('error', (error, message) => {
       if(error === 'reconnect' && message === 'error on reconnect') {
         return done()
       }

--- a/test/hashes-test.ts
+++ b/test/hashes-test.ts
@@ -47,7 +47,7 @@ describe('Ledger', function() {
       var account = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
       var expectedEntryHash =
         '2B6AC232AA4C4BE41BF49D2459FA4A0347E1B543A4C92FCEE0821C0201E2E9A8'
-      var actualEntryHash = hashes.computeAccountHash(account)
+      var actualEntryHash = hashes.computeAccountLedgerObjectID(account)
 
       assert.equal(actualEntryHash, expectedEntryHash)
     })
@@ -105,18 +105,18 @@ describe('Ledger', function() {
       var sequence = 137
       var expectedEntryHash =
         '03F0AED09DEEE74CEF85CD57A0429D6113507CF759C597BABB4ADB752F734CE3'
-      var actualEntryHash = hashes.computeOrderHash(account, sequence)
+      var actualEntryHash = hashes.computeOrderID(account, sequence)
 
       assert.equal(actualEntryHash, expectedEntryHash)
     })
   })
 
-  describe('computeSignerListHash', function() {
+  describe('computeSignerListLedgerObjectID', function() {
     it('will calculate the SignerList index for r32UufnaCGL82HubijgJGDmdE5hac7ZvLw', function() {
       var account = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
       var expectedEntryHash =
         '778365D5180F5DF3016817D1F318527AD7410D83F8636CF48C43E8AF72AB49BF'
-      var actualEntryHash = hashes.computeSignerListHash(account)
+      var actualEntryHash = hashes.computeSignerListLedgerObjectID(account)
       assert.equal(actualEntryHash, expectedEntryHash)
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,9 +174,9 @@
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
 "@types/json-schema@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
-  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
 "@types/lodash@^4.14.136":
   version "4.14.149"
@@ -211,15 +211,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.14.0.tgz#e9179fa3c44e00b3106b85d7b69342901fb43e3b"
-  integrity sha512-KcyKS7G6IWnIgl3ZpyxyBCxhkBPV+0a5Jjy2g5HxlrbG2ZLQNFeneIBVXdaBCYOVjvGmGGFKom1kgiAY75SDeQ==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.14.0"
-    eslint-scope "^5.0.0"
-
 "@typescript-eslint/experimental-utils@2.24.0":
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
@@ -229,33 +220,43 @@
     "@typescript-eslint/typescript-estree" "2.24.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.3.3":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.14.0.tgz#30fa0523d86d74172a5e32274558404ba4262cd6"
-  integrity sha512-haS+8D35fUydIs+zdSf4BxpOartb/DjrZ2IxQ5sR8zyGfd77uT9ZJZYF8+I0WPhzqHmfafUBx8MYpcp8pfaoSA==
+"@typescript-eslint/experimental-utils@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz#801a952c10b58e486c9a0b36cf21e2aab1e9e01a"
+  integrity sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.27.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.27.0.tgz#d91664335b2c46584294e42eb4ff35838c427287"
+  integrity sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.14.0"
-    "@typescript-eslint/typescript-estree" "2.14.0"
+    "@typescript-eslint/experimental-utils" "2.27.0"
+    "@typescript-eslint/typescript-estree" "2.27.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.14.0.tgz#c67698acdc14547f095eeefe908958d93e1a648d"
-  integrity sha512-pnLpUcMNG7GfFFfNQbEX6f1aPa5fMnH2G9By+A1yovYI4VIOK2DzkaRuUlIkbagpAcrxQHLqovI1YWqEcXyRnA==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash.unescape "4.0.1"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.24.0":
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz#38bbc8bb479790d2f324797ffbcdb346d897c62a"
   integrity sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
+  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -1687,6 +1688,13 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
@@ -3009,11 +3017,6 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
@@ -4767,12 +4770,7 @@ ts-node@^8.4.1:
     source-map-support "^0.5.6"
     yn "3.1.1"
 
-tslib@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,24 +201,14 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^2.3.3":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz#a86cf618c965a462cddf3601f594544b134d6d68"
-  integrity sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.30.0.tgz#312a37e80542a764d96e8ad88a105316cdcd7b05"
+  integrity sha512-PGejii0qIZ9Q40RB2jIHyUpRWs1GJuHP1pkoCiaeicfwO9z7Fx03NQzupuyzAmv+q9/gFNHu7lo1ByMXe8PNyg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.24.0"
-    eslint-utils "^1.4.3"
+    "@typescript-eslint/experimental-utils" "2.30.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
-
-"@typescript-eslint/experimental-utils@2.24.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz#a5cb2ed89fedf8b59638dc83484eb0c8c35e1143"
-  integrity sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.24.0"
-    eslint-scope "^5.0.0"
 
 "@typescript-eslint/experimental-utils@2.27.0":
   version "2.27.0"
@@ -227,6 +217,16 @@
   dependencies:
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/typescript-estree" "2.27.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/experimental-utils@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.30.0.tgz#9845e868c01f3aed66472c561d4b6bac44809dd0"
+  integrity sha512-L3/tS9t+hAHksy8xuorhOzhdefN0ERPDWmR9CclsIGOUqGKy6tqc/P+SoXeJRye5gazkuPO0cK9MQRnolykzkA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.30.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -240,10 +240,10 @@
     "@typescript-eslint/typescript-estree" "2.27.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.24.0":
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz#38bbc8bb479790d2f324797ffbcdb346d897c62a"
-  integrity sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==
+"@typescript-eslint/typescript-estree@2.27.0":
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
+  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -253,10 +253,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
-  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
+"@typescript-eslint/typescript-estree@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.30.0.tgz#1b8e848b55144270255ffbfe4c63291f8f766615"
+  integrity sha512-nI5WOechrA0qAhnr+DzqwmqHsx7Ulr/+0H7bWCcClDhhWkSyZR5BmTvnBEyONwJCTWHfc5PAQExX24VD26IAVw==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,150 +266,149 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@webassemblyjs/ast@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
-  integrity sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==
+"@webassemblyjs/ast@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
+  integrity sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==
   dependencies:
-    "@webassemblyjs/helper-module-context" "1.8.5"
-    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
-    "@webassemblyjs/wast-parser" "1.8.5"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/wast-parser" "1.9.0"
 
-"@webassemblyjs/floating-point-hex-parser@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
-  integrity sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==
+"@webassemblyjs/floating-point-hex-parser@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
+  integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
-"@webassemblyjs/helper-api-error@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz#c49dad22f645227c5edb610bdb9697f1aab721f7"
-  integrity sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==
+"@webassemblyjs/helper-api-error@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
+  integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
 
-"@webassemblyjs/helper-buffer@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz#fea93e429863dd5e4338555f42292385a653f204"
-  integrity sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==
+"@webassemblyjs/helper-buffer@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz#a1442d269c5feb23fcbc9ef759dac3547f29de00"
+  integrity sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==
 
-"@webassemblyjs/helper-code-frame@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz#9a740ff48e3faa3022b1dff54423df9aa293c25e"
-  integrity sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==
+"@webassemblyjs/helper-code-frame@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz#647f8892cd2043a82ac0c8c5e75c36f1d9159f27"
+  integrity sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==
   dependencies:
-    "@webassemblyjs/wast-printer" "1.8.5"
+    "@webassemblyjs/wast-printer" "1.9.0"
 
-"@webassemblyjs/helper-fsm@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz#ba0b7d3b3f7e4733da6059c9332275d860702452"
-  integrity sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==
+"@webassemblyjs/helper-fsm@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz#c05256b71244214671f4b08ec108ad63b70eddb8"
+  integrity sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==
 
-"@webassemblyjs/helper-module-context@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz#def4b9927b0101dc8cbbd8d1edb5b7b9c82eb245"
-  integrity sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==
+"@webassemblyjs/helper-module-context@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz#25d8884b76839871a08a6c6f806c3979ef712f07"
+  integrity sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    mamacro "^0.0.3"
+    "@webassemblyjs/ast" "1.9.0"
 
-"@webassemblyjs/helper-wasm-bytecode@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz#537a750eddf5c1e932f3744206551c91c1b93e61"
-  integrity sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==
+"@webassemblyjs/helper-wasm-bytecode@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
+  integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
 
-"@webassemblyjs/helper-wasm-section@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz#74ca6a6bcbe19e50a3b6b462847e69503e6bfcbf"
-  integrity sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==
+"@webassemblyjs/helper-wasm-section@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz#5a4138d5a6292ba18b04c5ae49717e4167965346"
+  integrity sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-buffer" "1.8.5"
-    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
-    "@webassemblyjs/wasm-gen" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-buffer" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/wasm-gen" "1.9.0"
 
-"@webassemblyjs/ieee754@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz#712329dbef240f36bf57bd2f7b8fb9bf4154421e"
-  integrity sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==
+"@webassemblyjs/ieee754@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
+  integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
-"@webassemblyjs/leb128@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.8.5.tgz#044edeb34ea679f3e04cd4fd9824d5e35767ae10"
-  integrity sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==
+"@webassemblyjs/leb128@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.9.0.tgz#f19ca0b76a6dc55623a09cffa769e838fa1e1c95"
+  integrity sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==
   dependencies:
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/utf8@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.8.5.tgz#a8bf3b5d8ffe986c7c1e373ccbdc2a0915f0cedc"
-  integrity sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==
+"@webassemblyjs/utf8@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
+  integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
 
-"@webassemblyjs/wasm-edit@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz#962da12aa5acc1c131c81c4232991c82ce56e01a"
-  integrity sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==
+"@webassemblyjs/wasm-edit@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz#3fe6d79d3f0f922183aa86002c42dd256cfee9cf"
+  integrity sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-buffer" "1.8.5"
-    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
-    "@webassemblyjs/helper-wasm-section" "1.8.5"
-    "@webassemblyjs/wasm-gen" "1.8.5"
-    "@webassemblyjs/wasm-opt" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
-    "@webassemblyjs/wast-printer" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-buffer" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/helper-wasm-section" "1.9.0"
+    "@webassemblyjs/wasm-gen" "1.9.0"
+    "@webassemblyjs/wasm-opt" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    "@webassemblyjs/wast-printer" "1.9.0"
 
-"@webassemblyjs/wasm-gen@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz#54840766c2c1002eb64ed1abe720aded714f98bc"
-  integrity sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==
+"@webassemblyjs/wasm-gen@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
+  integrity sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
-    "@webassemblyjs/ieee754" "1.8.5"
-    "@webassemblyjs/leb128" "1.8.5"
-    "@webassemblyjs/utf8" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/ieee754" "1.9.0"
+    "@webassemblyjs/leb128" "1.9.0"
+    "@webassemblyjs/utf8" "1.9.0"
 
-"@webassemblyjs/wasm-opt@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz#b24d9f6ba50394af1349f510afa8ffcb8a63d264"
-  integrity sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==
+"@webassemblyjs/wasm-opt@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
+  integrity sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-buffer" "1.8.5"
-    "@webassemblyjs/wasm-gen" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-buffer" "1.9.0"
+    "@webassemblyjs/wasm-gen" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
 
-"@webassemblyjs/wasm-parser@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz#21576f0ec88b91427357b8536383668ef7c66b8d"
-  integrity sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==
+"@webassemblyjs/wasm-parser@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz#9d48e44826df4a6598294aa6c87469d642fff65e"
+  integrity sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-api-error" "1.8.5"
-    "@webassemblyjs/helper-wasm-bytecode" "1.8.5"
-    "@webassemblyjs/ieee754" "1.8.5"
-    "@webassemblyjs/leb128" "1.8.5"
-    "@webassemblyjs/utf8" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-api-error" "1.9.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
+    "@webassemblyjs/ieee754" "1.9.0"
+    "@webassemblyjs/leb128" "1.9.0"
+    "@webassemblyjs/utf8" "1.9.0"
 
-"@webassemblyjs/wast-parser@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz#e10eecd542d0e7bd394f6827c49f3df6d4eefb8c"
-  integrity sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==
+"@webassemblyjs/wast-parser@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz#3031115d79ac5bd261556cecc3fa90a3ef451914"
+  integrity sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/floating-point-hex-parser" "1.8.5"
-    "@webassemblyjs/helper-api-error" "1.8.5"
-    "@webassemblyjs/helper-code-frame" "1.8.5"
-    "@webassemblyjs/helper-fsm" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/floating-point-hex-parser" "1.9.0"
+    "@webassemblyjs/helper-api-error" "1.9.0"
+    "@webassemblyjs/helper-code-frame" "1.9.0"
+    "@webassemblyjs/helper-fsm" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/wast-printer@1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz#114bbc481fd10ca0e23b3560fa812748b0bae5bc"
-  integrity sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==
+"@webassemblyjs/wast-printer@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899"
+  integrity sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/wast-parser" "1.8.5"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
 "@xtuc/ieee754@^1.2.0":
@@ -440,7 +439,7 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
   integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
-acorn@^6.2.1:
+acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
@@ -1022,7 +1021,7 @@ chokidar@3.3.0:
   optionalDependencies:
     fsevents "~2.1.1"
 
-chokidar@^2.0.2:
+chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -3081,11 +3080,6 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
 
-mamacro@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
-  integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
-
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -3261,10 +3255,10 @@ mkdirp@0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^0.5.1:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
-  integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
+mkdirp@^0.5.1, mkdirp@^0.5.3:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
 
@@ -5050,12 +5044,12 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-watchpack@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
-  integrity sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
+watchpack@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.1.tgz#280da0a8718592174010c078c7585a74cd8cd0e2"
+  integrity sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==
   dependencies:
-    chokidar "^2.0.2"
+    chokidar "^2.1.8"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
@@ -5104,15 +5098,15 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-map "~0.6.1"
 
 webpack@^4.42.0:
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.42.0.tgz#b901635dd6179391d90740a63c93f76f39883eb8"
-  integrity sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==
+  version "4.43.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
+  integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
   dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-module-context" "1.8.5"
-    "@webassemblyjs/wasm-edit" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.2.1"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^6.4.1"
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"
@@ -5123,13 +5117,13 @@ webpack@^4.42.0:
     loader-utils "^1.2.3"
     memory-fs "^0.4.1"
     micromatch "^3.1.10"
-    mkdirp "^0.5.1"
+    mkdirp "^0.5.3"
     neo-async "^2.6.1"
     node-libs-browser "^2.2.1"
     schema-utils "^1.0.0"
     tapable "^1.1.3"
     terser-webpack-plugin "^1.4.3"
-    watchpack "^1.6.0"
+    watchpack "^1.6.1"
     webpack-sources "^1.4.1"
 
 which-module@^2.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4387,10 +4387,10 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
-  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+source-map-support@^0.5.17, source-map-support@~0.5.12:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -4776,14 +4776,14 @@ tryer@^1.0.1:
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
 ts-node@^8.4.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.6"
+    source-map-support "^0.5.17"
     yn "3.1.1"
 
 tslib@^1.8.1, tslib@^1.9.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,10 +449,12 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+agent-base@6:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
+  integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -2424,12 +2426,12 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
-    agent-base "5"
+    agent-base "6"
     debug "4"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,9 +1792,9 @@ etag@~1.8.1:
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 eventemitter2@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.0.0.tgz#218eb512c3603c5341724b6af7b686a1aa5ab8f5"
-  integrity sha512-ZuNWHD7S7IoikyEmx35vPU8H1W0L+oi644+4mSTg7nwXvBQpIwQL7DPjYUF0VMB0jPkNMo3MqD07E7MYrkFmjQ==
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.3.1.tgz#14ec7db8c659aa9b36ad2ce4bfcaba95ad525536"
+  integrity sha512-cxfu3g0IBn/JEhAPV33NZTi8llQQ5j62D0Yf4ir1U9uQ1DlRZLL3Hh2E/+TWDprSy4BETWvrGBZMUexuC2b6Lw==
 
 events@^3.0.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,9 +179,9 @@
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
 "@types/lodash@^4.14.136":
-  version "4.14.149"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
-  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+  version "4.14.150"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
+  integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
 
 "@types/mocha@^7.0.1":
   version "7.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,9 +189,9 @@
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
 "@types/node@*", "@types/node@^13.1.1":
-  version "13.9.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.3.tgz#6356df2647de9eac569f9a52eda3480fa9e70b4d"
-  integrity sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==
+  version "13.13.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
+  integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
 
 "@types/ws@^7.2.0":
   version "7.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3782,10 +3782,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,10 +2857,10 @@ istanbul-lib-source-maps@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.0.tgz#d4d16d035db99581b6194e119bbf36c963c5eb70"
-  integrity sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==
+istanbul-reports@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
+  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
@@ -3385,7 +3385,7 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-preload@^0.2.0:
+node-preload@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/node-preload/-/node-preload-0.2.1.tgz#c03043bb327f417a18fee7ab7ee57b408a144301"
   integrity sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==
@@ -3412,9 +3412,9 @@ npm-run-path@^2.0.0:
     path-key "^2.0.0"
 
 nyc@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-15.0.0.tgz#eb32db2c0f29242c2414fe46357f230121cfc162"
-  integrity sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-15.0.1.tgz#bd4d5c2b17f2ec04370365a5ca1fc0ed26f9f93d"
+  integrity sha512-n0MBXYBYRqa67IVt62qW1r/d9UH/Qtr7SF1w/nQLJ9KxvWF6b2xCHImRAixHN9tnMMYHC2P14uo6KddNGwMgGg==
   dependencies:
     "@istanbuljs/load-nyc-config" "^1.0.0"
     "@istanbuljs/schema" "^0.1.2"
@@ -3431,10 +3431,9 @@ nyc@^15.0.0:
     istanbul-lib-processinfo "^2.0.2"
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
-    istanbul-reports "^3.0.0"
-    js-yaml "^3.13.1"
+    istanbul-reports "^3.0.2"
     make-dir "^3.0.0"
-    node-preload "^0.2.0"
+    node-preload "^0.2.1"
     p-map "^3.0.0"
     process-on-spawn "^1.0.0"
     resolve-from "^5.0.0"
@@ -3442,7 +3441,6 @@ nyc@^15.0.0:
     signal-exit "^3.0.2"
     spawn-wrap "^2.0.0"
     test-exclude "^6.0.0"
-    uuid "^3.3.3"
     yargs "^15.0.2"
 
 object-assign@^4.1.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -654,6 +654,11 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async@0.9.x:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1530,9 +1535,11 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 ejs@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.0.1.tgz#30c8f6ee9948502cc32e85c37a3f8b39b5a614a5"
-  integrity sha512-cuIMtJwxvzumSAkqaaoGY/L6Fc/t6YvoP9/VIaK0V/CyqKLEQ8sqODmYfy/cjXEdZ9+OOL8TecbJu+1RsofGDw==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.2.tgz#a9986e6920a60f2a3229e87d4f0f3c073209874c"
+  integrity sha512-zFuywxrAWtX5Mk2KAuoJNkXXbfezpNA0v7i+YC971QORguPekpjpAgeOv99YWSdKXwj7JxI2QAWDeDkE8fWtXw==
+  dependencies:
+    jake "^10.6.1"
 
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.2"
@@ -1966,6 +1973,13 @@ file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+filelist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.1.tgz#f10d1a3ae86c1694808e8f20906f43d4c9132dbb"
+  integrity sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 filesize@^3.6.1:
   version "3.6.1"
@@ -2864,6 +2878,16 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jake@^10.6.1:
+  version "10.6.1"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.6.1.tgz#c9c476cfd6e726ef600ee9bb2b880d5425ff8c79"
+  integrity sha512-pHUK3+V0BjOb1XSi95rbBksrMdIqLVC9bJqDnshVyleYsET3H0XAq+3VB2E3notcYvv4wRdRHn13p7vobG+wfQ==
+  dependencies:
+    async "0.9.x"
+    chalk "^2.4.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
 
 js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,6 +4113,14 @@ ripple-address-codec@^4.0.0:
     base-x "3.0.7"
     create-hash "^1.1.2"
 
+ripple-address-codec@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ripple-address-codec/-/ripple-address-codec-4.1.1.tgz#48e5d76b00b6b9752b1d376646d5abbcd3c8bd67"
+  integrity sha512-mcVD8f7+CH6XaBnLkRcmw4KyHMufa0HTJE3TYeaecwleIQASLYVenjQmVJLgmJQcDUS2Ldh/EltqktmiFMFgkg==
+  dependencies:
+    base-x "3.0.7"
+    create-hash "^1.1.2"
+
 ripple-binary-codec@^0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.2.6.tgz#a8c45c905c12d5dc6fa7e179c3584d56fb8bdb07"

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,9 +194,9 @@
   integrity sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==
 
 "@types/ws@^7.2.0":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.2.tgz#1bd2038bc80aea60f8a20b2dcf08602a72e65063"
-  integrity sha512-oqnI3DbGCVI9zJ/WHdFo3CUE8jQ8CVQDUIKaDtlTcNeT4zs6UCg9Gvk5QrFx2QPkRszpM6yc8o0p4aGjCsTi+w==
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.3.tgz#a3add56077ac6cc9396b9502c7252a1635922032"
+  integrity sha512-VT/GK7nvDA7lfHy40G3LKM+ICqmdIsBLBHGXcWD97MtqQEjNMX+7Gudo8YGpaSlYdTX7IFThhCE8Jx09HegymQ==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
# 1.7.0 (2020-04-28)

* Export hashing functions (#1275)
* Add failHard (fail_hard) option in `submit` method (#1029)
* Add type for parseAccountFlags (#1258)
* Add api.connection.getReserveBase() (#1259)
* Travis: remove node 8 (#1257)
* Dependencies
  * Update ripple-address-codec, @types/ws, @types/lodash, https-proxy-agent
  * Update devDependencies: eventemitter2, nyc, ejs, @types/node, webpack, ts-node, prettier, @typescript-eslint/eslint-plugin