### PR TITLE
fix #999: use 'current' ledger when preparing txs

### DIFF
--- a/src/transaction/utils.ts
+++ b/src/transaction/utils.ts
@@ -346,9 +346,9 @@ function prepareTransaction(
     }
 
     try {
-      // Consider requesting from the 'current' ledger (instead of 'validated').
       const response = await api.request('account_info', {
-        account: classicAccount
+        account: classicAccount,
+        ledger_index: 'current' // Fix #999
       })
       newTxJSON.Sequence = response.account_data.Sequence
       return Promise.resolve()


### PR DESCRIPTION
See #999 

This should make `tefPAST_SEQ` occur less often, and make the behavior consistent when connecting to a rippled server in Reporting Mode.