### PR TITLE
Add Wallet.fromSecret(...) as an alias for Wallet.fromSeed(...)

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -79,12 +79,7 @@ class Wallet {
    * @param algorithm - The digital signature algorithm to generate an address fro.
    * @returns A Wallet derived from a secret (AKA a seed).
    */
-  public static fromSecret(
-    secret: string,
-    algorithm: ECDSA = DEFAULT_ALGORITHM,
-  ): Wallet {
-    return Wallet.fromSeed(secret, algorithm)
-  }
+  public static fromSecret = Wallet.fromSeed
 
   /**
    * Derives a wallet from a mnemonic.

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -73,6 +73,20 @@ class Wallet {
   }
 
   /**
+   * Derives a wallet from a secret (AKA a seed)
+   *
+   * @param secret - A string used to generate a keypair (publicKey/privateKey) to derive a wallet.
+   * @param algorithm - The digital signature algorithm to generate an address fro.
+   * @returns A Wallet derived from a secret (AKA a seed).
+   */
+  public static fromSecret(
+    secret: string,
+    algorithm: ECDSA = DEFAULT_ALGORITHM,
+  ): Wallet {
+    return Wallet.fromSeed(secret, algorithm)
+  }
+
+  /**
    * Derives a wallet from a mnemonic.
    *
    * @param mnemonic - A string consisting of words (whitespace delimited) used to derive a wallet.

--- a/test/wallet/index.ts
+++ b/test/wallet/index.ts
@@ -84,6 +84,37 @@ describe('Wallet', function () {
     })
   })
 
+  describe('fromSecret', function () {
+    const seed = 'ssL9dv2W5RK8L3tuzQxYY6EaZhSxW'
+    const publicKey =
+      '030E58CDD076E798C84755590AAF6237CA8FAE821070A59F648B517A30DC6F589D'
+    const privateKey =
+      '00141BA006D3363D2FB2785E8DF4E44D3A49908780CB4FB51F6D217C08C021429F'
+
+    it('derives a wallet using default algorithm', function () {
+      const wallet = Wallet.fromSecret(seed)
+
+      assert.equal(wallet.publicKey, publicKey)
+      assert.equal(wallet.privateKey, privateKey)
+    })
+
+    it('derives a wallet using algorithm ecdsa-secp256k1', function () {
+      const algorithm = ECDSA.secp256k1
+      const wallet = Wallet.fromSecret(seed, algorithm)
+
+      assert.equal(wallet.publicKey, publicKey)
+      assert.equal(wallet.privateKey, privateKey)
+    })
+
+    it('derives a wallet using algorithm ed25519', function () {
+      const algorithm = ECDSA.ed25519
+      const wallet = Wallet.fromSecret(seed, algorithm)
+
+      assert.equal(wallet.publicKey, publicKey)
+      assert.equal(wallet.privateKey, privateKey)
+    })
+  })
+
   describe('fromMnemonic', function () {
     const mnemonic =
       'try milk link drift aware pass obtain again music stick pluck fold'


### PR DESCRIPTION
## High Level Overview of Change

Title says it all

### Context of Change

It seemed odd to have to use .fromSeed(...) on variables named 'secret', even if it works. This makes more intuitive sense.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] New feature (non-breaking change which adds functionality)

## Before / After

Added a Wallet.fromSecret(...) method to generate a wallet which just uses fromSeed underneath.

## Test Plan

Added a CI tests to ensure the wallet works as expected.
