### PR TITLE
Implements TypeScript types for transaction method requests/responses

### DIFF
--- a/src/models/methods/baseMethod.ts
+++ b/src/models/methods/baseMethod.ts
@@ -23,5 +23,4 @@ export interface BaseResponse {
     error?: string
     request?: Response
     api_version?: number
-    searched_all?: boolean // used in `tx`
 }

--- a/src/models/methods/baseMethod.ts
+++ b/src/models/methods/baseMethod.ts
@@ -23,4 +23,5 @@ export interface BaseResponse {
     error?: string
     request?: Response
     api_version?: number
+    searched_all?: boolean // used in `tx`
 }

--- a/src/models/methods/index.ts
+++ b/src/models/methods/index.ts
@@ -15,6 +15,10 @@ import { PathFindRequest, PathFindResponse } from "./pathFind";
 import { PingRequest, PingResponse } from "./ping";
 import { RandomRequest, RandomResponse } from "./random";
 import { RipplePathFindRequest, RipplePathFindResponse } from "./ripplePathFind";
+import { SubmitRequest, SubmitResponse } from "./submit";
+import { SubmitMultisignedRequest, SubmitMultisignedResponse } from "./submitMultisigned";
+import { TransactionEntryRequest, TransactionEntryResponse } from "./transactionEntry";
+import { TxRequest, TxResponse } from "./tx";
 
 type Request = // account methods
                AccountChannelsRequest 
@@ -26,6 +30,11 @@ type Request = // account methods
              | AccountTxRequest
              | GatewayBalancesRequest
              | NoRippleCheckRequest
+               // transaction methods
+             | SubmitRequest
+             | SubmitMultisignedRequest
+             | TransactionEntryRequest
+             | TxRequest
                // path and order book methods
              | BookOffersRequest
              | DepositAuthorizedRequest
@@ -48,6 +57,11 @@ type Response = // account methods
               | AccountTxResponse
               | GatewayBalancesResponse
               | NoRippleCheckResponse
+                // transaction methods
+              | SubmitResponse
+              | SubmitMultisignedResponse
+              | TransactionEntryResponse
+              | TxResponse
                 // path and order book methods
               | BookOffersResponse
               | DepositAuthorizedResponse
@@ -82,6 +96,15 @@ export {
     GatewayBalancesResponse,
     NoRippleCheckRequest,
     NoRippleCheckResponse,
+    // transaction methods
+    SubmitRequest,
+    SubmitResponse,
+    SubmitMultisignedRequest,
+    SubmitMultisignedResponse,
+    TransactionEntryRequest,
+    TransactionEntryResponse,
+    TxRequest,
+    TxResponse,
     // path and order book methods
     BookOffersRequest,
     BookOffersResponse,

--- a/src/models/methods/submit.ts
+++ b/src/models/methods/submit.ts
@@ -1,0 +1,26 @@
+import { BaseRequest, BaseResponse } from "./baseMethod";
+
+export interface SubmitRequest extends BaseRequest {
+  command: "submit"
+  tx_blob: string
+  fail_hard?: boolean
+}
+
+export interface SubmitResponse extends BaseResponse {
+  result: {
+      engine_result: string
+      engine_result_code: number
+      engine_result_message: string
+      tx_blob: string
+      tx_json: any // TODO: type this properly when we have Transaction types
+      accepted: boolean
+      account_sequence_available: number
+      account_sequence_next: number
+      applied: boolean
+      broadcast: boolean
+      kept: boolean
+      queued: boolean
+      open_ledger_cost: string
+      validated_ledger_index: number
+  }
+}

--- a/src/models/methods/submitMultisigned.ts
+++ b/src/models/methods/submitMultisigned.ts
@@ -1,0 +1,17 @@
+import { BaseRequest, BaseResponse } from "./baseMethod";
+
+export interface SubmitMultisignedRequest extends BaseRequest {
+  command: "submit_multisigned"
+  tx_json: any // TODO: type this properly when we have Transaction types
+  fail_hard?: boolean
+}
+
+export interface SubmitMultisignedResponse extends BaseResponse {
+  result: {
+    engine_result: string
+    engine_result_code: number
+    engine_result_message: string
+    tx_blob: string
+    tx_json: any // TODO: type this properly when we have Transaction types
+  }
+}

--- a/src/models/methods/transactionEntry.ts
+++ b/src/models/methods/transactionEntry.ts
@@ -1,0 +1,19 @@
+import { LedgerIndex } from "../common";
+import { TransactionMetadata } from "../common/transaction";
+import { BaseRequest, BaseResponse } from "./baseMethod";
+
+export interface TransactionEntryRequest extends BaseRequest {
+  command: "transaction_entry"
+  ledger_hash?: string
+  ledger_index?: LedgerIndex
+  tx_hash: string
+}
+
+export interface TransactionEntryResponse extends BaseResponse {
+  result: {
+    ledger_hash: string
+    ledger_index: number
+    metadata: TransactionMetadata
+    tx_json: any // TODO: type this properly when we have Transaction types
+  }
+}

--- a/src/models/methods/tx.ts
+++ b/src/models/methods/tx.ts
@@ -1,0 +1,19 @@
+import { TransactionMetadata } from "../common/transaction";
+import { BaseRequest, BaseResponse } from "./baseMethod";
+
+export interface TxRequest extends BaseRequest {
+  command: "tx"
+  transaction: string
+  binary?: boolean
+  min_ledger?: number
+  max_ledger?: number
+}
+
+export interface TxResponse extends BaseResponse {
+  result: {
+    hash: string
+    ledger_index: number
+    meta: TransactionMetadata | string
+    validated?: boolean
+  } // TODO: needs to be `& Transaction` once that type is available
+}

--- a/src/models/methods/tx.ts
+++ b/src/models/methods/tx.ts
@@ -16,4 +16,5 @@ export interface TxResponse extends BaseResponse {
     meta: TransactionMetadata | string
     validated?: boolean
   } // TODO: needs to be `& Transaction` once that type is available
+  searched_all?: boolean
 }


### PR DESCRIPTION
## High Level Overview of Change

This PR creates new TypeScript types for all rippled transaction methods (https://xrpl.org/transaction-methods.html), and the request shapes and response shapes. `sign` and `sign_for` are purposely excluded, because the library has offline signing functionality, and it is unadvised to use those methods unless you are running your own rippled server.

### Context of Change

xrpl.js v2.0 models

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

This PR doesn't change any existing code, so tests are fine.

<!--
## Future Tasks
For future tasks related to PR.
-->