### PR TITLE
fix: allow multiple settings at once

### DIFF
--- a/src/transaction/settings.ts
+++ b/src/transaction/settings.ts
@@ -17,9 +17,9 @@ function setTransactionFlags(
   txJSON: TransactionJSON,
   values: FormattedSettings
 ) {
-  const keys = Object.keys(values)
+  const keys = Object.keys(values).filter((key) => AccountFlagIndices[key] !== undefined)
   assert.ok(
-    keys.length === 1,
+    keys.length <= 1,
     'ERROR: can only set one setting per transaction'
   )
   const flagName = keys[0]


### PR DESCRIPTION
Currently, `prepareSettings` only accepts one setting: if you set `domain` and `emailHash`, then `prepareSettings` returns an error:

```
AssertionError [ERR_ASSERTION]: ERROR: can only set one setting per transaction
```

This PR fixes that.