### PR TITLE
refactor: addResponse method on mock server object

### DIFF
--- a/test/broadcast-client-test.ts
+++ b/test/broadcast-client-test.ts
@@ -4,7 +4,6 @@ import setupClient from './setup-client'
 import responses from './fixtures/responses'
 import rippled from './fixtures/rippled'
 import {ignoreWebSocketDisconnect} from './utils'
-import { addRippledResponse } from './mock-rippled'
 
 const TIMEOUT = 20000
 
@@ -24,7 +23,7 @@ describe('BroadcastClient', function () {
 
   it('base', function () {
     this.mocks.forEach((mock) => {
-      addRippledResponse(mock, {command: 'server_info'}, rippled.server_info.normal)
+      mock.addResponse({command: 'server_info'}, rippled.server_info.normal)
     })
     const expected = {request_server_info: 1}
     this.mocks.forEach((mock) => mock.expect(Object.assign({}, expected)))

--- a/test/client/getFee/index.ts
+++ b/test/client/getFee/index.ts
@@ -1,5 +1,4 @@
 import assert from 'assert-diff'
-import { addRippledResponse } from '../../mock-rippled'
 import rippled from '../../fixtures/rippled'
 import {TestSuite} from '../../utils'
 
@@ -10,13 +9,13 @@ import {TestSuite} from '../../utils'
  */
 export default <TestSuite>{
   'getFee': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const fee = await client.getFee()
     assert.strictEqual(fee, '0.000012')
   },
 
   'getFee default': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = undefined
     const fee = await client.getFee()
     assert.strictEqual(fee, '0.000012')
@@ -24,13 +23,13 @@ export default <TestSuite>{
 
   'getFee - high load_factor': async (client, address, mockRippled) => {
     
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.highLoadFactor)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.highLoadFactor)
     const fee = await client.getFee()
     assert.strictEqual(fee, '2')
   },
 
   'getFee - high load_factor with custom maxFeeXRP': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.highLoadFactor)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.highLoadFactor)
     // Ensure that overriding with high maxFeeXRP of '51540' causes no errors.
     // (fee will actually be 51539.607552)
     client._maxFeeXRP = '51540'
@@ -39,7 +38,7 @@ export default <TestSuite>{
   },
 
   'getFee custom cushion': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1.4
     const fee = await client.getFee()
     assert.strictEqual(fee, '0.000014')
@@ -48,14 +47,14 @@ export default <TestSuite>{
   // This is not recommended since it may result in attempting to pay
   // less than the base fee. However, this test verifies the existing behavior.
   'getFee cushion less than 1.0': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 0.9
     const fee = await client.getFee()
     assert.strictEqual(fee, '0.000009')
   },
 
   'getFee reporting': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const fee = await client.getFee()
     assert.strictEqual(fee, '0.000012')
   }

