### PR TITLE
Change multisign to return an encoded transaction instead of a Transaction object

### DIFF
--- a/src/wallet/signer.ts
+++ b/src/wallet/signer.ts
@@ -3,6 +3,7 @@ import { flatMap } from 'lodash'
 import { decodeAccountID } from 'ripple-address-codec'
 import {
   decode,
+  encode,
   encodeForSigning,
   encodeForSigningClaim,
 } from 'ripple-binary-codec'
@@ -42,7 +43,7 @@ function sign(wallet: Wallet, tx: Transaction, forMultisign = false): string {
  * - The SigningPubKey field is not the empty string in any given transaction
  * - Any transaction is missing a Signers field.
  */
-function multisign(transactions: Array<Transaction | string>): Transaction {
+function multisign(transactions: Array<Transaction | string>): string {
   if (transactions.length === 0) {
     throw new ValidationError('There were 0 transactions to multisign')
   }
@@ -76,7 +77,7 @@ function multisign(transactions: Array<Transaction | string>): Transaction {
 
   validateTransactionEquivalence(decodedTransactions)
 
-  return getTransactionWithAllSigners(decodedTransactions)
+  return encode(getTransactionWithAllSigners(decodedTransactions))
 }
 
 /**

--- a/test/wallet/signer.ts
+++ b/test/wallet/signer.ts
@@ -121,7 +121,7 @@ const multisignTxToCombine2: Transaction = {
   TransactionType: 'TrustSet',
 }
 
-const expectedMultisign: Transaction = {
+const expectedMultisign: string = encode({
   Account: 'rEuLyBCvcw4CFmzv8RepSiAoNgF8tTGJQC',
   Fee: '30000',
   Flags: 262144,
@@ -153,7 +153,7 @@ const expectedMultisign: Transaction = {
   ],
   SigningPubKey: '',
   TransactionType: 'TrustSet',
-}
+})
 
 describe('Signer', function () {
   it('sign', function () {


### PR DESCRIPTION
## High Level Overview of Change

Encode multisign's return instead of just returning the Transaction object 

### Context of Change

This change was inspired by using multisign and realizing the Transaction shouldn't be modified after combining signatures. (All Transaction modifications should happen before then)

### Type of Change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After

Before multisign returned a Transaction object, now it encodes that object before returning.

## Test Plan

CI Passes