### PR TITLE
feat: cleanup flag naming

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/max-dependencies -- Client needs a lot of dependencies by definition */
 /* eslint-disable @typescript-eslint/member-ordering -- TODO: remove when instance methods aren't members */
 /* eslint-disable max-lines -- This might not be necessary later, but this file needs to be big right now */
 import { EventEmitter } from 'events'
@@ -389,20 +388,36 @@ class Client extends EventEmitter {
     return this.connection.request(nextPageRequest) as unknown as U
   }
 
-  public on(event: 'ledgerClosed', listener: (ledger: LedgerStream) => void)
+  public on(
+    event: 'ledgerClosed',
+    listener: (ledger: LedgerStream) => void,
+  ): this
   public on(
     event: 'validationReceived',
     listener: (validation: ValidationStream) => void,
-  )
-  public on(event: 'transaction', listener: (tx: TransactionStream) => void)
+  ): this
+  public on(
+    event: 'transaction',
+    listener: (tx: TransactionStream) => void,
+  ): this
   public on(
     event: 'peerStatusChange',
     listener: (status: PeerStatusStream) => void,
-  )
-  public on(event: 'consensusPhase', listener: (phase: ConsensusStream) => void)
-  public on(event: 'path_find', listener: (path: PathFindStream) => void)
-  public on(event: string, listener: (...args: any[]) => void)
-  public on(eventName: string, listener: (...args: any[]) => void) {
+  ): this
+  public on(
+    event: 'consensusPhase',
+    listener: (phase: ConsensusStream) => void,
+  ): this
+  public on(event: 'path_find', listener: (path: PathFindStream) => void): this
+  public on(event: 'error', listener: (...err: any[]) => void): this
+  /**
+   * Event handler for subscription streams.
+   *
+   * @param eventName - Name of the event. Only forwards streams.
+   * @param listener - Function to run on event.
+   * @returns This, because it inherits from EventEmitter.
+   */
+  public on(eventName: string, listener: (...args: any[]) => void): this {
     return super.on(eventName, listener)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Broadcast client is experimental
-import BroadcastClient from './client/broadcastClient'
+export { default as BroadcastClient } from './client/broadcastClient'
 
 export { Client } from './client'
 
@@ -9,8 +9,8 @@ export * from './common/types/objects/ledger'
 
 export * from './models/methods'
 
-export * from './utils'
+export * from './models/methods'
 
-export { BroadcastClient }
+export * from './utils'
 
 export { default as Wallet } from './wallet'

--- a/src/ledger/autofill.ts
+++ b/src/ledger/autofill.ts
@@ -25,11 +25,13 @@ interface ClassicAccountAndTag {
  * @param signersCount - The expected number of signers for this transaction. Used for multisign.
  * @returns An autofilled transaction.
  */
-async function autofill(
+async function autofill<T extends Transaction>(
   client: Client,
-  tx: Transaction,
+  transaction: T,
   signersCount?: number,
-): Promise<Transaction> {
+): Promise<T> {
+  const tx = {...transaction}
+
   setValidAddresses(tx)
 
   setTransactionFlagsToNumber(tx)

--- a/src/ledger/autofill.ts
+++ b/src/ledger/autofill.ts
@@ -21,7 +21,7 @@ interface ClassicAccountAndTag {
  * Autofills fields in a transaction.
  *
  * @param client - A client.
- * @param tx - A transaction to autofill fields.
+ * @param transaction - A transaction to autofill fields.
  * @param signersCount - The expected number of signers for this transaction. Used for multisign.
  * @returns An autofilled transaction.
  */
@@ -30,7 +30,7 @@ async function autofill<T extends Transaction>(
   transaction: T,
   signersCount?: number,
 ): Promise<T> {
-  const tx = {...transaction}
+  const tx = { ...transaction }
 
   setValidAddresses(tx)
 

--- a/src/models/transactions/accountSet.ts
+++ b/src/models/transactions/accountSet.ts
@@ -35,7 +35,7 @@ export interface AccountSetFlagsInterface {
 
 export interface AccountSet extends BaseTransaction {
   TransactionType: 'AccountSet'
-  Flags?: number | AccountSetTransactionFlags
+  Flags?: number | AccountSetFlagsInterface
   ClearFlag?: number
   Domain?: string
   EmailHash?: string

--- a/src/models/transactions/accountSet.ts
+++ b/src/models/transactions/accountSet.ts
@@ -3,7 +3,7 @@ import { ValidationError } from '../../common/errors'
 
 import { BaseTransaction, verifyBaseTransaction } from './common'
 
-enum AccountSetFlagEnum {
+export enum AccountSetFlags {
   asfRequireDest = 1,
   asfRequireAuth = 2,
   asfDisallowXRP = 3,
@@ -15,13 +15,32 @@ enum AccountSetFlagEnum {
   asfDepositAuth = 9,
 }
 
+export enum AccountSetTransactionFlags {
+  tfRequireDestTag = 0x00010000,
+  tfOptionalDestTag = 0x00020000,
+  tfRequireAuth = 0x00040000,
+  tfOptionalAuth = 0x00080000,
+  tfDisallowXRP = 0x00100000,
+  tfAllowXRP = 0x00200000,
+}
+
+export interface AccountSetFlagsInterface {
+  tfRequireDestTag?: boolean
+  tfOptionalDestTag?: boolean
+  tfRequireAuth?: boolean
+  tfOptionalAuth?: boolean
+  tfDisallowXRP?: boolean
+  tfAllowXRP?: boolean
+}
+
 export interface AccountSet extends BaseTransaction {
   TransactionType: 'AccountSet'
+  Flags?: number | AccountSetTransactionFlags
   ClearFlag?: number
   Domain?: string
   EmailHash?: string
   MessageKey?: string
-  SetFlag?: AccountSetFlagEnum
+  SetFlag?: AccountSetFlags
   TransferRate?: number
   TickSize?: number
 }
@@ -42,7 +61,7 @@ export function verifyAccountSet(tx: Record<string, unknown>): void {
     if (typeof tx.ClearFlag !== 'number') {
       throw new ValidationError('AccountSet: invalid ClearFlag')
     }
-    if (!Object.values(AccountSetFlagEnum).includes(tx.ClearFlag)) {
+    if (!Object.values(AccountSetFlags).includes(tx.ClearFlag)) {
       throw new ValidationError('AccountSet: invalid ClearFlag')
     }
   }
@@ -63,7 +82,7 @@ export function verifyAccountSet(tx: Record<string, unknown>): void {
     if (typeof tx.SetFlag !== 'number') {
       throw new ValidationError('AccountSet: invalid SetFlag')
     }
-    if (!Object.values(AccountSetFlagEnum).includes(tx.SetFlag)) {
+    if (!Object.values(AccountSetFlags).includes(tx.SetFlag)) {
       throw new ValidationError('AccountSet: invalid SetFlag')
     }
   }

--- a/src/models/transactions/offerCreate.ts
+++ b/src/models/transactions/offerCreate.ts
@@ -10,14 +10,14 @@ import {
 } from './common'
 
 // eslint-disable-next-line no-shadow -- variable declaration is unique
-export enum OfferCreateFlagsEnum {
+export enum OfferCreateTransactionFlags {
   tfPassive = 0x00010000,
   tfImmediateOrCancel = 0x00020000,
   tfFillOrKill = 0x00040000,
   tfSell = 0x00080000,
 }
 
-export interface OfferCreateFlags extends GlobalFlags {
+export interface OfferCreateFlagsInterface extends GlobalFlags {
   tfPassive?: boolean
   tfImmediateOrCancel?: boolean
   tfFillOrKill?: boolean
@@ -26,7 +26,7 @@ export interface OfferCreateFlags extends GlobalFlags {
 
 export interface OfferCreate extends BaseTransaction {
   TransactionType: 'OfferCreate'
-  Flags?: number | OfferCreateFlags
+  Flags?: number | OfferCreateFlagsInterface
   Expiration?: number
   OfferSequence?: number
   TakerGets: Amount

--- a/src/models/transactions/payment.ts
+++ b/src/models/transactions/payment.ts
@@ -11,13 +11,13 @@ import {
   verifyBaseTransaction,
 } from './common'
 
-export enum PaymentTransactionFlagsEnum {
+export enum PaymentTransactionFlags {
   tfNoDirectRipple = 0x00010000,
   tfPartialPayment = 0x00020000,
   tfLimitQuality = 0x00040000,
 }
 
-export interface PaymentTransactionFlags extends GlobalFlags {
+export interface PaymentFlagsInterface extends GlobalFlags {
   tfNoDirectRipple?: boolean
   tfPartialPayment?: boolean
   tfLimitQuality?: boolean
@@ -31,7 +31,7 @@ export interface Payment extends BaseTransaction {
   Paths?: Path[]
   SendMax?: Amount
   DeliverMin?: Amount
-  Flags?: number | PaymentTransactionFlags
+  Flags?: number | PaymentFlagsInterface
 }
 
 /**
@@ -94,11 +94,11 @@ function checkPartialPayment(tx: Record<string, unknown>): void {
     }
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Only used by JS
-    const flags = tx.Flags as number | PaymentTransactionFlags
+    const flags = tx.Flags as number | PaymentFlagsInterface
     const isTfPartialPayment =
-      typeof flags === 'number'
-        ? isFlagEnabled(flags, PaymentTransactionFlagsEnum.tfPartialPayment)
-        : flags.tfPartialPayment ?? false
+      typeof flags !== 'number'
+        ? flags.tfPartialPayment ?? false
+        : isFlagEnabled(flags, PaymentTransactionFlags.tfPartialPayment)
 
     if (!isTfPartialPayment) {
       throw new ValidationError(

--- a/src/models/transactions/paymentChannelClaim.ts
+++ b/src/models/transactions/paymentChannelClaim.ts
@@ -3,20 +3,19 @@ import { ValidationError } from '../../common/errors'
 
 import { BaseTransaction, GlobalFlags, verifyBaseTransaction } from './common'
 
-// eslint-disable-next-line no-shadow -- variable declaration is unique
-export enum PaymentChannelClaimFlagsEnum {
+export enum PaymentChannelClaimTransactionFlags {
   tfRenew = 0x00010000,
   tfClose = 0x00020000,
 }
 
-export interface PaymentChannelClaimFlags extends GlobalFlags {
+export interface PaymentChannelClaimFlagsInterface extends GlobalFlags {
   tfRenew?: boolean
   tfClose?: boolean
 }
 
 export interface PaymentChannelClaim extends BaseTransaction {
   TransactionType: 'PaymentChannelClaim'
-  Flags?: number | PaymentChannelClaimFlags
+  Flags?: number | PaymentChannelClaimFlagsInterface
   Channel: string
   Balance?: string
   Amount?: string

--- a/src/models/transactions/transaction.ts
+++ b/src/models/transactions/transaction.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/max-dependencies -- All methods need to be exported */
 
 import { AccountDelete } from './accountDelete'
-import { AccountSet } from './accountSet'
+import { AccountSet, AccountSetFlags, AccountSetTransactionFlags } from './accountSet'
 import { CheckCancel } from './checkCancel'
 import { CheckCash } from './checkCash'
 import { CheckCreate } from './checkCreate'
@@ -11,15 +11,17 @@ import { EscrowCreate } from './escrowCreate'
 import { EscrowFinish } from './escrowFinish'
 import Metadata from './metadata'
 import { OfferCancel } from './offerCancel'
-import { OfferCreate } from './offerCreate'
-import { Payment } from './payment'
-import { PaymentChannelClaim } from './paymentChannelClaim'
+import { OfferCreate, OfferCreateTransactionFlags } from './offerCreate'
+import { Payment, PaymentTransactionFlags } from './payment'
+import { PaymentChannelClaim, PaymentChannelClaimTransactionFlags } from './paymentChannelClaim'
 import { PaymentChannelCreate } from './paymentChannelCreate'
 import { PaymentChannelFund } from './paymentChannelFund'
 import { SetRegularKey } from './setRegularKey'
 import { SignerListSet } from './signerListSet'
 import { TicketCreate } from './ticketCreate'
-import { TrustSet } from './trustSet'
+import { TrustSet, TrustSetTransactionFlags } from './trustSet'
+
+
 
 export type Transaction =
   | AccountDelete
@@ -45,4 +47,13 @@ export type Transaction =
 export interface TransactionAndMetadata {
   transaction: Transaction
   metadata: Metadata
+}
+
+export {
+  AccountSetFlags,
+  AccountSetTransactionFlags,
+  OfferCreateTransactionFlags,
+  PaymentTransactionFlags,
+  PaymentChannelClaimTransactionFlags,
+  TrustSetTransactionFlags
 }

--- a/src/models/transactions/transaction.ts
+++ b/src/models/transactions/transaction.ts
@@ -1,7 +1,11 @@
 /* eslint-disable import/max-dependencies -- All methods need to be exported */
 
 import { AccountDelete } from './accountDelete'
-import { AccountSet, AccountSetFlags, AccountSetTransactionFlags } from './accountSet'
+import {
+  AccountSet,
+  AccountSetFlags,
+  AccountSetTransactionFlags,
+} from './accountSet'
 import { CheckCancel } from './checkCancel'
 import { CheckCash } from './checkCash'
 import { CheckCreate } from './checkCreate'
@@ -13,15 +17,16 @@ import Metadata from './metadata'
 import { OfferCancel } from './offerCancel'
 import { OfferCreate, OfferCreateTransactionFlags } from './offerCreate'
 import { Payment, PaymentTransactionFlags } from './payment'
-import { PaymentChannelClaim, PaymentChannelClaimTransactionFlags } from './paymentChannelClaim'
+import {
+  PaymentChannelClaim,
+  PaymentChannelClaimTransactionFlags,
+} from './paymentChannelClaim'
 import { PaymentChannelCreate } from './paymentChannelCreate'
 import { PaymentChannelFund } from './paymentChannelFund'
 import { SetRegularKey } from './setRegularKey'
 import { SignerListSet } from './signerListSet'
 import { TicketCreate } from './ticketCreate'
 import { TrustSet, TrustSetTransactionFlags } from './trustSet'
-
-
 
 export type Transaction =
   | AccountDelete
@@ -55,5 +60,5 @@ export {
   OfferCreateTransactionFlags,
   PaymentTransactionFlags,
   PaymentChannelClaimTransactionFlags,
-  TrustSetTransactionFlags
+  TrustSetTransactionFlags,
 }

--- a/src/models/transactions/trustSet.ts
+++ b/src/models/transactions/trustSet.ts
@@ -8,7 +8,7 @@ import {
   verifyBaseTransaction,
 } from './common'
 
-export enum TrustSetFlagsEnum {
+export enum TrustSetTransactionFlags {
   tfSetfAuth = 0x00010000,
   tfSetNoRipple = 0x00020000,
   tfClearNoRipple = 0x00040000,
@@ -16,7 +16,7 @@ export enum TrustSetFlagsEnum {
   tfClearFreeze = 0x00200000,
 }
 
-export interface TrustSetFlags extends GlobalFlags {
+export interface TrustSetFlagsInterface extends GlobalFlags {
   tfSetfAuth?: boolean
   tfSetNoRipple?: boolean
   tfClearNoRipple?: boolean
@@ -29,7 +29,7 @@ export interface TrustSet extends BaseTransaction {
   LimitAmount: Amount
   QualityIn?: number
   QualityOut?: number
-  Flags?: number | TrustSetFlags
+  Flags?: number | TrustSetFlagsInterface
 }
 
 /**

--- a/src/models/utils/index.ts
+++ b/src/models/utils/index.ts
@@ -3,15 +3,17 @@
 import { ValidationError } from '../../common/errors'
 // eslint-disable-next-line import/no-cycle -- cycle is safe
 import {
-  OfferCreateFlags,
-  OfferCreateFlagsEnum,
-  PaymentChannelClaimFlags,
-  PaymentChannelClaimFlagsEnum,
+  AccountSetFlagsInterface,
+  AccountSetTransactionFlags,
+  OfferCreateFlagsInterface,
+  OfferCreateTransactionFlags,
+  PaymentChannelClaimFlagsInterface,
+  PaymentChannelClaimTransactionFlags,
+  PaymentFlagsInterface,
   PaymentTransactionFlags,
-  PaymentTransactionFlagsEnum,
   Transaction,
-  TrustSetFlags,
-  TrustSetFlagsEnum,
+  TrustSetFlagsInterface,
+  TrustSetTransactionFlags,
 } from '../transactions'
 import type { GlobalFlags } from '../transactions/common'
 
@@ -55,6 +57,9 @@ export function setTransactionFlagsToNumber(tx: Transaction): void {
   }
 
   switch (tx.TransactionType) {
+    case 'AccountSet':
+      tx.Flags =convertAccountSetFlagsToNumber(tx.Flags)
+      return
     case 'OfferCreate':
       tx.Flags = convertOfferCreateFlagsToNumber(tx.Flags)
       return
@@ -72,24 +77,28 @@ export function setTransactionFlagsToNumber(tx: Transaction): void {
   }
 }
 
-function convertOfferCreateFlagsToNumber(flags: OfferCreateFlags): number {
-  return reduceFlags(flags, OfferCreateFlagsEnum)
+function convertAccountSetFlagsToNumber(flags: AccountSetFlagsInterface): number {
+  return reduceFlags(flags, AccountSetTransactionFlags)
+}
+
+function convertOfferCreateFlagsToNumber(flags: OfferCreateFlagsInterface): number {
+  return reduceFlags(flags, OfferCreateTransactionFlags)
 }
 
 function convertPaymentChannelClaimFlagsToNumber(
-  flags: PaymentChannelClaimFlags,
+  flags: PaymentChannelClaimFlagsInterface,
 ): number {
-  return reduceFlags(flags, PaymentChannelClaimFlagsEnum)
+  return reduceFlags(flags, PaymentChannelClaimTransactionFlags)
 }
 
 function convertPaymentTransactionFlagsToNumber(
-  flags: PaymentTransactionFlags,
+  flags: PaymentFlagsInterface,
 ): number {
-  return reduceFlags(flags, PaymentTransactionFlagsEnum)
+  return reduceFlags(flags, PaymentTransactionFlags)
 }
 
-function convertTrustSetFlagsToNumber(flags: TrustSetFlags): number {
-  return reduceFlags(flags, TrustSetFlagsEnum)
+function convertTrustSetFlagsToNumber(flags: TrustSetFlagsInterface): number {
+  return reduceFlags(flags, TrustSetTransactionFlags)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- added ValidationError check for flagEnum

--- a/test/models/payment.ts
+++ b/test/models/payment.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai'
 import { ValidationError } from 'xrpl-local/common/errors'
 
 import {
-  PaymentTransactionFlagsEnum,
+  PaymentTransactionFlags,
   verifyPayment,
 } from '../../src/models/transactions/payment'
 
@@ -107,7 +107,7 @@ describe('Payment', function () {
 
   it(`verifies valid DeliverMin with tfPartialPayment flag set as a number`, function () {
     paymentTransaction.DeliverMin = '10000'
-    paymentTransaction.Flags = PaymentTransactionFlagsEnum.tfPartialPayment
+    paymentTransaction.Flags = PaymentTransactionFlags.tfPartialPayment
     assert.doesNotThrow(() => verifyPayment(paymentTransaction))
   })
 

--- a/test/models/utils.ts
+++ b/test/models/utils.ts
@@ -4,13 +4,13 @@ import { assert } from 'chai'
 import {
   DepositPreauth,
   OfferCreate,
-  OfferCreateFlagsEnum,
+  OfferCreateTransactionFlags,
   PaymentChannelClaim,
-  PaymentChannelClaimFlagsEnum,
+  PaymentChannelClaimTransactionFlags,
   Payment,
-  PaymentTransactionFlagsEnum,
+  PaymentTransactionFlags,
   TrustSet,
-  TrustSetFlagsEnum,
+  TrustSetTransactionFlags,
 } from '../../src/models/transactions'
 import {
   isFlagEnabled,
@@ -65,7 +65,7 @@ describe('Models Utils', function () {
         },
       }
 
-      const { tfPassive, tfFillOrKill } = OfferCreateFlagsEnum
+      const { tfPassive, tfFillOrKill } = OfferCreateTransactionFlags
       const expected: number = tfPassive | tfFillOrKill
 
       setTransactionFlagsToNumber(tx)
@@ -84,7 +84,7 @@ describe('Models Utils', function () {
         },
       }
 
-      const { tfRenew } = PaymentChannelClaimFlagsEnum
+      const { tfRenew } = PaymentChannelClaimTransactionFlags
       const expected: number = tfRenew
 
       setTransactionFlagsToNumber(tx)
@@ -104,7 +104,7 @@ describe('Models Utils', function () {
         },
       }
 
-      const { tfPartialPayment, tfLimitQuality } = PaymentTransactionFlagsEnum
+      const { tfPartialPayment, tfLimitQuality } = PaymentTransactionFlags
       const expected: number = tfPartialPayment | tfLimitQuality
 
       setTransactionFlagsToNumber(tx)
@@ -131,7 +131,7 @@ describe('Models Utils', function () {
         },
       }
 
-      const { tfSetfAuth, tfClearNoRipple, tfClearFreeze } = TrustSetFlagsEnum
+      const { tfSetfAuth, tfClearNoRipple, tfClearFreeze } = TrustSetTransactionFlags
       const expected: number = tfSetfAuth | tfClearNoRipple | tfClearFreeze
 
       setTransactionFlagsToNumber(tx)


### PR DESCRIPTION
## High Level Overview of Change
Cleans up how flags are named.

### Context of Change
Replaces `<TxType>FlagEnum` with `<TxType>TransactionFlags`, and exports flag enums. This makes it such that a client trying to access a flag value would use `OfferCreateTransactionFlags.tfPassive` instead of `OfferCreateFlagsEnum.tfPassive`.

It also adds `AccountSetTransactionFlags`, which is import *AND* different from `AccountSetFlags`

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release