### PR TITLE
Proposed 1.8.2-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-lib",
-  "version": "1.8.1",
+  "version": "1.8.2-beta.0",
   "license": "ISC",
   "description": "A TypeScript/JavaScript API for interacting with the XRP Ledger in Node.js and the browser",
   "files": [

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -225,18 +225,21 @@ class RequestManager {
   cancel(id: number) {
     const {timer} = this.promisesAwaitingResponse[id]
     clearTimeout(timer)
+    delete this.promisesAwaitingResponse[id]
   }
 
   resolve(id: number, data: any) {
     const {timer, resolve} = this.promisesAwaitingResponse[id]
     clearTimeout(timer)
     resolve(data)
+    delete this.promisesAwaitingResponse[id]
   }
 
   reject(id: number, error: Error) {
     const {timer, reject} = this.promisesAwaitingResponse[id]
     clearTimeout(timer)
     reject(error)
+    delete this.promisesAwaitingResponse[id]
   }
 
   rejectAll(error: Error) {
@@ -278,7 +281,7 @@ class RequestManager {
       throw new ResponseFormatError('valid id not found in response', data)
     }
     if (!this.promisesAwaitingResponse[data.id]) {
-      throw new ResponseFormatError('response handler not found', data)
+      return
     }
     if (data.status === 'error') {
       const error = new RippledError(data.error_message || data.error, data)


### PR DESCRIPTION
Published to npm as 1.8.2-beta.0. https://www.npmjs.com/package/ripple-lib?activeTab=versions

Install it as `ripple-lib@1.8.2-beta.0` or, since it is tagged as `beta`, use `ripple-lib@beta`