### PR TITLE
build: include lodash in webpack build

### DIFF
--- a/test/localintegrationrunner.html
+++ b/test/localintegrationrunner.html
@@ -9,7 +9,6 @@
     <div id="mocha"></div>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="hacks/phantomhacks.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js" integrity="sha512-90vH1Z83AJY9DmlWa8WkjkV79yfS2n2Oxhsi2dZbIv0nC4E6m5AbH8Nh156kkM7JePmqD6tcZsfad1ueoaovww==" crossorigin="anonymous"></script>
     <script src="../build/ripple-latest.js"></script>
     <script>
       if (window.initMochaPhantomJS) {

--- a/test/localintegrationrunner.html
+++ b/test/localintegrationrunner.html
@@ -9,7 +9,7 @@
     <div id="mocha"></div>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="hacks/phantomhacks.js"></script>
-    <script src="./vendor/lodash.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js" integrity="sha512-90vH1Z83AJY9DmlWa8WkjkV79yfS2n2Oxhsi2dZbIv0nC4E6m5AbH8Nh156kkM7JePmqD6tcZsfad1ueoaovww==" crossorigin="anonymous"></script>
     <script src="../build/ripple-latest.js"></script>
     <script>
       if (window.initMochaPhantomJS) {

--- a/test/localintegrationrunner.html
+++ b/test/localintegrationrunner.html
@@ -9,6 +9,7 @@
     <div id="mocha"></div>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="hacks/phantomhacks.js"></script>
+    <script src="./vendor/lodash.min.js"
     <script src="../build/ripple-latest.js"></script>
     <script>
       if (window.initMochaPhantomJS) {

--- a/test/localintegrationrunner.html
+++ b/test/localintegrationrunner.html
@@ -9,7 +9,7 @@
     <div id="mocha"></div>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="hacks/phantomhacks.js"></script>
-    <script src="./vendor/lodash.min.js"
+    <script src="./vendor/lodash.min.js"></script>
     <script src="../build/ripple-latest.js"></script>
     <script>
       if (window.initMochaPhantomJS) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,6 @@ function getDefaultConfiguration() {
   cache: true,
   performance: { hints: false },
   stats: 'errors-only',
-  externals: [{
-    'lodash': '_'
-  }],
   entry: './dist/npm/index.js',
   output: {
     library: 'ripple',


### PR DESCRIPTION
## High Level Overview of Change
Stop excluding lodash from webpack build.

### Context of Change
Previously, we would webpack ripple-latest without lodash, as it is a frequently used library. This really only saves ~80KB, which is not worth the hassle of not packaging these together.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Build 
- [ ] Documentation Updates
- [ ] Release