### PR TITLE
fix: websocket wouldn't close properly on erroring test

### DIFF
--- a/src/client/connection.ts
+++ b/src/client/connection.ts
@@ -401,10 +401,10 @@ export class Connection extends EventEmitter {
         this.emit('error', 'websocket', error.message, error)
       )
       // Handle a closed connection: reconnect if it was unexpected
-      this._ws.once('close', (code) => {
+      this._ws.once('close', (code, reason) => {
         this._clearHeartbeatInterval()
         this._requestManager.rejectAll(
-          new DisconnectedError('websocket was closed')
+          new DisconnectedError(`websocket was closed, ${reason}`)
         )
         this._ws.removeAllListeners()
         this._ws = null

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -232,7 +232,7 @@ class Client extends EventEmitter {
       // 4000: Connection uses a 4000 code internally to indicate a manual disconnect/close
       // Since 4000 is a normal disconnect reason, we convert this to the standard exit code 1000
       if (finalCode === 4000) {
-        finalCode = 1000 
+        finalCode = 1000
       }
       this.emit('disconnected', finalCode)
     })

--- a/test/connection-test.ts
+++ b/test/connection-test.ts
@@ -572,4 +572,13 @@ describe('Connection', function () {
       data: {disconnectIn: 5}
     })
   })
+
+  it('should not crash on error', async function (done) {
+    this.mockRippled.suppressOutput = true
+    this.client.connection.request({
+      command: 'test_garbage'
+    })
+    .then(() => new Error('Should not have succeeded'))
+    .catch(done())
+  })
 })

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -95,7 +95,7 @@ export function createMockRippled(port) {
         mock.emit('request_' + request.command, request, conn)
       } catch (err) {
         console.error('Error: ' + err.message)
-        assert(false, err.message)
+        conn.close(4000, err.message)
       }
     })
   })

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -81,6 +81,8 @@ export function createMockRippled(port) {
     mock.expectedRequests = expectedRequests
   }
 
+  mock.suppressOutput = false
+
   mock.on('connection', function (this: MockedWebSocketServer, conn: any) {
     if (mock.config.breakNextConnection) {
       mock.config.breakNextConnection = false
@@ -94,7 +96,8 @@ export function createMockRippled(port) {
         const request = JSON.parse(requestJSON)
         mock.emit('request_' + request.command, request, conn)
       } catch (err) {
-        console.error('Error: ' + err.message)
+        if (!mock.suppressOutput)
+          console.error('Error: ' + err.message)
         conn.close(4000, err.message)
       }
     })


### PR DESCRIPTION
## High Level Overview of Change

When a test failed because of an error in its code, the `afterEach` script would fail because the websocket wouldn't properly disconnect. This fixes that problem. A different error is thrown, but it's also pretty descriptive, so it's fine.

### Context of Change

test cleanup

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.