### PR TITLE
refactor: adds error response object

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
     ],
     'max-lines-per-function': [
       'warn',
-      { max: 40, skipBlankLines: 'true', skipComments: 'true' },
+      { max: 40, skipBlankLines: true, skipComments: true },
     ],
     'max-statements': ['warn', 25],
     'id-length': ['error', { exceptions: ['_'] }], // exception for lodash

--- a/src/client/requestManager.ts
+++ b/src/client/requestManager.ts
@@ -4,7 +4,7 @@ import {
   TimeoutError,
 } from '../common/errors'
 import { Response } from '../models/methods'
-import { BaseRequest } from '../models/methods/baseMethod'
+import { BaseRequest, ErrorResponse } from '../models/methods/baseMethod'
 
 /**
  * Manage all the requests made to the websocket, and their async responses
@@ -126,7 +126,7 @@ export default class RequestManager {
    * @param response - The response to handle.
    * @throws ResponseFormatError if the response format is invalid, RippledError if rippled returns an error.
    */
-  public handleResponse(response: Partial<Response>): void {
+  public handleResponse(response: Partial<Response | ErrorResponse>): void {
     if (
       response.id == null ||
       !Number.isInteger(response.id) ||
@@ -142,9 +142,11 @@ export default class RequestManager {
       this.reject(response.id, error)
     }
     if (response.status === 'error') {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We know this must be true
+      const errorResponse = response as Partial<ErrorResponse>
       const error = new RippledError(
-        response.error_message ?? response.error,
-        response,
+        errorResponse.error_message ?? errorResponse.error,
+        errorResponse,
       )
       this.reject(response.id, error)
       return

--- a/src/models/methods/baseMethod.ts
+++ b/src/models/methods/baseMethod.ts
@@ -1,3 +1,5 @@
+import type { Request } from '.'
+
 export interface BaseRequest {
   [x: string]: unknown
   id?: number | string
@@ -13,15 +15,22 @@ interface Warning {
 
 export interface BaseResponse {
   id: number | string
-  status: 'success' | 'error' | string
+  status: 'success' | string
   type: 'response' | string
   result: unknown
   warning?: 'load'
   warnings?: Warning[]
   forwarded?: boolean
-  error?: string
+  api_version?: number
+}
+
+export interface ErrorResponse {
+  id: number | string
+  status: 'error'
+  type: 'response' | string
+  error: string
+  error_code?: string
   error_message?: string
-  // TODO: type this better
-  request?: unknown
+  request: Request
   api_version?: number
 }

--- a/src/models/methods/index.ts
+++ b/src/models/methods/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import/max-dependencies -- All methods need to be exported */
-
 import {
   AccountChannelsRequest,
   AccountChannelsResponse,

--- a/src/models/methods/index.ts
+++ b/src/models/methods/index.ts
@@ -13,6 +13,7 @@ import { AccountLinesRequest, AccountLinesResponse } from './accountLines'
 import { AccountObjectsRequest, AccountObjectsResponse } from './accountObjects'
 import { AccountOffersRequest, AccountOffersResponse } from './accountOffers'
 import { AccountTxRequest, AccountTxResponse } from './accountTx'
+import { ErrorResponse } from './baseMethod'
 import { BookOffersRequest, BookOffersResponse } from './bookOffers'
 import { ChannelVerifyRequest, ChannelVerifyResponse } from './channelVerify'
 import {
@@ -224,4 +225,5 @@ export {
   PingResponse,
   RandomRequest,
   RandomResponse,
+  ErrorResponse,
 }

--- a/src/models/transactions/transaction.ts
+++ b/src/models/transactions/transaction.ts
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import { encode, decode } from 'ripple-binary-codec'
 
 import { ValidationError } from '../../common/errors'
-import TransactionMetadata from './metadata'
+import { setTransactionFlagsToNumber } from '../utils'
 
 import { AccountDelete, verifyAccountDelete } from './accountDelete'
 import {
@@ -22,12 +22,14 @@ import { DepositPreauth, verifyDepositPreauth } from './depositPreauth'
 import { EscrowCancel, verifyEscrowCancel } from './escrowCancel'
 import { EscrowCreate, verifyEscrowCreate } from './escrowCreate'
 import { EscrowFinish, verifyEscrowFinish } from './escrowFinish'
+import TransactionMetadata from './metadata'
 import { OfferCancel, verifyOfferCancel } from './offerCancel'
 import {
   OfferCreate,
   verifyOfferCreate,
   OfferCreateTransactionFlags,
 } from './offerCreate'
+import { Payment, verifyPayment, PaymentTransactionFlags } from './payment'
 import {
   PaymentChannelClaim,
   verifyPaymentChannelClaim,
@@ -41,12 +43,10 @@ import {
   PaymentChannelFund,
   verifyPaymentChannelFund,
 } from './paymentChannelFund'
-import { Payment, verifyPayment, PaymentTransactionFlags } from './payment'
 import { SetRegularKey, verifySetRegularKey } from './setRegularKey'
 import { SignerListSet, verifySignerListSet } from './signerListSet'
 import { TicketCreate, verifyTicketCreate } from './ticketCreate'
 import { TrustSet, verifyTrustSet, TrustSetTransactionFlags } from './trustSet'
-import { setTransactionFlagsToNumber } from '../utils'
 
 export type Transaction =
   | AccountDelete
@@ -79,6 +79,7 @@ export interface TransactionAndMetadata {
  * Encode/decode and individual type validation.
  *
  * @param tx - A Transaction.
+ * @param transaction
  * @throws ValidationError When the Transaction is malformed.
  */
 export function verify(transaction: Record<string, unknown>): void {

--- a/src/models/transactions/transaction.ts
+++ b/src/models/transactions/transaction.ts
@@ -1,6 +1,5 @@
 /* eslint-disable complexity -- verifies 19 tx types hence a lot of checks needed */
 /* eslint-disable max-lines-per-function -- need to work with a lot of Tx verifications */
-/* eslint-disable import/max-dependencies -- need to test more than 5 TxTypes */
 
 import _ from 'lodash'
 import { encode, decode } from 'ripple-binary-codec'
@@ -78,8 +77,7 @@ export interface TransactionAndMetadata {
  * Verifies various Transaction Types.
  * Encode/decode and individual type validation.
  *
- * @param tx - A Transaction.
- * @param transaction
+ * @param transaction - A Transaction.
  * @throws ValidationError When the Transaction is malformed.
  */
 export function verify(transaction: Record<string, unknown>): void {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -72,13 +72,13 @@ class Wallet {
     return Wallet.deriveWallet(seed, algorithm)
   }
 
-  // .
-  // Derives a wallet from a secret (AKA a seed)
-  //
-  // @param secret - A string used to generate a keypair (publicKey/privateKey) to derive a wallet.
-  // @param algorithm - The digital signature algorithm to generate an address fro.
-  // @returns A Wallet derived from a secret (AKA a seed).
-  //
+  /**
+   * Derives a wallet from a secret (AKA a seed).
+   *
+   * @param secret - A string used to generate a keypair (publicKey/privateKey) to derive a wallet.
+   * @param algorithm - The digital signature algorithm to generate an address fro.
+   * @returns A Wallet derived from a secret (AKA a seed).
+   */
   public static fromSecret = Wallet.fromSeed
 
   /**

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -72,13 +72,13 @@ class Wallet {
     return Wallet.deriveWallet(seed, algorithm)
   }
 
-  /**
-   * Derives a wallet from a secret (AKA a seed)
-   *
-   * @param secret - A string used to generate a keypair (publicKey/privateKey) to derive a wallet.
-   * @param algorithm - The digital signature algorithm to generate an address fro.
-   * @returns A Wallet derived from a secret (AKA a seed).
-   */
+  // .
+  // Derives a wallet from a secret (AKA a seed)
+  //
+  // @param secret - A string used to generate a keypair (publicKey/privateKey) to derive a wallet.
+  // @param algorithm - The digital signature algorithm to generate an address fro.
+  // @returns A Wallet derived from a secret (AKA a seed).
+  //
   public static fromSecret = Wallet.fromSeed
 
   /**

--- a/test/client/subscribe.ts
+++ b/test/client/subscribe.ts
@@ -1,8 +1,7 @@
 import { assert } from 'chai'
 
 import rippled from '../fixtures/rippled'
-import {setupClient, teardownClient} from '../setupClient'
-
+import { setupClient, teardownClient } from '../setupClient'
 
 describe('Subscription', function () {
   beforeEach(setupClient)

--- a/test/integration/integration.ts
+++ b/test/integration/integration.ts
@@ -7,6 +7,7 @@ import { Client, Wallet } from 'xrpl-local'
 import { AccountSet, SignerListSet } from 'xrpl-local/models/transactions'
 import { convertStringToHex } from 'xrpl-local/utils'
 import { sign, multisign } from 'xrpl-local/wallet/signer'
+
 import { Transaction } from '../../src/models/transactions'
 
 import serverUrl from './serverUrl'

--- a/test/integration/requests/utility.ts
+++ b/test/integration/requests/utility.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai'
 import _ from 'lodash'
+
 import { Client } from 'xrpl-local'
 
 import serverUrl from '../serverUrl'

--- a/test/mockRippled.ts
+++ b/test/mockRippled.ts
@@ -86,6 +86,7 @@ export default function createMockRippled(port: number): MockedWebSocketServer {
         }
 
         if (!mock.suppressOutput) {
+          // eslint-disable-next-line no-console -- only printed out on error
           console.error(err.message)
         }
         if (request != null) {

--- a/test/mockRippled.ts
+++ b/test/mockRippled.ts
@@ -3,7 +3,10 @@ import _ from 'lodash'
 import { Server as WebSocketServer } from 'ws'
 
 import type { Request } from '../src'
-import type { BaseResponse } from '../src/models/methods/baseMethod'
+import type {
+  BaseResponse,
+  ErrorResponse,
+} from '../src/models/methods/baseMethod'
 
 import { getFreePort } from './testUtils'
 
@@ -104,8 +107,9 @@ export default function createMockRippled(port: number): MockedWebSocketServer {
   mock.addResponse = function (
     command: string,
     response:
-      | Record<string, unknown>
-      | ((r: Request) => Record<string, unknown>),
+      | Response
+      | ErrorResponse
+      | ((r: Request) => Response | ErrorResponse),
   ): void {
     if (typeof command !== 'string') {
       throw new Error('command is not a string')

--- a/test/models/accountDelete.ts
+++ b/test/models/accountDelete.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyAccountDelete } from './../../src/models/transactions/accountDelete'
-import { verify } from './../../src/models/transactions'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
+import { verify } from '../../src/models/transactions'
+import { verifyAccountDelete } from '../../src/models/transactions/accountDelete'
 
 /**
  * AccountDelete Transaction Verification Testing.

--- a/test/models/accountSet.ts
+++ b/test/models/accountSet.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyAccountSet } from './../../src/models/transactions/accountSet'
-import { verify } from '../../src/models/transactions'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
+import { verify } from '../../src/models/transactions'
+import { verifyAccountSet } from '../../src/models/transactions/accountSet'
 
 /**
  * AccountSet Transaction Verification Testing.

--- a/test/models/checkCancel.ts
+++ b/test/models/checkCancel.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyCheckCancel } from './../../src/models/transactions/checkCancel'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyCheckCancel } from '../../src/models/transactions/checkCancel'
 
 /**
  * CheckCancel Transaction Verification Testing.

--- a/test/models/checkCash.ts
+++ b/test/models/checkCash.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyCheckCash } from './../../src/models/transactions/checkCash'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyCheckCash } from '../../src/models/transactions/checkCash'
 
 /**
  * CheckCash Transaction Verification Testing.

--- a/test/models/checkCreate.ts
+++ b/test/models/checkCreate.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyCheckCreate } from './../../src/models/transactions/checkCreate'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyCheckCreate } from '../../src/models/transactions/checkCreate'
 
 /**
  * CheckCreate Transaction Verification Testing.

--- a/test/models/depositPreauth.ts
+++ b/test/models/depositPreauth.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyDepositPreauth } from './../../src/models/transactions/depositPreauth'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyDepositPreauth } from '../../src/models/transactions/depositPreauth'
 
 /**
  * DepositPreauth Transaction Verification Testing.

--- a/test/models/escrowCancel.ts
+++ b/test/models/escrowCancel.ts
@@ -1,7 +1,8 @@
-import { verifyEscrowCancel } from './../../src/models/transactions/escrowCancel'
 import { assert } from 'chai'
+
 import { ValidationError } from '../../src/common/errors'
 import { verify } from '../../src/models/transactions'
+import { verifyEscrowCancel } from '../../src/models/transactions/escrowCancel'
 
 /**
  * Transaction Verification Testing.

--- a/test/models/escrowCreate.ts
+++ b/test/models/escrowCreate.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyEscrowCreate } from './../../src/models/transactions/escrowCreate'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyEscrowCreate } from '../../src/models/transactions/escrowCreate'
 
 /**
  * EscrowCreate Transaction Verification Testing.

--- a/test/models/escrowFinish.ts
+++ b/test/models/escrowFinish.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyEscrowFinish } from './../../src/models/transactions/escrowFinish'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyEscrowFinish } from '../../src/models/transactions/escrowFinish'
 
 /**
  * EscrowFinish Transaction Verification Testing.

--- a/test/models/offerCancel.ts
+++ b/test/models/offerCancel.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyOfferCancel } from './../../src/models/transactions/offerCancel'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyOfferCancel } from '../../src/models/transactions/offerCancel'
 
 /**
  * OfferCancel Transaction Verification Testing.

--- a/test/models/offerCreate.ts
+++ b/test/models/offerCreate.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyOfferCreate } from './../../src/models/transactions/offerCreate'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyOfferCreate } from '../../src/models/transactions/offerCreate'
 
 /**
  * OfferCreate Transaction Verification Testing.

--- a/test/models/paymentChannelClaim.ts
+++ b/test/models/paymentChannelClaim.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyPaymentChannelClaim } from './../../src/models/transactions/paymentChannelClaim'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyPaymentChannelClaim } from '../../src/models/transactions/paymentChannelClaim'
 
 /**
  * PaymentChannelClaim Transaction Verification Testing.

--- a/test/models/paymentChannelCreate.ts
+++ b/test/models/paymentChannelCreate.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyPaymentChannelCreate } from './../../src/models/transactions/paymentChannelCreate'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyPaymentChannelCreate } from '../../src/models/transactions/paymentChannelCreate'
 
 /**
  * PaymentChannelCreate Transaction Verification Testing.

--- a/test/models/paymentChannelFund.ts
+++ b/test/models/paymentChannelFund.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyPaymentChannelFund } from './../../src/models/transactions/paymentChannelFund'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyPaymentChannelFund } from '../../src/models/transactions/paymentChannelFund'
 
 /**
  * PaymentChannelFund Transaction Verification Testing.

--- a/test/models/ticketCreate.ts
+++ b/test/models/ticketCreate.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyTicketCreate } from './../../src/models/transactions/ticketCreate'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyTicketCreate } from '../../src/models/transactions/ticketCreate'
 
 /**
  * TicketCreate Transaction Verification Testing.

--- a/test/models/trustSet.ts
+++ b/test/models/trustSet.ts
@@ -1,7 +1,9 @@
-import { ValidationError } from 'xrpl-local/common/errors'
-import { verifyTrustSet } from './../../src/models/transactions/trustSet'
 import { assert } from 'chai'
+
+import { ValidationError } from 'xrpl-local/common/errors'
+
 import { verify } from '../../src/models/transactions'
+import { verifyTrustSet } from '../../src/models/transactions/trustSet'
 
 /**
  * TrustSet Transaction Verification Testing.


### PR DESCRIPTION
## High Level Overview of Change

Adds an error response object to account for error responses. Also ran the auto-linter.

### Context of Change

We didn't have an error response object. It's not super necessary since the client throws an error if an error response is received, but it's still good to have one.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes.