### PR TITLE
Fix generateXAddress example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5714,7 +5714,7 @@ secret | secret string | The secret corresponding to the address.
 ### Example
 
 ```javascript
-return api.generateAddress();
+return api.generateXAddress();
 ```
 
 

--- a/docs/src/generateXAddress.md.ejs
+++ b/docs/src/generateXAddress.md.ejs
@@ -17,7 +17,7 @@ This method returns an object with the following structure:
 ### Example
 
 ```javascript
-return api.generateAddress();
+return api.generateXAddress();
 ```
 
 <%- renderFixture('responses/generate-x-address.json') %>


### PR DESCRIPTION
Fixes wrong `generateXAddress` example in API Methods.