### PR TITLE
Correctly export txFlags and accountSetFlags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -102,7 +102,7 @@
   - [iso8601ToRippleTime](#iso8601torippletime)
   - [rippleTimeToISO8601](#rippletimetoiso8601)
   - [txFlags](#txflags)
-  - [accountSetFlags](#accountsetflags)
+  - [AccountSet Flags](#accountset-flags)
   - [schemaValidator](#schemavalidator)
   - [schemaValidate](#schemavalidate)
 - [API Events](#api-events)
@@ -6444,20 +6444,28 @@ The remaining transaction types do not have any flags at this time.
 * PaymentChannelCreate
 * PaymentChannelFund
 
-## accountSetFlags
+## AccountSet Flags
 
 To modify account flags, you can use an AccountSet transaction and its `SetFlag` or `ClearFlag` fields.
 	
 The flags are called [AccountSet flags (asf*)](https://xrpl.org/accountset.html#accountset-flags):
 
 `RippleAPI.accountSetFlags.requireDestinationTag`: Require a destination tag to send transactions to this account.
+
 `RippleAPI.accountSetFlags.requireAuthorization`: Require authorization for users to hold balances issued by this address. Can only be enabled if the address has no trust lines connected to it.
+
 `RippleAPI.accountSetFlags.disallowIncomingXRP`: XRP should not be sent to this account. (Enforced by client applications, not by rippled)
+
 `RippleAPI.accountSetFlags.disableMasterKey`: Disallow use of the master key pair. Can only be enabled if the account has configured another way to sign transactions.
+
 `RippleAPI.accountSetFlags.enableTransactionIDTracking`: Track the ID of this account's most recent transaction.
+
 `RippleAPI.accountSetFlags.noFreeze`: Permanently give up the ability to freeze individual trust lines or disable Global Freeze. This flag can never be disabled after being enabled.
+
 `RippleAPI.accountSetFlags.globalFreeze`:	Freeze all assets issued by this account.
+
 `RippleAPI.accountSetFlags.defaultRipple`: Enable [rippling](https://xrpl.org/rippling.html) on this account's trust lines by default.
+
 `RippleAPI.accountSetFlags.depositAuth`:Enable Deposit Authorization on this account.
 
 ## schemaValidator

--- a/docs/src/accountSetFlags.md.ejs
+++ b/docs/src/accountSetFlags.md.ejs
@@ -1,15 +1,23 @@
-## accountSetFlags
+## AccountSet Flags
 
 To modify account flags, you can use an AccountSet transaction and its `SetFlag` or `ClearFlag` fields.
 	
 The flags are called [AccountSet flags (asf*)](https://xrpl.org/accountset.html#accountset-flags):
 
 `RippleAPI.accountSetFlags.requireDestinationTag`: Require a destination tag to send transactions to this account.
+
 `RippleAPI.accountSetFlags.requireAuthorization`: Require authorization for users to hold balances issued by this address. Can only be enabled if the address has no trust lines connected to it.
+
 `RippleAPI.accountSetFlags.disallowIncomingXRP`: XRP should not be sent to this account. (Enforced by client applications, not by rippled)
+
 `RippleAPI.accountSetFlags.disableMasterKey`: Disallow use of the master key pair. Can only be enabled if the account has configured another way to sign transactions.
+
 `RippleAPI.accountSetFlags.enableTransactionIDTracking`: Track the ID of this account's most recent transaction.
+
 `RippleAPI.accountSetFlags.noFreeze`: Permanently give up the ability to freeze individual trust lines or disable Global Freeze. This flag can never be disabled after being enabled.
+
 `RippleAPI.accountSetFlags.globalFreeze`:	Freeze all assets issued by this account.
+
 `RippleAPI.accountSetFlags.defaultRipple`: Enable [rippling](https://xrpl.org/rippling.html) on this account's trust lines by default.
+
 `RippleAPI.accountSetFlags.depositAuth`:Enable Deposit Authorization on this account.

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,7 @@ import {
   rippleTimeToISO8601,
   iso8601ToRippleTime,
   txFlags,
-  ensureClassicAddress,
+  ensureClassicAddress
 } from './common'
 import {
   connect,
@@ -488,6 +488,8 @@ class RippleAPI extends EventEmitter {
   rippleTimeToISO8601 = rippleTimeToISO8601 // @deprecated Invoke from top-level package instead
   iso8601ToRippleTime = iso8601ToRippleTime // @deprecated Invoke from top-level package instead
   txFlags = txFlags
+  static txFlags = txFlags
+  accountSetFlags = constants.AccountSetFlags
   static accountSetFlags = constants.AccountSetFlags
 
   isValidAddress = schemaValidator.isValidAddress


### PR DESCRIPTION
## High Level Overview of Change
Exports `txFlags` and `accountSetFlags` on both `api` instance and on `RippleAPI` class.

Fixes #1483 
Fixes #1568 

### Context of Change
Exports both `txFlags` and `accountSetFlags` in the same manner on the RippleAPI class.

Also adjusts the documentation formatting and builds documentation.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
