### PR TITLE
Update sign docs with more info about keypairs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5659,8 +5659,8 @@ Name | Type | Description
 ---- | ---- | -----------
 txJSON | string | Transaction represented as a JSON string in rippled format.
 keypair | object | *Optional* The private and public key of the account that is initiating the transaction. (This field cannot be used with secret).
-*keypair.* privateKey | privateKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key. Ed25519 keys are prefixed with 0xED. You can read more about how keys are derived [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
-*keypair.* publicKey | publicKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key. Ed25519 keys are prefixed with 0xED. You can read about how keys are derived [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
+*keypair.* privateKey | privateKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key. Ed25519 keys are prefixed with 0xED. You can read about how keys are derived [here](https://xrpl.org/cryptographic-keys.html).
+*keypair.* publicKey | publicKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key. Ed25519 keys are prefixed with 0xED. You can read about how keys are derived [here](https://xrpl.org/cryptographic-keys.html).
 options | object | *Optional* Options that control the type of signature to create.
 *options.* signAs | [address](#address) | *Optional* The account that the signature should count for in multisigning.
 secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field cannot be used with keypair).
@@ -5694,7 +5694,9 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 }
 ```
 
+
 ### Example Keypairs
+
 To learn how keypairs are derived read [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
 ```javascript
 // secp25519 (33 bytes)
@@ -5757,7 +5759,7 @@ const multiSignPaymentTransaction = {
 };
 
 const multiSignPaymentInstruction = {
-    signersCount: 2
+  signersCount: 2
 };
 
 const api = new RippleAPI({

--- a/docs/index.md
+++ b/docs/index.md
@@ -5659,8 +5659,8 @@ Name | Type | Description
 ---- | ---- | -----------
 txJSON | string | Transaction represented as a JSON string in rippled format.
 keypair | object | *Optional* The private and public key of the account that is initiating the transaction. (This field cannot be used with secret).
-*keypair.* privateKey | privateKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key.
-*keypair.* publicKey | publicKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key.
+*keypair.* privateKey | privateKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key. Ed25519 keys are prefixed with 0xED. You can read more about how keys are derived [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
+*keypair.* publicKey | publicKey | The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key. Ed25519 keys are prefixed with 0xED. You can read about how keys are derived [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
 options | object | *Optional* Options that control the type of signature to create.
 *options.* signAs | [address](#address) | *Optional* The account that the signature should count for in multisigning.
 secret | secret string | *Optional* The secret of the account that is initiating the transaction. (This field cannot be used with keypair).
@@ -5694,6 +5694,17 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 }
 ```
 
+### Example Keypairs
+To learn how keypairs are derived read [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
+```javascript
+// secp25519 (33 bytes)
+const privateKey = "002512BBDFDBB77510883B7DCCBEF270B86DEAC8B64AC762873D75A1BEE6298665"
+const publicKey = "0390A196799EE412284A5D80BF78C3E84CBB80E1437A0AECD9ADF94D7FEAAFA284"
+
+// ed25519 (Note the 0xED prefixes a 32 byte value for a total of 33 bytes)
+const privateKey = "ED0B6CBAC838DFE7F47EA1BD0DF00EC282FDF45510C92161072CCFB84035390C4D"
+const publicKey = "ED1A7C082846CFF58FF9A892BA4BA2593151CCF1DBA59F37714CC9ED39824AF85F"
+```
 
 ### Example (multi-signing)
 

--- a/docs/src/sign.md.ejs
+++ b/docs/src/sign.md.ejs
@@ -35,6 +35,19 @@ return api.sign(txJSON, secret); // or: api.sign(txJSON, keypair);
 
 <%- renderFixture("responses/sign.json") %>
 
+### Example Keypairs
+
+To learn how keypairs are derived read [here](https://xrpl.org/cryptographic-keys.html#generating-keys).
+```javascript
+// secp25519 (33 bytes)
+const privateKey = "002512BBDFDBB77510883B7DCCBEF270B86DEAC8B64AC762873D75A1BEE6298665"
+const publicKey = "0390A196799EE412284A5D80BF78C3E84CBB80E1437A0AECD9ADF94D7FEAAFA284"
+
+// ed25519 (Note the 0xED prefixes a 32 byte value for a total of 33 bytes)
+const privateKey = "ED0B6CBAC838DFE7F47EA1BD0DF00EC282FDF45510C92161072CCFB84035390C4D"
+const publicKey = "ED1A7C082846CFF58FF9A892BA4BA2593151CCF1DBA59F37714CC9ED39824AF85F"
+```
+
 ### Example (multi-signing)
 
 ```javascript

--- a/src/common/schemas/input/sign.json
+++ b/src/common/schemas/input/sign.json
@@ -17,11 +17,11 @@
       "properties": {
         "privateKey": {
           "type": "privateKey",
-          "description": "The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key."
+          "description": "The uppercase hexadecimal representation of the secp256k1 or Ed25519 private key. Ed25519 keys are prefixed with 0xED. You can read about how keys are derived [here](https://xrpl.org/cryptographic-keys.html)."
         },
         "publicKey": {
           "type": "publicKey",
-          "description": "The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key."
+          "description": "The uppercase hexadecimal representation of the secp256k1 or Ed25519 public key. Ed25519 keys are prefixed with 0xED. You can read about how keys are derived [here](https://xrpl.org/cryptographic-keys.html)."
         }
       },
       "description": "The private and public key of the account that is initiating the transaction. (This field cannot be used with secret).",


### PR DESCRIPTION
## High Level Overview of Change

* Added examples of what private and public keypairs look like for the sign method to give readers an intuition for the data type
* Added links to how keypairs are derived in rippled and ripple-lib so that they can dive deeper if they want to

Fixes #1045 

### Context of Change

This is in response to #1045 to improve the documentation's covering of the two encodings ed25519 and secp256k1. 
There are also several changes being made in the xrpl-dev-portal to add examples of the keys to their derivation to help developers see what the keys actually look like.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Documentation Updates

## Before / After

Added links in the public key/private key fields for the sign api, and added an example of what keypairs look like in the two formats.

## Test Plan

No tests for docs change.