### PR TITLE
Removed legacy exit code conversion

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -163,11 +163,10 @@ class RippleAPI extends EventEmitter {
       })
       this.connection.on('disconnected', (code) => {
         let finalCode = code
-        // 1005: This is a backwards-compatible fix for this change in the ws library: https://github.com/websockets/ws/issues/1257
         // 4000: Connection uses a 4000 code internally to indicate a manual disconnect/close
-        // TODO: Remove in next major, breaking version
-        if (finalCode === 1005 || finalCode === 4000) {
-          finalCode = 1000
+        // Since 4000 is a normal disconnect reason, we convert this to the standard exit code 1000
+        if (finalCode === 4000) {
+          finalCode = 1000 
         }
         this.emit('disconnected', finalCode)
       })


### PR DESCRIPTION
## High Level Overview of Change

Removed an exit code we were supporting temporarily due to a ws library bug.

### Context of Change

Responding to a TODO left 2 years ago to get rid of the conversion on the next breaking change. 
We were converting exit code 1005 to 1000 to be backwards compatible with old versions of the ws library which were incorrectly exiting with 1000 instead of 1005. (Link to issue: https://github.com/websockets/ws/issues/1257)
 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After

Before we were turning the exit code 1005 

## Test Plan

CI tests pass