### PR TITLE
fix: run browser tests on all integration tests

### DIFF
--- a/test/localIntegrationRunner.html
+++ b/test/localIntegrationRunner.html
@@ -17,6 +17,11 @@
       mocha.ui('bdd')
     </script>
 
+    <script src="../testCompiledForWeb/offerCancel.js"></script>
+    <script src="../testCompiledForWeb/offerCreate.js"></script>
+    <script src="../testCompiledForWeb/payment.js"></script>
+    <script src="../testCompiledForWeb/signerListSet.js"></script>
+    <script src="../testCompiledForWeb/utility.js"></script>
     <script src="../testCompiledForWeb/integration.js"></script>
 
     <script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,7 +128,7 @@ function webpackIntegrationTests() {
   const dir = './test/integration/'
   const tests = []
   const dirPaths = fs.readdirSync(dir)
-  tests.push(webpackForTest(path.join(dir, 'integration.ts')))
+  tests.push(webpackForTest(`./${path.join(dir, 'integration.ts')}`))
   const subdirs = dirPaths.filter(
     (filename) =>
       !filename.match(/\/?([^\/]*)\.ts$/) && filename !== 'README.md',
@@ -136,10 +136,13 @@ function webpackIntegrationTests() {
   subdirs.forEach((subdir) => {
     const subdirPaths = fs.readdirSync(path.join(dir, subdir))
     subdirPaths.forEach((filename) => {
-      tests.push(webpackForTest(path.join(dir, subdir, filename)))
+      tests.push(webpackForTest(`./${path.join(dir, subdir, filename)}`))
     })
   })
-  return Object.assign({}, getDefaultConfiguration(), tests)
+  console.log(tests)
+  return tests.map(
+    (test) => (env, argv) => Object.assign({}, getDefaultConfiguration(), test),
+  )
 }
 
 module.exports = [
@@ -158,5 +161,7 @@ module.exports = [
     }
     return config
   },
-  (env, argv) => webpackIntegrationTests(),
+  ...webpackIntegrationTests(),
 ]
+
+console.log(module.exports)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,7 +139,6 @@ function webpackIntegrationTests() {
       tests.push(webpackForTest(`./${path.join(dir, subdir, filename)}`))
     })
   })
-  console.log(tests)
   return tests.map(
     (test) => (env, argv) => Object.assign({}, getDefaultConfiguration(), test),
   )
@@ -163,5 +162,3 @@ module.exports = [
   },
   ...webpackIntegrationTests(),
 ]
-
-console.log(module.exports)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 'use strict'
 const path = require('path')
+const fs = require('fs')
 const webpack = require('webpack')
 const assert = require('assert')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
@@ -51,7 +52,7 @@ function getDefaultConfiguration() {
 }
 
 function webpackForTest(testFileName) {
-  const match = testFileName.match(/\/?([^\/]*).ts$/)
+  const match = testFileName.match(/\/?([^\/]*)\.ts$/)
   if (!match) {
     assert(false, 'wrong filename:' + testFileName)
   }
@@ -119,7 +120,26 @@ function webpackForTest(testFileName) {
       },
     },
   }
-  return Object.assign({}, getDefaultConfiguration(), test)
+  // return Object.assign({}, getDefaultConfiguration(), test)
+  return test
+}
+
+function webpackIntegrationTests() {
+  const dir = './test/integration/'
+  const tests = []
+  const dirPaths = fs.readdirSync(dir)
+  tests.push(webpackForTest(path.join(dir, 'integration.ts')))
+  const subdirs = dirPaths.filter(
+    (filename) =>
+      !filename.match(/\/?([^\/]*)\.ts$/) && filename !== 'README.md',
+  )
+  subdirs.forEach((subdir) => {
+    const subdirPaths = fs.readdirSync(path.join(dir, subdir))
+    subdirPaths.forEach((filename) => {
+      tests.push(webpackForTest(path.join(dir, subdir, filename)))
+    })
+  })
+  return Object.assign({}, getDefaultConfiguration(), tests)
 }
 
 module.exports = [
@@ -138,5 +158,5 @@ module.exports = [
     }
     return config
   },
-  (env, argv) => webpackForTest('./test/integration/integration.ts'),
+  (env, argv) => webpackIntegrationTests(),
 ]


### PR DESCRIPTION
## High Level Overview of Change

This PR webpacks all the integration test files for testing, and runs all of the tests on the browser.

### Context of Change

Because we started using multiple files for integration tests, the browser tests did not pick up those files, and continued to only run the tests on the one file.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

CI passes. All the integration tests run on the browser.

## Future Tasks
This is not the best code, and needs to be revamped a bit before we officially publish 2.0. But it's good enough for now.
* The script tags in `localIntegrationRunner.html` should be dynamically added
* The files in `testCompiledForWeb` should be properly nested in folders
* Browser tests should print better debugging info in the CLI