--- a/test/client/prepareCheckCancel/index.ts
+++ b/test/client/prepareCheckCancel/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'prepareCheckCancel': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareCheckCancel(
       address,
       requests.prepareCheckCancel.normal
@@ -21,7 +20,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/prepareCheckCash/index.ts
+++ b/test/client/prepareCheckCash/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'prepareCheckCash amount': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareCheckCash(
       address,
       requests.prepareCheckCash.amount
@@ -21,7 +20,7 @@ export default <TestSuite>{
   },
 
   'prepareCheckCash deliverMin': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareCheckCash(
       address,
       requests.prepareCheckCash.deliverMin
@@ -30,7 +29,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/prepareCheckCreate/index.ts
+++ b/test/client/prepareCheckCreate/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'prepareCheckCreate': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -26,7 +25,7 @@ export default <TestSuite>{
   },
 
   'prepareCheckCreate full': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareCheckCreate(
       address,
       requests.prepareCheckCreate.full
@@ -35,7 +34,7 @@ export default <TestSuite>{
   },
 
   'prepareCheckCreate with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/prepareEscrowCancellation/index.ts
+++ b/test/client/prepareEscrowCancellation/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'prepareEscrowCancellation': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareEscrowCancellation(
       address,
       requests.prepareEscrowCancellation.normal,
@@ -26,7 +25,7 @@ export default <TestSuite>{
   },
 
   'prepareEscrowCancellation with memos': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareEscrowCancellation(
       address,
       requests.prepareEscrowCancellation.memos
@@ -39,7 +38,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/prepareEscrowCreation/index.ts
+++ b/test/client/prepareEscrowCreation/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertRejects, assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -19,7 +18,7 @@ export const config = {
  */
 export default <TestSuite>{
   'prepareEscrowCreation': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -33,7 +32,7 @@ export default <TestSuite>{
   },
 
   'prepareEscrowCreation full': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareEscrowCreation(
       address,
       requests.prepareEscrowCreation.full
@@ -42,7 +41,7 @@ export default <TestSuite>{
   },
 
   'prepareEscrowCreation - invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const escrow = Object.assign({}, requests.prepareEscrowCreation.full)
     delete escrow.amount // Make invalid
     await assertRejects(
@@ -53,7 +52,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000396',

--- a/test/client/prepareEscrowExecution/index.ts
+++ b/test/client/prepareEscrowExecution/index.ts
@@ -2,7 +2,6 @@ import {TestSuite, assertRejects, assertResultMatch} from '../../utils'
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
 /**
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'prepareEscrowExecution': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareEscrowExecution(
       address,
       requests.prepareEscrowExecution.normal,
@@ -26,7 +25,7 @@ export default <TestSuite>{
   },
 
   'prepareEscrowExecution - simple': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareEscrowExecution(
       address,
       requests.prepareEscrowExecution.simple
@@ -39,7 +38,7 @@ export default <TestSuite>{
   },
 
   'prepareEscrowExecution - no condition': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     await assertRejects(
       client.prepareEscrowExecution(
         address,
@@ -52,7 +51,7 @@ export default <TestSuite>{
   },
 
   'prepareEscrowExecution - no fulfillment': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     await assertRejects(
       client.prepareEscrowExecution(
         address,
@@ -65,7 +64,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000396',

--- a/test/client/prepareOrder/index.ts
+++ b/test/client/prepareOrder/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertRejects, assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,14 +11,14 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'buy order': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrder.buy
     const result = await client.prepareOrder(address, request)
     assertResultMatch(result, responses.prepareOrder.buy, 'prepare')
   },
 
   'buy order with expiration': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrder.expiration
     const response = responses.prepareOrder.expiration
     const result = await client.prepareOrder(
@@ -31,7 +30,7 @@ export default <TestSuite>{
   },
 
   'sell order': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrder.sell
     const result = await client.prepareOrder(
       address,
@@ -42,7 +41,7 @@ export default <TestSuite>{
   },
 
   'invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = Object.assign({}, requests.prepareOrder.sell)
     delete request.direction // Make invalid
     await assertRejects(
@@ -57,7 +56,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrder.sell
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,

--- a/test/client/prepareOrderCancellation/index.ts
+++ b/test/client/prepareOrderCancellation/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertRejects, assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'prepareOrderCancellation': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrderCancellation.simple
     const result = await client.prepareOrderCancellation(
       address,
@@ -27,7 +26,7 @@ export default <TestSuite>{
   },
 
   'no instructions': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrderCancellation.simple
     const result = await client.prepareOrderCancellation(address, request)
     assertResultMatch(
@@ -38,7 +37,7 @@ export default <TestSuite>{
   },
 
   'with memos': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrderCancellation.withMemos
     const result = await client.prepareOrderCancellation(address, request)
     assertResultMatch(
@@ -49,7 +48,7 @@ export default <TestSuite>{
   },
 
   'invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = Object.assign(
       {},
       requests.prepareOrderCancellation.withMemos
@@ -64,7 +63,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const request = requests.prepareOrderCancellation.simple
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,

--- a/test/client/preparePayment/index.ts
+++ b/test/client/preparePayment/index.ts
@@ -1,7 +1,6 @@
 import {assertResultMatch, TestSuite, assertRejects} from '../../utils'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import requests from '../../fixtures/requests'
 import {ValidationError} from 'xrpl-local/common/errors'
 import binary from 'ripple-binary-codec'
@@ -21,7 +20,7 @@ const RECIPIENT_ADDRESS = 'rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo'
  */
 export default <TestSuite>{
   'normal': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -35,7 +34,7 @@ export default <TestSuite>{
   },
 
   'min amount xrp': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -49,7 +48,7 @@ export default <TestSuite>{
   },
 
   'min amount xrp2xrp': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const response = await client.preparePayment(
       address,
       REQUEST_FIXTURES.minAmount,
@@ -59,7 +58,7 @@ export default <TestSuite>{
   },
 
   'XRP to XRP': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = {
       source: {
         address: 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59',
@@ -88,7 +87,7 @@ export default <TestSuite>{
   },
 
   'XRP drops to XRP drops': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = {
       source: {
         address: 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59',
@@ -117,7 +116,7 @@ export default <TestSuite>{
   },
 
   'XRP drops to XRP': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = {
       source: {
         address: 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59',
@@ -146,7 +145,7 @@ export default <TestSuite>{
   },
 
   'XRP to XRP drops': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = {
       source: {
         address: 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59',
@@ -180,7 +179,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = {
       source: {
         address: address,
@@ -205,7 +204,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     // Marking as "any" to get around the fact that TS won't allow this.
     const payment: any = {
       source: {address: address},
@@ -227,7 +226,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = {
       source: {
         address: address,
@@ -246,7 +245,7 @@ export default <TestSuite>{
   },
 
   'XRP to XRP no partial': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     return assertRejects(
       client.preparePayment(address, REQUEST_FIXTURES.wrongPartial),
       ValidationError,
@@ -255,7 +254,7 @@ export default <TestSuite>{
   },
 
   'address must match payment.source.address': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     return assertRejects(
       client.preparePayment(address, REQUEST_FIXTURES.wrongAddress),
       ValidationError,
@@ -264,7 +263,7 @@ export default <TestSuite>{
   },
 
   'wrong amount': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     return assertRejects(
       client.preparePayment(address, REQUEST_FIXTURES.wrongAmount),
       ValidationError,
@@ -273,7 +272,7 @@ export default <TestSuite>{
   },
 
   'throws when fee exceeds 2 XRP': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       fee: '2.1'
@@ -301,7 +300,7 @@ export default <TestSuite>{
   // },
 
   'preparePayment without counterparty set': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       sequence: 23
@@ -319,7 +318,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     // See also: 'sign succeeds with source.amount/destination.minAmount'
 
     const localInstructions = {
@@ -369,7 +368,7 @@ export default <TestSuite>{
   },
 
   'destination.minAmount': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const response = await client.preparePayment(
       address,
       responses.getPaths.sendAll[0],
@@ -379,7 +378,7 @@ export default <TestSuite>{
   },
 
   'caps fee at 2 XRP by default': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
     const expectedResponse = {
       txJSON:
@@ -403,7 +402,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._maxFeeXRP = '2.2'
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
@@ -427,7 +426,7 @@ export default <TestSuite>{
   },
 
   'fee - default maxFee of 2 XRP': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
     const expectedResponse = {
       txJSON:
@@ -451,7 +450,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
     client._maxFeeXRP = '3'
     const localInstructions = {
@@ -476,7 +475,7 @@ export default <TestSuite>{
   },
 
   'fee - capped to maxFee': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
     client._maxFeeXRP = '5'
     const localInstructions = {

--- a/test/client/preparePaymentChannelClaim/index.ts
+++ b/test/client/preparePaymentChannelClaim/index.ts
@@ -2,7 +2,6 @@ import assert from 'assert-diff'
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 const {preparePaymentChannelClaim: REQUEST_FIXTURES} = requests
@@ -15,7 +14,7 @@ const {preparePaymentChannelClaim: RESPONSE_FIXTURES} = responses
  */
 export default <TestSuite>{
   'default': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -29,7 +28,7 @@ export default <TestSuite>{
   },
 
   'with renew': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -43,7 +42,7 @@ export default <TestSuite>{
   },
 
   'with close': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -57,7 +56,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -76,7 +75,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     try {
       const prepared = await client.preparePaymentChannelClaim(
         address,
@@ -100,7 +99,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     try {
       const prepared = await client.preparePaymentChannelClaim(
         address,

--- a/test/client/preparePaymentChannelCreate/index.ts
+++ b/test/client/preparePaymentChannelCreate/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -19,7 +18,7 @@ export const config = {
  */
 export default <TestSuite>{
   'preparePaymentChannelCreate': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -37,7 +36,7 @@ export default <TestSuite>{
   },
 
   'preparePaymentChannelCreate full': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.preparePaymentChannelCreate(
       address,
       requests.preparePaymentChannelCreate.full
@@ -50,7 +49,7 @@ export default <TestSuite>{
   },
 
   'preparePaymentChannelCreate with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/preparePaymentChannelFund/index.ts
+++ b/test/client/preparePaymentChannelFund/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'preparePaymentChannelFund': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -30,7 +29,7 @@ export default <TestSuite>{
   },
 
   'preparePaymentChannelFund full': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.preparePaymentChannelFund(
       address,
       requests.preparePaymentChannelFund.full
@@ -43,7 +42,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/prepareSettings/index.ts
+++ b/test/client/prepareSettings/index.ts
@@ -2,7 +2,6 @@ import assert from 'assert-diff'
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -13,7 +12,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'simple test': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const response = await client.prepareSettings(
       address,
       requests.prepareSettings.domain,
@@ -22,7 +21,7 @@ export default <TestSuite>{
     assertResultMatch(response, responses.prepareSettings.flags, 'prepare')
   },
   'no maxLedgerVersion': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const response = await client.prepareSettings(
       address,
       requests.prepareSettings.domain,
@@ -37,7 +36,7 @@ export default <TestSuite>{
     )
   },
   'no instructions': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const response = await client.prepareSettings(
       address,
       requests.prepareSettings.domain
@@ -49,7 +48,7 @@ export default <TestSuite>{
     )
   },
   'regularKey': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const regularKey = {regularKey: 'rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD'}
     const response = await client.prepareSettings(
       address,
@@ -59,7 +58,7 @@ export default <TestSuite>{
     assertResultMatch(response, responses.prepareSettings.regularKey, 'prepare')
   },
   'remove regularKey': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const regularKey = {regularKey: null}
     const response = await client.prepareSettings(
       address,
@@ -73,7 +72,7 @@ export default <TestSuite>{
     )
   },
   'flag set': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = {requireDestinationTag: true}
     const response = await client.prepareSettings(
       address,
@@ -83,7 +82,7 @@ export default <TestSuite>{
     assertResultMatch(response, responses.prepareSettings.flagSet, 'prepare')
   },
   'flag clear': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = {requireDestinationTag: false}
     const response = await client.prepareSettings(
       address,
@@ -93,7 +92,7 @@ export default <TestSuite>{
     assertResultMatch(response, responses.prepareSettings.flagClear, 'prepare')
   },
   'set depositAuth flag': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = {depositAuth: true}
     const response = await client.prepareSettings(
       address,
@@ -107,7 +106,7 @@ export default <TestSuite>{
     )
   },
   'clear depositAuth flag': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = {depositAuth: false}
     const response = await client.prepareSettings(
       address,
@@ -121,7 +120,7 @@ export default <TestSuite>{
     )
   },
   'integer field clear': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = {transferRate: null}
     const response = await client.prepareSettings(
       address,
@@ -132,7 +131,7 @@ export default <TestSuite>{
     assert.strictEqual(JSON.parse(response.txJSON).TransferRate, 0)
   },
   'set transferRate': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = {transferRate: 1}
     const response = await client.prepareSettings(
       address,
@@ -146,7 +145,7 @@ export default <TestSuite>{
     )
   },
   'set signers': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = requests.prepareSettings.signers.normal
     const response = await client.prepareSettings(
       address,
@@ -156,7 +155,7 @@ export default <TestSuite>{
     assertResultMatch(response, responses.prepareSettings.signers, 'prepare')
   },
   'signers no threshold': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = requests.prepareSettings.signers.noThreshold
     try {
       const response = await client.prepareSettings(
@@ -177,7 +176,7 @@ export default <TestSuite>{
     }
   },
   'signers no weights': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = requests.prepareSettings.signers.noWeights
     const localInstructions = {
       signersCount: 1,
@@ -191,7 +190,7 @@ export default <TestSuite>{
     assertResultMatch(response, responses.prepareSettings.noWeights, 'prepare')
   },
   'fee for multisign': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       signersCount: 4,
       ...instructionsWithMaxLedgerVersionOffset
@@ -208,7 +207,7 @@ export default <TestSuite>{
     )
   },
   'no signer list': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const settings = requests.prepareSettings.noSignerEntries
     const localInstructions = {
       signersCount: 1,
@@ -226,7 +225,7 @@ export default <TestSuite>{
     )
   },
   'invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     // domain must be a string
     const settings = Object.assign({}, requests.prepareSettings.domain, {
       domain: 123
@@ -255,7 +254,7 @@ export default <TestSuite>{
     }
   },
   'offline': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const secret = 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV'
 
     const settings = requests.prepareSettings.domain
@@ -272,7 +271,7 @@ export default <TestSuite>{
     )
   },
   'prepare settings with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const instructions = {
       ticketSequence: 23,
       maxLedgerVersion: 8820051,

--- a/test/client/prepareTicket/index.ts
+++ b/test/client/prepareTicket/index.ts
@@ -1,7 +1,6 @@
 import {assertResultMatch, TestSuite} from '../../utils'
 // import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 // import requests from '../../fixtures/requests'
 // import {ValidationError} from 'xrpl-local/common/errors'
 // import binary from 'ripple-binary-codec'
@@ -25,7 +24,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const expected = {
       txJSON:
         '{"TransactionType":"TicketCreate", "TicketCount": 2, "Account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59","Flags":2147483648,"LastLedgerSequence":8819954,"Sequence":23,"Fee":"12"}',
@@ -40,7 +39,7 @@ export default <TestSuite>{
   },
 
   'creates a ticket successfully with another ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const expected = {
       txJSON:
         '{"TransactionType":"TicketCreate", "TicketCount": 1, "Account":"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59","Flags":2147483648,"LastLedgerSequence":8819954,"Sequence": 0,"TicketSequence":23,"Fee":"12"}',

--- a/test/client/prepareTransaction/index.ts
+++ b/test/client/prepareTransaction/index.ts
@@ -2,7 +2,6 @@ import {ValidationError} from 'xrpl-local/common/errors'
 // import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertRejects, assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -24,7 +23,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = instructionsWithMaxLedgerVersionOffset
     const txJSON = {
       TransactionType: 'DepositPreauth',
@@ -45,7 +44,7 @@ export default <TestSuite>{
   },
 
   'does not overwrite Fee in Instructions': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       fee: '0.000014' // CAUTION: This `fee` is specified in XRP, not drops.
@@ -72,7 +71,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       fee: '0.000016'
@@ -95,7 +94,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       fee: '0.000018'
@@ -118,7 +117,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       Fee: '0.000022' // Intentionally capitalized in this test, but the correct field would be `fee`
@@ -140,7 +139,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = instructionsWithMaxLedgerVersionOffset
     const txJSON = {
       TransactionType: 'DepositPreauth',
@@ -156,7 +155,7 @@ export default <TestSuite>{
   },
 
   'does not overwrite Sequence in txJSON': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -180,7 +179,7 @@ export default <TestSuite>{
   },
 
   'does not overwrite Sequence in Instructions': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -208,7 +207,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -237,7 +236,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -261,7 +260,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -282,7 +281,7 @@ export default <TestSuite>{
   // LastLedgerSequence aka maxLedgerVersion/maxLedgerVersionOffset:
 
   'does not overwrite LastLedgerSequence in txJSON': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {}
     const txJSON = {
       TransactionType: 'DepositPreauth',
@@ -308,7 +307,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       maxLedgerVersion: 8890000
     }
@@ -334,7 +333,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxLedgerVersionOffset: 124
@@ -361,7 +360,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       maxLedgerVersion: 8900000
     }
@@ -384,7 +383,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxLedgerVersionOffset: 123
@@ -408,7 +407,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxLedgerVersion: 8900000,
@@ -432,7 +431,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxLedgerVersion: 8900000,
@@ -457,7 +456,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       MaxLedgerVersion: 8900000 // Intentionally capitalized in this test, but the correct field would be `maxLedgerVersion`
@@ -479,7 +478,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = instructionsWithMaxLedgerVersionOffset
     const txJSON = {
       TransactionType: 'DepositPreauth',
@@ -499,7 +498,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = instructionsWithMaxLedgerVersionOffset
     const txJSON = {
       TransactionType: 'DepositPreauth',
@@ -519,7 +518,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = instructionsWithMaxLedgerVersionOffset
     const txJSON = {
       TransactionType: 'DepositPreauth',
@@ -543,7 +542,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -562,7 +561,7 @@ export default <TestSuite>{
   },
 
   'rejects Promise when Account is missing': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -580,7 +579,7 @@ export default <TestSuite>{
   },
 
   'rejects Promise when Account is not a string': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -599,7 +598,7 @@ export default <TestSuite>{
   },
 
   'rejects Promise when Account is invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -636,7 +635,7 @@ export default <TestSuite>{
   // },
 
   'rejects Promise when TransactionType is missing': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -659,7 +658,7 @@ export default <TestSuite>{
   //
   // at Function.from (ripple-binary-codec/distrib/npm/enums/index.js:43:15)
   'prepares tx when TransactionType is invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -686,7 +685,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -725,7 +724,7 @@ export default <TestSuite>{
   //    hash:
   //     'C181D470684311658852713DA81F8201062535C8DE2FF853F7DD9981BB85312F' } })]
   'prepares tx when a required field is missing': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -748,7 +747,7 @@ export default <TestSuite>{
   },
 
   'DepositPreauth - Authorize': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -774,7 +773,7 @@ export default <TestSuite>{
   },
 
   'DepositPreauth - Unauthorize': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -802,7 +801,7 @@ export default <TestSuite>{
   },
 
   'AccountDelete': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '5.0' // 5 XRP fee for AccountDelete
@@ -831,7 +830,7 @@ export default <TestSuite>{
 
   // prepareTransaction - Payment
   'Payment - normal': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -859,7 +858,7 @@ export default <TestSuite>{
   },
 
   'min amount xrp': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -892,7 +891,7 @@ export default <TestSuite>{
   },
 
   'min amount xrp2xrp': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const txJSON = {
       TransactionType: 'Payment',
       Account: address,
@@ -954,7 +953,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
 
     const txJSON = {
@@ -993,7 +992,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
 
     const txJSON = {
@@ -1037,7 +1036,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
     client._maxFeeXRP = '3'
     const localInstructions = {
@@ -1078,7 +1077,7 @@ export default <TestSuite>{
 
   // prepareTransaction - Payment
   'fee is capped to maxFee': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     client._feeCushion = 1000000
     client._maxFeeXRP = '5'
     const localInstructions = {
@@ -1146,7 +1145,7 @@ export default <TestSuite>{
 
 
   'xaddress-issuer': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -1174,7 +1173,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelCreate': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -1204,7 +1203,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelCreate full': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const txJSON = {
       Account: address,
       TransactionType: 'PaymentChannelCreate',
@@ -1227,7 +1226,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelFund': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -1248,7 +1247,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelFund full': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const txJSON = {
       Account: address,
       TransactionType: 'PaymentChannelFund',
@@ -1267,7 +1266,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelClaim': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -1290,7 +1289,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelClaim with renew': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -1320,7 +1319,7 @@ export default <TestSuite>{
   },
 
   'PaymentChannelClaim with close': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012'
@@ -1354,7 +1353,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ticketSequence: 23,
       sequence: 23
@@ -1373,7 +1372,7 @@ export default <TestSuite>{
   },
 
   'sets sequence to 0 if a ticketSequence is passed': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',
@@ -1406,7 +1405,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/prepareTrustline/index.ts
+++ b/test/client/prepareTrustline/index.ts
@@ -1,7 +1,6 @@
 import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {assertRejects, assertResultMatch, TestSuite} from '../../utils'
 const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
 
@@ -12,7 +11,7 @@ const instructionsWithMaxLedgerVersionOffset = {maxLedgerVersionOffset: 100}
  */
 export default <TestSuite>{
   'simple': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareTrustline(
       address,
       requests.prepareTrustline.simple,
@@ -22,7 +21,7 @@ export default <TestSuite>{
   },
 
   'frozen': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareTrustline(
       address,
       requests.prepareTrustline.frozen
@@ -31,7 +30,7 @@ export default <TestSuite>{
   },
 
   'complex': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareTrustline(
       address,
       requests.prepareTrustline.complex,
@@ -41,7 +40,7 @@ export default <TestSuite>{
   },
 
   'invalid': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const trustline = Object.assign({}, requests.prepareTrustline.complex)
     delete trustline.limit // Make invalid
 
@@ -57,7 +56,7 @@ export default <TestSuite>{
   },
 
   'xaddress-issuer': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const result = await client.prepareTrustline(
       address,
       requests.prepareTrustline.issuedXAddress,
@@ -67,7 +66,7 @@ export default <TestSuite>{
   },
 
   'with ticket': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const localInstructions = {
       ...instructionsWithMaxLedgerVersionOffset,
       maxFee: '0.000012',

--- a/test/client/request/index.ts
+++ b/test/client/request/index.ts
@@ -1,6 +1,5 @@
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
-import { addRippledResponse } from '../../mock-rippled'
 import {TestSuite, assertResultMatch} from '../../utils'
 
 /**
@@ -10,7 +9,7 @@ import {TestSuite, assertResultMatch} from '../../utils'
  */
 export default <TestSuite>{
   'request account_objects': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'account_objects', account: address}, rippled.account_objects.normal)
+    mockRippled.addResponse({command: 'account_objects', account: address}, rippled.account_objects.normal)
     const result = await client.request({command: 'account_objects',
       account: address
     })
@@ -23,7 +22,7 @@ export default <TestSuite>{
   },
 
   'request account_objects - invalid options': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'account_objects', account: address}, rippled.account_objects.normal)
+    mockRippled.addResponse({command: 'account_objects', account: address}, rippled.account_objects.normal)
     // @ts-ignore Intentionally no local validation of these options
     const result = await client.request({command: 'account_objects',
       account: address,

--- a/test/client/sign/index.ts
+++ b/test/client/sign/index.ts
@@ -5,7 +5,6 @@ import requests from '../../fixtures/requests'
 import responses from '../../fixtures/responses'
 import rippled from '../../fixtures/rippled'
 import {TestSuite} from '../../utils'
-import { addRippledResponse } from '../../mock-rippled'
 
 const {schemaValidator} = Client._PRIVATE
 const {sign: REQUEST_FIXTURES} = requests
@@ -60,7 +59,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const secret = 'shsWGZcmZz6YsWWmcnpfr6fLTdtFV'
     const payment = {
       source: {
@@ -168,7 +167,7 @@ export default <TestSuite>{
   },
 
   'succeeds - prepared payment': async (client, address, mockRippled) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = await client.preparePayment(address, {
       source: {
         address: address,
@@ -244,7 +243,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const payment = await client.preparePayment(address, {
       source: {
         address: address,
@@ -272,7 +271,7 @@ export default <TestSuite>{
     address,
     mockRippled
   ) => {
-    addRippledResponse(mockRippled, {command: 'server_info'}, rippled.server_info.normal)
+    mockRippled.addResponse({command: 'server_info'}, rippled.server_info.normal)
     const order = {
       direction: 'sell',
       quantity: {

--- a/test/mock-rippled.ts
+++ b/test/mock-rippled.ts
@@ -29,11 +29,6 @@ function createResponse(request, response, overrides = {}) {
   return JSON.stringify(Object.assign({}, response, change))
 }
 
-export function addRippledResponse(mock: MockedWebSocketServer, request: Request, response) {
-  const command = request.command
-  mock.responses[command] = response
-}
-
 function createLedgerResponse(request, response) {
   const newResponse = JSON.parse(createResponse(request, response))
   if (newResponse.result && newResponse.result.ledger) {
@@ -65,6 +60,11 @@ export function createMockRippled(port) {
   Object.assign(mock, EventEmitter2.prototype)
 
   mock.responses = {}
+
+  mock.addResponse = (request: Request, response: object) => {
+    const command = request.command
+    mock.responses[command] = response
+  }
 
   const close = mock.close
   mock.close = function () {


### PR DESCRIPTION
## High Level Overview of Change

Improve https://github.com/ripple/ripple-lib/pull/1551 to be slightly more concise

### Context of Change

This idea came to mind while I was reviewing https://github.com/ripple/ripple-lib/pull/1551

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before:
A standalone `addRippledResponse` function

After:
We have an `addResponse` method on the mock server object, which is a little cleaner and saves us a line of code (no need to import)

## Test Plan

Existing tests pass