### PR TITLE
build: remove linter rules already in base config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,36 +31,7 @@ module.exports = {
       "error",
       {
         selector: "interface",
-        format: ["PascalCase"],
-      },
-      {
-        selector: "interface",
-        format: ["snake_case"],
-      },
-    ],
-    // Ignore type imports when counting dependencies.
-    "import/max-dependencies": [
-      "error",
-      {
-        max: 10,
-        ignoreTypeImports: true,
-      },
-    ],
-    // Removes comments and blank lines from the max-line rules
-    "max-lines-per-function": [
-      "warn",
-      {
-        max: 50,
-        skipBlankLines: true,
-        skipComments: true,
-      },
-    ],
-    "max-lines": [
-      "warn",
-      {
-        max: 250,
-        skipBlankLines: true,
-        skipComments: true,
+        format: ["PascalCase", 'snake_case'],
       },
     ],
     "max-statements": ["warn", 25],

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,6 +6,7 @@
         "./test/**/*.ts",
         "./snippets/src/**/*.ts",
         ".prettierrc.js",
+        ".eslintrc.js",
         "jest.config.js"
     ]
 }


### PR DESCRIPTION
## High Level Overview of Change
A couple of linter rules were moved to the @xrpl/typescript-style repo, and so they can be removed here. Also adds linting for `eslintrc.js`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
