### PR TITLE
getSettings: allow ledgerVersion to be validated, closed, or current

### DIFF
--- a/src/ledger/settings.ts
+++ b/src/ledger/settings.ts
@@ -9,7 +9,7 @@ import {Settings} from '../common/constants'
 const AccountFlags = constants.AccountFlags
 
 export type SettingsOptions = {
-  ledgerVersion?: number
+  ledgerVersion?: number | 'validated' | 'closed' | 'current'
 }
 
 export function parseAccountFlags(


### PR DESCRIPTION
Aside from a numeric ledger index, we can also specify  'validated' | 'closed' | 'current'