### PR TITLE
Fix connectionTimeout option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -177,6 +177,7 @@ Name | Type | Description
 ---- | ---- | -----------
 authorization | string | *Optional* Username and password for HTTP basic authentication to the rippled server in the format **username:password**.
 certificate | string | *Optional* A string containing the certificate key of the client in PEM format. (Can be an array of certificates).
+connectionTimeout | integer | *Optional* Connection timeout, in milliseconds, before considering connect() to have failed.
 feeCushion | number | *Optional* Factor to multiply estimated fee by to provide a cushion in case the required fee rises during submission of a transaction. Defaults to `1.2`.
 key | string | *Optional* A string containing the private key of the client in PEM format. (Can be an array of keys).
 maxFeeXRP | string | *Optional* Maximum fee to use with transactions, in XRP. Must be a string-encoded number. Defaults to `'2'`.
@@ -184,7 +185,7 @@ passphrase | string | *Optional* The passphrase for the private key of the clien
 proxy | uri string | *Optional* URI for HTTP/HTTPS proxy to use to connect to the rippled server.
 proxyAuthorization | string | *Optional* Username and password for HTTP basic authentication to the proxy in the format **username:password**.
 server | uri string | *Optional* URI for rippled websocket port to connect to. Must start with `wss://`, `ws://`, `wss+unix://`, or `ws+unix://`.
-timeout | integer | *Optional* Timeout in milliseconds before considering a request to have failed.
+timeout | integer | *Optional* Request timeout in milliseconds before considering a request to have failed. See also: connectionTimeout.
 trace | boolean | *Optional* If true, log rippled requests and responses to stdout.
 trustedCertificates | array\<string\> | *Optional* Array of PEM-formatted SSL certificates to trust when connecting to a proxy. This is useful if you want to use a self-signed certificate on the proxy server. Note: Each element must contain a single certificate; concatenated certificates are not valid.
 

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -119,7 +119,7 @@ function createWebSocket(url: string, config: ConnectionOptions): WebSocket {
  * ws.send(), but promisified.
  */
 function websocketSendAsync(ws: WebSocket, message: string) {
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     ws.send(message, undefined, (error) => {
       if (error) {
         reject(new DisconnectedError(error.message, error))
@@ -326,7 +326,7 @@ export class Connection extends EventEmitter {
     this._url = url
     this._config = {
       timeout: 20 * 1000,
-      connectionTimeout: 2 * 1000,
+      connectionTimeout: 5 * 1000,
       ...options
     }
     if (typeof options.trace === 'function') {
@@ -488,7 +488,8 @@ export class Connection extends EventEmitter {
       this._onConnectionFailed(
         new ConnectionError(
           `Error: connect() timed out after ${this._config.connectionTimeout} ms. ` +
-            `If your internet connection is working, the rippled server may be blocked or inaccessible.`
+            `If your internet connection is working, the rippled server may be blocked or inaccessible. ` +
+            `You can also try setting the 'connectionTimeout' option in the RippleAPI constructor.`
         )
       )
     }, this._config.connectionTimeout)

--- a/src/common/connection.ts
+++ b/src/common/connection.ts
@@ -27,7 +27,7 @@ export interface ConnectionOptions {
   key?: string
   passphrase?: string
   certificate?: string
-  timeout: number
+  timeout: number // request timeout
   connectionTimeout: number
 }
 

--- a/src/common/schemas/input/api-options.json
+++ b/src/common/schemas/input/api-options.json
@@ -28,7 +28,7 @@
     },
     "timeout": {
       "type": "integer",
-      "description": "Timeout in milliseconds before considering a request to have failed.",
+      "description": "Request timeout in milliseconds before considering a request to have failed. See also: connectionTimeout.",
       "minimum": 1
     },
     "connectionTimeout": {

--- a/src/common/schemas/input/api-options.json
+++ b/src/common/schemas/input/api-options.json
@@ -31,6 +31,11 @@
       "description": "Timeout in milliseconds before considering a request to have failed.",
       "minimum": 1
     },
+    "connectionTimeout": {
+      "type": "integer",
+      "description": "Connection timeout, in milliseconds, before considering connect() to have failed.",
+      "minimum": 1
+    },
     "proxyAuthorization": {
       "type": "string",
       "description": "Username and password for HTTP basic authentication to the proxy in the format **username:password**."


### PR DESCRIPTION
If the rippled server is down or inaccessible, the connect() method could hang for a long time. Previously, a connection timeout was added. The default was 2000 ms. This was too short; slower connections could take longer than that to connect.

This PR changes the default connection timeout to 5000 ms.

The `RippleAPI` constructor was meant to be able to take a `connectionTimeout` option, but the option was missing from the JSON schema (`api-options.json`), so it was not actually allowed to be used.

This PR adds the `connectionTimeout` option to the JSON schema.

Thanks to:
- @southbite 
- @madshell
- @koresar
- @nickewansmith 
- @kincaidoneil 