### PR TITLE
Fixes miscommunication with `ripplingDisabled` in trustlines

### DIFF
--- a/src/ledger/parse/account-trustline.ts
+++ b/src/ledger/parse/account-trustline.ts
@@ -14,16 +14,16 @@ function parseAccountTrustline(trustline: Trustline): FormattedTrustline {
     counterparty: trustline.account,
     qualityIn: parseQuality(trustline.quality_in) || undefined,
     qualityOut: parseQuality(trustline.quality_out) || undefined,
-    ripplingDisabled: trustline.no_ripple || undefined,
-    frozen: trustline.freeze || undefined,
-    authorized: trustline.authorized || undefined
+    ripplingDisabled: trustline.no_ripple,
+    frozen: trustline.freeze,
+    authorized: trustline.authorized
   })
   // rippled doesn't provide the counterparty's qualities
   const counterparty = removeUndefined({
     limit: trustline.limit_peer,
-    ripplingDisabled: trustline.no_ripple_peer || undefined,
-    frozen: trustline.freeze_peer || undefined,
-    authorized: trustline.peer_authorized || undefined
+    ripplingDisabled: trustline.no_ripple_peer,
+    frozen: trustline.freeze_peer,
+    authorized: trustline.peer_authorized
   })
   const state = {
     balance: trustline.balance

--- a/test/api/getTrustlines/index.ts
+++ b/test/api/getTrustlines/index.ts
@@ -27,5 +27,14 @@ export default <TestSuite>{
 
   'getTrustlines - no options': async (api, address) => {
     await api.getTrustlines(address)
-  }
+  },
+
+  'getTrustlines - ripplingDisabled works properly': async (api, address) => {
+    const result = await api.getTrustlines(addresses.FOURTH_ACCOUNT)
+    assertResultMatch(
+      result,
+      RESPONSE_FIXTURES.ripplingDisabled,
+      'getTrustlines'
+    )
+  },
 }

--- a/test/fixtures/responses/get-trustlines-rippling-disabled.json
+++ b/test/fixtures/responses/get-trustlines-rippling-disabled.json
@@ -1,0 +1,22 @@
+[
+    {
+      "specification": {
+        "limit": "10000000000",
+        "currency": "ETH",
+        "counterparty": "rEyiXgWXCKsh9wXYRrXCYSgCbR1gj3Xd8b",
+        "ripplingDisabled": true
+      },
+      "counterparty": { "limit": "0", "ripplingDisabled": true },
+      "state": { "balance": "0" }
+    },
+    {
+      "specification": {
+        "limit": "10000000000",
+        "currency": "BTC",
+        "counterparty": "rEyiXgWXCKsh9wXYRrXCYSgCbR1gj3Xd8b",
+        "ripplingDisabled": false
+      },
+      "counterparty": { "limit": "0", "ripplingDisabled": true },
+      "state": { "balance": "0" }
+    }
+  ]

--- a/test/fixtures/responses/index.js
+++ b/test/fixtures/responses/index.js
@@ -102,7 +102,8 @@ module.exports = {
       item: require('./trustline-item.json'),
       count: 401
     }),
-    all: require('./get-trustlines-all.json')
+    all: require('./get-trustlines-all.json'),
+    ripplingDisabled: require('./get-trustlines-rippling-disabled.json')
   },
   getLedger: {
     header: require('./get-ledger'),

--- a/test/fixtures/rippled/account-lines.js
+++ b/test/fixtures/rippled/account-lines.js
@@ -370,3 +370,40 @@ module.exports.manyItems = function(request, options = {}) {
     }
   });
 };
+
+
+module.exports.ripplingDisabled = function(request, options = {}) {
+  _.defaults(options, {
+    ledger: BASE_LEDGER_INDEX
+  });
+
+  return JSON.stringify({
+    id: request.id,
+    status: 'success',
+    type: 'response',
+    result: {
+      account: request.account,
+      marker: options.marker,
+      limit: request.limit,
+      ledger_index: options.ledger,
+      lines: [{'account': 'rEyiXgWXCKsh9wXYRrXCYSgCbR1gj3Xd8b',
+            'balance': '0',
+            'currency': 'ETH',
+            'limit': '10000000000',
+            'limit_peer': '0',
+            'no_ripple': true,
+            'no_ripple_peer': true,
+            'quality_in': 0,
+            'quality_out': 0},
+           {'account': 'rEyiXgWXCKsh9wXYRrXCYSgCbR1gj3Xd8b',
+            'balance': '0',
+            'currency': 'BTC',
+            'limit': '10000000000',
+            'limit_peer': '0',
+            'no_ripple': false,
+            'no_ripple_peer': true,
+            'quality_in': 0,
+            'quality_out': 0}]
+    }
+  });
+};

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -668,6 +668,8 @@ export function createMockRippled(port) {
       conn.send(accountLinesResponse.counterparty(request))
     } else if (request.account === addresses.THIRD_ACCOUNT) {
       conn.send(accountLinesResponse.manyItems(request))
+    } else if (request.account === addresses.FOURTH_ACCOUNT) {
+      conn.send(accountLinesResponse.ripplingDisabled(request))
     } else if (request.account === addresses.NOTFOUND) {
       conn.send(createResponse(request, fixtures.account_info.notfound))
     } else {


### PR DESCRIPTION
## High Level Overview of Change

This PR corrects a miscommunication with `ripplingDisabled`. Initially, it would have the value `undefined` if it was `false`, now it is `false`. The same issue is corrected with `frozen` and `authenticated`.

### Context of Change

Fixes #1317 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test that tests for this behavior, and made sure the other tests were still passing.