### PR TITLE
Fixes ledger version in `getTrustlines`

### DIFF
--- a/src/ledger/trustlines.ts
+++ b/src/ledger/trustlines.ts
@@ -31,7 +31,7 @@ async function getTrustlines(
   // 2. Make Request
   const responses = await this._requestAll('account_lines', {
     account: address,
-    ledger_index: options.ledgerVersion,
+    ledger_index: options.ledgerVersion ?? await this.getLedgerVersion(),
     limit: options.limit,
     peer: options.counterparty
   })

--- a/src/ledger/trustlines.ts
+++ b/src/ledger/trustlines.ts
@@ -31,7 +31,7 @@ async function getTrustlines(
   // 2. Make Request
   const responses = await this._requestAll('account_lines', {
     account: address,
-    ledger_index: await this.getLedgerVersion(),
+    ledger_index: options.ledgerVersion, //await this.getLedgerVersion(),
     limit: options.limit,
     peer: options.counterparty
   })

--- a/src/ledger/trustlines.ts
+++ b/src/ledger/trustlines.ts
@@ -31,7 +31,7 @@ async function getTrustlines(
   // 2. Make Request
   const responses = await this._requestAll('account_lines', {
     account: address,
-    ledger_index: options.ledgerVersion, //await this.getLedgerVersion(),
+    ledger_index: options.ledgerVersion,
     limit: options.limit,
     peer: options.counterparty
   })

--- a/test/api/getTrustlines/index.ts
+++ b/test/api/getTrustlines/index.ts
@@ -37,4 +37,13 @@ export default <TestSuite>{
       'getTrustlines'
     )
   },
+
+  'getTrustlines - ledger version option': async (api, address) => {
+    const result = await api.getTrustlines(addresses.FOURTH_ACCOUNT, {ledgerVersion: 5})
+    assertResultMatch(
+      result,
+      RESPONSE_FIXTURES.moreThan400Items,
+      'getTrustlines'
+    )
+  },
 }

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -669,10 +669,10 @@ export function createMockRippled(port) {
     } else if (request.account === addresses.THIRD_ACCOUNT) {
       conn.send(accountLinesResponse.manyItems(request))
     } else if (request.account === addresses.FOURTH_ACCOUNT) {
-      if (request.ledger_index == null) {
-        conn.send(accountLinesResponse.ripplingDisabled(request))
-      } else {
+      if (request.ledger_index === 5) {
         conn.send(accountLinesResponse.manyItems(request))
+      } else {
+        conn.send(accountLinesResponse.ripplingDisabled(request))
       }
     } else if (request.account === addresses.NOTFOUND) {
       conn.send(createResponse(request, fixtures.account_info.notfound))

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -669,7 +669,11 @@ export function createMockRippled(port) {
     } else if (request.account === addresses.THIRD_ACCOUNT) {
       conn.send(accountLinesResponse.manyItems(request))
     } else if (request.account === addresses.FOURTH_ACCOUNT) {
-      conn.send(accountLinesResponse.ripplingDisabled(request))
+      if (request.ledger_index == null) {
+        conn.send(accountLinesResponse.ripplingDisabled(request))
+      } else {
+        conn.send(accountLinesResponse.manyItems(request))
+      }
     } else if (request.account === addresses.NOTFOUND) {
       conn.send(createResponse(request, fixtures.account_info.notfound))
     } else {


### PR DESCRIPTION
## High Level Overview of Change

`getTrustlines` wasn't using `ledgerVersion` in the options at all, and was instead getting the current ledger version. This PR fixes that.

### Context of Change

Fixes #1501 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

Added a test to check for the correct behavior. CI passes.

<!--
## Future Tasks
For future tasks related to PR.
-->